### PR TITLE
Open up access for signature generation so they can be reused by subclasses.

### DIFF
--- a/src/main/java/org/jvnet/hudson/update_center/Main.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Main.java
@@ -217,7 +217,7 @@ public class Main {
      * Because it mutates the signed object itself, validating the signature needs a bit of work,
      * but this enables a signature to be added transparently.
      */
-    private void sign(JSONObject o) throws GeneralSecurityException, IOException {
+    protected void sign(JSONObject o) throws GeneralSecurityException, IOException {
         JSONObject sign = new JSONObject();
 
 
@@ -265,7 +265,7 @@ public class Main {
     /**
      * Loads a certificate chain and makes sure it's valid.
      */
-    private List<X509Certificate> getCertificateChain() throws FileNotFoundException, GeneralSecurityException {
+    protected List<X509Certificate> getCertificateChain() throws FileNotFoundException, GeneralSecurityException {
         CertificateFactory cf = CertificateFactory.getInstance("X509");
         List<X509Certificate> certs = new ArrayList<X509Certificate>();
         for (File f : certificates) {


### PR DESCRIPTION
We extend the update center in order to add in a few additional plugins that are specific to our company's usage of Jenkins.  Previously we just reused the signature in the main Jenkins json, but with the recent addition of validating the signature caused this to no longer work.  We're hoping to be able to call into sign(JSON) to start including a valid signature of our own.
