### PR TITLE
Update master

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -18,3 +18,4 @@ assembla-jenkins=1        # Renamed to assembla
 pathignore-plugin         # renamed to pathignore
 associated-files-plugin   # renamed to associated-files       
 vagrant-plugin            # renamed to vagrant, herpderp
+blitz.io-jenkins          # renamed to blitz_io-jenkins


### PR DESCRIPTION
to remove a obsolete id  "blitz.io-jenkins" from update center
