### PR TITLE
Have plugin query include jpi packaging too.

### DIFF
--- a/src/main/java/org/jvnet/hudson/update_center/MavenRepositoryImpl.java
+++ b/src/main/java/org/jvnet/hudson/update_center/MavenRepositoryImpl.java
@@ -224,7 +224,9 @@ public class MavenRepositoryImpl extends MavenRepository {
 
     public Collection<PluginHistory> listHudsonPlugins() throws PlexusContainerException, ComponentLookupException, IOException, UnsupportedExistingLuceneIndexException, AbstractArtifactResolutionException {
         BooleanQuery q = new BooleanQuery();
-        q.add(indexer.constructQuery(ArtifactInfo.PACKAGING,"hpi"), Occur.MUST);
+        q.setMinimumNumberShouldMatch(1);
+        q.add(indexer.constructQuery(ArtifactInfo.PACKAGING,"hpi"), Occur.SHOULD);
+        q.add(indexer.constructQuery(ArtifactInfo.PACKAGING,"jpi"), Occur.SHOULD);
 
         FlatSearchRequest request = new FlatSearchRequest(q);
         FlatSearchResponse response = indexer.searchFlat(request);


### PR DESCRIPTION
I ran HPIResolve's main with org.jenkins-ci.plugins:job-dsl:1.18  before and after, and now it works.
