### PR TITLE
[JENKINS-20679] Add support for Minimum-Java-Version in manifest

### DIFF
--- a/src/main/java/org/jvnet/hudson/update_center/HPI.java
+++ b/src/main/java/org/jvnet/hudson/update_center/HPI.java
@@ -110,6 +110,10 @@ public class HPI extends MavenArtifact {
         return getManifestAttributes().getValue("Compatible-Since-Version");
     }
 
+    public String getMinimumJavaVersion() throws IOException {
+        return getManifestAttributes().getValue("Minimum-Java-Version");
+    }
+
     public String getDisplayName() throws IOException {
         return getManifestAttributes().getValue("Long-Name");
     }

--- a/src/main/java/org/jvnet/hudson/update_center/Plugin.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Plugin.java
@@ -422,6 +422,11 @@ public class Plugin {
         if (hpi.getCompatibleSinceVersion() != null) {
             json.put("compatibleSinceVersion",hpi.getCompatibleSinceVersion());
         }
+
+        if (hpi.getMinimumJavaVersion() != null) {
+            json.put("minimumJavaVersion", hpi.getMinimumJavaVersion());
+        }
+
         if (hpi.getSandboxStatus() != null) {
             json.put("sandboxStatus",hpi.getSandboxStatus());
         }

--- a/src/main/java/org/jvnet/hudson/update_center/Plugin.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Plugin.java
@@ -424,7 +424,7 @@ public class Plugin {
         }
 
         if (hpi.getMinimumJavaVersion() != null) {
-            json.put("minimumJavaVersion", hpi.getMinimumJavaVersion());
+            json.put("requiredJava", hpi.getMinimumJavaVersion());
         }
 
         if (hpi.getSandboxStatus() != null) {


### PR DESCRIPTION
[JENKINS-20679](https://issues.jenkins-ci.org/browse/JENKINS-20679)

Downstream from https://github.com/jenkinsci/maven-hpi-plugin/pull/75 and upstream of https://github.com/jenkinsci/jenkins/pull/3016.

Untested.