### PR TITLE
public artifact sha1 + metadata side by side with plugins binary

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,11 @@
       <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.10</version>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/main/java/org/jvnet/hudson/update_center/Main.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Main.java
@@ -36,6 +36,7 @@ import org.kohsuke.args4j.Option;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.util.ArrayList;
@@ -324,6 +325,11 @@ public class Main {
                 if (download!=null) {
                     for (HPI v : hpi.artifacts.values()) {
                         stage(v, new File(download, "plugins/" + hpi.artifactId + "/" + v.version + "/" + hpi.artifactId + ".hpi"));
+
+                        final File manifest = new File(download, "plugins/" + hpi.artifactId + "/" + v.version + "/MANIFEST.MF");
+                        try (OutputStream out = new FileOutputStream(manifest)) {
+                            v.getManifest().write(out);
+                        }
                     }
                     if (!hpi.artifacts.isEmpty())
                         createLatestSymlink(hpi, plugin.latest);

--- a/src/main/java/org/jvnet/hudson/update_center/Main.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Main.java
@@ -35,10 +35,11 @@ import org.kohsuke.args4j.Option;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.FileWriter;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
@@ -326,9 +327,8 @@ public class Main {
                     for (HPI v : hpi.artifacts.values()) {
                         stage(v, new File(download, "plugins/" + hpi.artifactId + "/" + v.version + "/" + hpi.artifactId + ".hpi"));
 
-                        final File manifest = new File(download, "plugins/" + hpi.artifactId + "/" + v.version + "/MANIFEST.MF");
-                        try (OutputStream out = new FileOutputStream(manifest)) {
-                            v.getManifest().write(out);
+                        try (Writer w = new FileWriter(new File(download, "plugins/" + hpi.artifactId + "/" + v.version + "/metadata.json"))) {
+                            new Plugin(v).toJSON().write(w);
                         }
                     }
                     if (!hpi.artifacts.isEmpty())
@@ -389,8 +389,8 @@ public class Main {
             throw new IOException("'ln -f " + src.getAbsolutePath() + " " +dst.getAbsolutePath() +
                     "' failed with code " + p.exitValue() + "\nError: " + IOUtils.toString(p.getErrorStream()) + "\nOutput: " + IOUtils.toString(p.getInputStream()));
 
-        final File sha1 = new File(dst.getAbsolutePath()+".sha1");
-        FileUtils.writeStringToFile(sha1, a.getSha256());
+        final File sha = new File(dst.getAbsolutePath()+".sha256");
+        FileUtils.writeStringToFile(sha, a.getSha256());
 
     }
 

--- a/src/main/java/org/jvnet/hudson/update_center/Main.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Main.java
@@ -384,7 +384,7 @@ public class Main {
                     "' failed with code " + p.exitValue() + "\nError: " + IOUtils.toString(p.getErrorStream()) + "\nOutput: " + IOUtils.toString(p.getInputStream()));
 
         final File sha1 = new File(dst.getAbsolutePath()+".sha1");
-        FileUtils.writeStringToFile(sha1, a.getSha1());
+        FileUtils.writeStringToFile(sha1, a.getSha256());
 
     }
 

--- a/src/main/java/org/jvnet/hudson/update_center/Main.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Main.java
@@ -383,6 +383,9 @@ public class Main {
             throw new IOException("'ln -f " + src.getAbsolutePath() + " " +dst.getAbsolutePath() +
                     "' failed with code " + p.exitValue() + "\nError: " + IOUtils.toString(p.getErrorStream()) + "\nOutput: " + IOUtils.toString(p.getInputStream()));
 
+        final File sha1 = new File(dst.getAbsolutePath()+".sha1");
+        FileUtils.writeStringToFile(sha1, a.getSha1());
+
     }
 
     /**

--- a/src/main/java/org/jvnet/hudson/update_center/MavenArtifact.java
+++ b/src/main/java/org/jvnet/hudson/update_center/MavenArtifact.java
@@ -26,6 +26,7 @@ package org.jvnet.hudson.update_center;
 import hudson.util.VersionNumber;
 import net.sf.json.JSONObject;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.maven.artifact.resolver.AbstractArtifactResolutionException;
 import org.sonatype.nexus.index.ArtifactInfo;
 
@@ -36,7 +37,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
@@ -135,6 +135,22 @@ public class MavenArtifact {
             throw new IOException(e);
         }
     }
+
+    public String getSha1() throws IOException {
+        try (FileInputStream fin = new FileInputStream(resolve())) {
+            MessageDigest sig = MessageDigest.getInstance("SHA1");
+            byte[] buf = new byte[2048];
+            int len;
+            while ((len=fin.read(buf,0,buf.length))>=0)
+                sig.update(buf,0,len);
+
+            return Hex.encodeHexString(sig.digest());
+        } catch (NoSuchAlgorithmException e) {
+            throw new IOException(e);
+        }
+
+    }
+
 
     public JSONObject toJSON(String name) throws IOException {
         JSONObject o = new JSONObject();

--- a/src/main/java/org/jvnet/hudson/update_center/MavenArtifact.java
+++ b/src/main/java/org/jvnet/hudson/update_center/MavenArtifact.java
@@ -27,6 +27,7 @@ import hudson.util.VersionNumber;
 import net.sf.json.JSONObject;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.maven.artifact.resolver.AbstractArtifactResolutionException;
 import org.sonatype.nexus.index.ArtifactInfo;
 
@@ -124,31 +125,26 @@ public class MavenArtifact {
      */
     public String getDigest() throws IOException {        
         try (FileInputStream fin = new FileInputStream(resolve())) {
-            MessageDigest sig = MessageDigest.getInstance("SHA1");            
+            MessageDigest sig = DigestUtils.getSha1Digest();
             byte[] buf = new byte[2048];
             int len;
             while ((len=fin.read(buf,0,buf.length))>=0)
                 sig.update(buf,0,len);
 
             return new String(Base64.encodeBase64(sig.digest()), "UTF-8");
-        } catch (NoSuchAlgorithmException e) {
-            throw new IOException(e);
         }
     }
 
-    public String getSha1() throws IOException {
+    public String getSha256() throws IOException {
         try (FileInputStream fin = new FileInputStream(resolve())) {
-            MessageDigest sig = MessageDigest.getInstance("SHA1");
+            MessageDigest sig = DigestUtils.getSha256Digest();
             byte[] buf = new byte[2048];
             int len;
-            while ((len=fin.read(buf,0,buf.length))>=0)
-                sig.update(buf,0,len);
+            while ((len = fin.read(buf, 0, buf.length)) >= 0)
+                sig.update(buf, 0, len);
 
             return Hex.encodeHexString(sig.digest());
-        } catch (NoSuchAlgorithmException e) {
-            throw new IOException(e);
         }
-
     }
 
 


### PR DESCRIPTION
to be consumed by docker image "install-plugin.sh" and configuration-as-code for plugin installation.
see https://github.com/jenkinsci/configuration-as-code-plugin/issues/104

note: publishing hex version of artifact digest for easiest consumption from a shell script (`sha1sum`) vs base64 encoded one using in UC json.