### PR TITLE
Add plugins dependent on delisted plugins

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -267,3 +267,7 @@ azure-slave-plugin
 copy-to-slave
 liquibase-runner
 perforce
+build-configurator  # depends on copy-to-slave
+lsf-cloud           # depends on copy-to-slave
+piketec-tpt         # depends on copy-to-slave
+reviewboard         # depends on perforce


### PR DESCRIPTION
Suspend distribution of plugins with mandatory dependencies on [plugins that have been removed from distribution in the 2018-03-26 security advisory](https://jenkins.io/security/advisory/2018-03-26/), and therefore can no longer be installed.

Thanks to @oleg-nenashev for letting me know about this problem.

FYI @PikeTec  @LaisvydasLT @AMCBridgeDevTeam and @roman-bilyi