### PR TITLE
removing piketec-tpt plugin from blacklist after removing dependency …

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -269,5 +269,4 @@ liquibase-runner
 perforce
 build-configurator  # depends on copy-to-slave
 lsf-cloud           # depends on copy-to-slave
-piketec-tpt         # depends on copy-to-slave
 reviewboard         # depends on perforce


### PR DESCRIPTION
…to insecure and blacklisted copy-to-slave plugin

Hello,

the newest version of the piketec-tpt plugin has no needs for the copy-to-slave plugin so the dependency is removed (additional to adding other features).

Best Regards,
Joachim

Merge Commit of the feature branch to master (pom.xml): https://github.com/jenkinsci/piketec-tpt-plugin/commit/8b2c893814c108fe819163f9f167e15184f68716#diff-600376dffeb79835ede4a0b285078036