### PR TITLE
Don't record SHA-256, use base64 for SHA-512

### DIFF
--- a/src/main/java/org/jvnet/hudson/update_center/MavenArtifact.java
+++ b/src/main/java/org/jvnet/hudson/update_center/MavenArtifact.java
@@ -25,11 +25,8 @@ package org.jvnet.hudson.update_center;
 
 import hudson.util.VersionNumber;
 import net.sf.json.JSONObject;
-import org.apache.commons.codec.BinaryDecoder;
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.lang.StringUtils;
 import org.apache.maven.artifact.resolver.AbstractArtifactResolutionException;
 import org.sonatype.nexus.index.ArtifactInfo;
 
@@ -39,7 +36,6 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
@@ -124,27 +120,23 @@ public class MavenArtifact {
 
     private static class Digests {
         String sha1;
-        String sha256;
         String sha512;
     }
 
     public Digests getDigests() throws IOException {
         try (FileInputStream fin = new FileInputStream(resolve())) {
             MessageDigest sha1 = DigestUtils.getSha1Digest();
-            MessageDigest sha256 = DigestUtils.getSha256Digest();
             MessageDigest sha512 = DigestUtils.getSha512Digest();
             byte[] buf = new byte[2048];
             int len;
             while ((len=fin.read(buf,0,buf.length)) >= 0) {
                 sha1.update(buf, 0, len);
-                sha256.update(buf, 0, len);
                 sha512.update(buf, 0, len);
             }
 
             Digests ret = new Digests();
             ret.sha1 = new String(Base64.encodeBase64(sha1.digest()), "UTF-8");
-            ret.sha256 = Hex.encodeHexString(sha256.digest());
-            ret.sha512 = Hex.encodeHexString(sha512.digest());
+            ret.sha512 = new String(Base64.encodeBase64(sha512.digest()), "UTF-8");
             return ret;
         }
     }
@@ -158,7 +150,6 @@ public class MavenArtifact {
         o.put("buildDate", getTimestampAsString());
         Digests d = getDigests();
         o.put("sha1", d.sha1);
-        o.put("sha256", d.sha256);
         o.put("sha512", d.sha512);
 
         return o;


### PR DESCRIPTION
Followup to #191 that hopefully is less bandwidth hungry:

- Skip SHA-256 which was mostly for convenience (compare to Artifactory checksums) anyway
- Use base64 encoding for SHA-512 to shave off bits at the cost of being weird

FYI @orrc (previous #191 reviewer), @rtyler 