### PR TITLE
publish plugin metadata side-by-side with artifact

### DIFF
--- a/src/main/java/org/jvnet/hudson/update_center/Main.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Main.java
@@ -319,6 +319,12 @@ public class Main {
                 pluginToDocumentationUrl.put(plugin.artifactId, plugin.getPluginUrl());
 
                 JSONObject json = plugin.toJSON();
+                final JSONObject versions = new JSONObject();
+                for (VersionNumber version : hpi.artifacts.keySet()) {
+                    versions.accumulate(version.toString(), "http://updates.jenkins-ci.org/download/plugins/" + hpi.artifactId + "/" + version + "/metadata.json");
+                }
+                json.accumulate("versions", versions);
+
                 System.out.println("=> " + json);
                 plugins.put(plugin.artifactId, json);
                 latest.add(plugin.artifactId+".hpi", plugin.latest.getURL().getPath());

--- a/src/main/java/org/jvnet/hudson/update_center/Main.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Main.java
@@ -35,9 +35,11 @@ import org.kohsuke.args4j.Option;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
@@ -324,6 +326,10 @@ public class Main {
                 if (download!=null) {
                     for (HPI v : hpi.artifacts.values()) {
                         stage(v, new File(download, "plugins/" + hpi.artifactId + "/" + v.version + "/" + hpi.artifactId + ".hpi"));
+
+                        try (Writer w = new FileWriter(new File(download, "plugins/" + hpi.artifactId + "/" + v.version + "/metadata.json"))) {
+                            new Plugin(v).toJSON().write(w);
+                        }
                     }
                     if (!hpi.artifacts.isEmpty())
                         createLatestSymlink(hpi, plugin.latest);


### PR DESCRIPTION
In addition to all versions of plugins HPIs, update center to publish metadata as JSON (the same one consumed by `hudson.model.UpdateSite.Plugin`)

Primary use-case is for Configuration-as-Code plugin to be able to install specific version of a plugin with dependencies. 

also see https://github.com/jenkins-infra/update-center2/pull/192

