### PR TITLE
Blacklist influxdb-query for initial release with vulnerability

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -274,3 +274,6 @@ reviewboard         # depends on perforce
 # requested by maintainer in https://github.com/jenkins-infra/update-center2/pull/199
 websphere-deployer-1.5.5
 websphere-deployer-1.5.6
+
+# https://github.com/jenkins-infra/repository-permissions-updater/pull/721#issuecomment-396358858
+influxdb-query


### PR DESCRIPTION
We consider credentials stored in plaintext to be vulnerabilities, and the maintainer ignored my requests to fix this before initial release:

https://issues.jenkins-ci.org/browse/HOSTING-568?focusedCommentId=339941&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-339941
https://github.com/jenkins-infra/repository-permissions-updater/pull/721#issuecomment-396358858

So suspend distribution while the plugin has no users, and the issue is unresolved.