### PR TITLE
 [INFRA-1666] Prefer index.jelly to <description> for excerpt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,12 @@
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-container-default</artifactId>
       <version>1.5.5</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.collections</groupId>
+          <artifactId>google-collections</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
@@ -173,6 +179,11 @@
       <groupId>jetty</groupId>
       <artifactId>jetty-util</artifactId>
       <version>6.0.0rc1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+      <artifactId>owasp-java-html-sanitizer</artifactId>
+      <version>20180219.1</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/src/main/java/org/jvnet/hudson/update_center/MavenArtifact.java
+++ b/src/main/java/org/jvnet/hudson/update_center/MavenArtifact.java
@@ -110,6 +110,14 @@ public class MavenArtifact {
         }
     }
 
+    public File resolveJar() throws IOException {
+        try {
+            return repository.resolve(artifact, "jar", null);
+        } catch (AbstractArtifactResolutionException e) {
+            throw new IOException("Failed to resolve artifact " + artifact + " jar", e);
+        }
+    }
+
     public File resolveSources() throws IOException {
         try {
             return repository.resolve(artifact,"jar","sources");

--- a/src/main/java/org/jvnet/hudson/update_center/MavenRepositoryImpl.java
+++ b/src/main/java/org/jvnet/hudson/update_center/MavenRepositoryImpl.java
@@ -66,6 +66,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -161,7 +162,7 @@ public class MavenRepositoryImpl extends MavenRepository {
 
         URLConnection con = url.openConnection();
         if (url.getUserInfo()!=null) {
-            con.setRequestProperty("Authorization","Basic "+new sun.misc.BASE64Encoder().encode(url.getUserInfo().getBytes("UTF-8")));
+            con.setRequestProperty("Authorization", "Basic " + Base64.getEncoder().encodeToString(url.getUserInfo().getBytes("UTF-8")));
         }
 
         if (!expanded.exists() || !local.exists() || (local.lastModified()!=con.getLastModified() && !offlineIndex)) {

--- a/src/main/java/org/jvnet/hudson/update_center/Plugin.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Plugin.java
@@ -52,6 +52,8 @@ import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
@@ -438,7 +440,9 @@ public class Plugin {
                 try (InputStream is = jf.getInputStream(indexJelly)) {
                     org.w3c.dom.Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(is);
                     StringWriter sw = new StringWriter();
-                    TransformerFactory.newInstance().newTransformer().transform(new DOMSource(doc.getDocumentElement()), new StreamResult(sw));
+                    Transformer transformer = TransformerFactory.newInstance().newTransformer();
+                    transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+                    transformer.transform(new DOMSource(doc.getDocumentElement()), new StreamResult(sw));
                     description = sw.toString().trim();
                 }
             }

--- a/src/main/java/org/jvnet/hudson/update_center/Plugin.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Plugin.java
@@ -57,6 +57,10 @@ import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
+import org.owasp.html.HtmlSanitizer;
+import org.owasp.html.HtmlStreamRenderer;
+import org.owasp.html.PolicyFactory;
+import org.owasp.html.Sanitizers;
 import org.w3c.dom.NodeList;
 
 /**
@@ -414,6 +418,8 @@ public class Plugin {
         return name;
     }
 
+    private static final PolicyFactory HTML_POLICY = Sanitizers.BLOCKS.and(Sanitizers.FORMATTING).and(Sanitizers.LINKS);
+
     public JSONObject toJSON() throws Exception {
         JSONObject json = latest.toJSON(artifactId);
 
@@ -448,7 +454,10 @@ public class Plugin {
                     for (int i = 0; i < nl.getLength(); i++) {
                         transformer.transform(new DOMSource(nl.item(i)), result);
                     }
-                    description = sw.toString().trim();
+                    StringBuilder b = new StringBuilder();
+                    HtmlStreamRenderer renderer = HtmlStreamRenderer.create(b, Throwable::printStackTrace, html -> System.err.println("Bad HTML: " + html));
+                    HtmlSanitizer.sanitize(sw.toString(), HTML_POLICY.apply(renderer));
+                    description = b.toString().trim();
                 }
             }
         }

--- a/src/main/java/org/jvnet/hudson/update_center/Plugin.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Plugin.java
@@ -57,6 +57,7 @@ import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
+import org.w3c.dom.NodeList;
 
 /**
  * An entry of a plugin in the update center metadata.
@@ -442,7 +443,11 @@ public class Plugin {
                     StringWriter sw = new StringWriter();
                     Transformer transformer = TransformerFactory.newInstance().newTransformer();
                     transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
-                    transformer.transform(new DOMSource(doc.getDocumentElement()), new StreamResult(sw));
+                    StreamResult result = new StreamResult(sw);
+                    NodeList nl = doc.getDocumentElement().getChildNodes();
+                    for (int i = 0; i < nl.getLength(); i++) {
+                        transformer.transform(new DOMSource(nl.item(i)), result);
+                    }
                     description = sw.toString().trim();
                 }
             }


### PR DESCRIPTION
[INFRA-1666](https://issues.jenkins-ci.org/browse/INFRA-1666)

See [installed view](https://github.com/jenkinsci/jenkins/blob/6c49fabc45062e86f6243225a4c6c6a929725fc0/core/src/main/resources/hudson/PluginManager/installed.jelly#L87-L100) vs. [update view](https://github.com/jenkinsci/jenkins/blob/6c49fabc45062e86f6243225a4c6c6a929725fc0/core/src/main/resources/hudson/PluginManager/table.jelly#L100-L102).

Before, from [this](https://github.com/jenkinsci/accurev-plugin/blob/b2a01a82c982f61bc50e96af548e339f9c29ff61/pom.xml#L15):

```json
"excerpt": "This plugin allows you to use AccuRev as a SCM.",
```

After, from [this](https://github.com/jenkinsci/accurev-plugin/blob/b2a01a82c982f61bc50e96af548e339f9c29ff61/src/main/resources/index.jelly#L3):

```json
"excerpt": "This plugin integrates <a href=\"http://www.accurev.com/\">AccuRev SCM<\/a> to Jenkins."
```

More to the point, before incrementalification:

```json
"excerpt": ""
```

and after incrementalification:

```json
"excerpt": "The Jenkins Plugins Parent POM Project"
```

and after this PR:

```json
"excerpt": "Plugin that defines Pipeline API."
```

CC @daniel-beck @kshultzCB