### PR TITLE
Improve GitHub repo detection using GitHub API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,11 @@
       <version>1.1.1</version>
     </dependency>
     <dependency>
+      <groupId>org.kohsuke</groupId>
+      <artifactId>github-api</artifactId>
+      <version>1.93</version>
+    </dependency>
+    <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-impl</artifactId>
       <version>2.1.6</version>

--- a/src/main/java/org/jvnet/hudson/update_center/GitHubSource.java
+++ b/src/main/java/org/jvnet/hudson/update_center/GitHubSource.java
@@ -1,0 +1,71 @@
+package org.jvnet.hudson.update_center;
+
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GitHub;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.TreeSet;
+
+public class GitHubSource {
+
+    private GitHub github;
+
+    private static String GITHUB_API_USERNAME = System.getenv("GITHUB_USERNAME");
+    private static String GITHUB_API_PASSWORD = System.getenv("GITHUB_PASSWORD");
+
+    private Set<String> repoNames;
+
+    private GitHubSource() {
+        try {
+            if (GITHUB_API_USERNAME != null && GITHUB_API_PASSWORD != null) {
+                github = GitHub.connectUsingPassword(GITHUB_API_USERNAME, GITHUB_API_PASSWORD);
+
+                this.repoNames = new TreeSet<>(new Comparator<String>() {
+                    @Override
+                    public int compare(String o1, String o2) {
+                        return o1.compareToIgnoreCase(o2);
+                    }
+                });
+                for (GHRepository repo : github.getOrganization("jenkinsci").getRepositories().values()) {
+                    repoNames.add(StringUtils.stripEnd(repo.getHttpTransportUrl(), ".git"));
+                }
+            }
+        } catch (IOException e) {
+            // ignore, fall back to dumb mode
+        }
+    }
+
+    private static GitHubSource instance;
+
+    public static GitHubSource getInstance() {
+        if (instance == null) {
+            instance = new GitHubSource();
+        }
+        return instance;
+    }
+
+    public boolean isRepoExisting(String url) {
+        if (repoNames != null) {
+            return repoNames.contains(url);
+        } else {
+            try {
+                HttpClient client = new HttpClient();
+                GetMethod get = new GetMethod(url);
+                get.setFollowRedirects(true);
+                if (client.executeMethod(get) >= 400) {
+                    return false;
+                }
+            } catch (Exception e) {
+                // that didn't work
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/src/main/java/org/jvnet/hudson/update_center/Plugin.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Plugin.java
@@ -314,18 +314,9 @@ public class Plugin {
     }
 
     private String requireGitHubRepoExistence(String url) {
-        try {
-            HttpClient client = new HttpClient();
-            GetMethod get = new GetMethod(url);
-            get.setFollowRedirects(true);
-            if (client.executeMethod(get) >= 400) {
-                return null;
-            }
-        } catch (Exception e) {
-            // that didn't work
-            return null;
-        }
-        return url;
+        GitHubSource gh = GitHubSource.getInstance();
+        String shortenedUrl = StringUtils.removeEndIgnoreCase(url, "-plugin");
+        return gh.isRepoExisting(url) ? url : (gh.isRepoExisting(shortenedUrl) ? shortenedUrl : null);
     }
 
     /**


### PR DESCRIPTION
Both finds more repos, and is quicker overall.

Newly discovered repos via fallback:

* jenkinsci/accelerated-build-now-plugin
* jenkinsci/aws-beanstalk-publisher-plugin
* jenkinsci/awseb-deployment-plugin
* jenkinsci/clearcase-ucm-plugin
* jenkinsci/codeclimate-plugin
* jenkinsci/commit-message-trigger-plugin
* jenkinsci/copy-data-to-workspace-plugin
* jenkinsci/drmemory-plugin
* jenkinsci/dumpinfo-buildwrapper-plugin
* jenkinsci/flashlog-plugin
* jenkinsci/gearman-plugin
* jenkinsci/jquery-detached
* jenkinsci/rqm-plugin
* jenkinsci/scripted-cloud-plugin