### PR TITLE
[INFRA-1666] Prefer index.jelly to <description> for excerpt (redux)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,12 @@
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-container-default</artifactId>
       <version>1.5.5</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.collections</groupId>
+          <artifactId>google-collections</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
@@ -183,6 +189,11 @@
       <groupId>jetty</groupId>
       <artifactId>jetty-util</artifactId>
       <version>6.0.0rc1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+      <artifactId>owasp-java-html-sanitizer</artifactId>
+      <version>20180219.1</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/src/main/java/org/jvnet/hudson/update_center/MavenArtifact.java
+++ b/src/main/java/org/jvnet/hudson/update_center/MavenArtifact.java
@@ -110,6 +110,14 @@ public class MavenArtifact {
         }
     }
 
+    public File resolveJar() throws IOException {
+        try {
+            return repository.resolve(artifact, "jar", null);
+        } catch (AbstractArtifactResolutionException e) {
+            throw new IOException("Failed to resolve artifact " + artifact + " jar", e);
+        }
+    }
+
     public File resolveSources() throws IOException {
         try {
             return repository.resolve(artifact,"jar","sources");

--- a/src/main/java/org/jvnet/hudson/update_center/MavenRepositoryImpl.java
+++ b/src/main/java/org/jvnet/hudson/update_center/MavenRepositoryImpl.java
@@ -87,6 +87,7 @@ public class MavenRepositoryImpl extends MavenRepository {
     protected ArtifactFactory af;
     protected ArtifactResolver ar;
     protected List<ArtifactRepository> remoteRepositories = new ArrayList<ArtifactRepository>();
+    private final File localRepo;
     protected ArtifactRepository local;
     protected ArtifactRepositoryFactory arf;
     private PlexusContainer plexus;
@@ -109,8 +110,9 @@ public class MavenRepositoryImpl extends MavenRepository {
         ar = plexus.lookup(ArtifactResolver.class);
         arf = plexus.lookup(ArtifactRepositoryFactory.class);
 
+        localRepo = new File(new File(System.getProperty("user.home")), ".m2/repository");
         local = arf.createArtifactRepository("local",
-                new File(new File(System.getProperty("user.home")), ".m2/repository").toURI().toURL().toExternalForm(),
+                localRepo.toURI().toURL().toExternalForm(),
                 new DefaultRepositoryLayout(), POLICY, POLICY);
     }
 
@@ -221,6 +223,9 @@ public class MavenRepositoryImpl extends MavenRepository {
 
     protected File resolve(ArtifactInfo a, String type, String classifier) throws AbstractArtifactResolutionException {
         Artifact artifact = af.createArtifactWithClassifier(a.groupId, a.artifactId, a.version, type, classifier);
+        if (!new File(localRepo, local.pathOf(artifact)).isFile()) {
+            System.err.println("Downloading " + artifact);
+        }
         ar.resolve(artifact, remoteRepositories, local);
         return artifact.getFile();
     }

--- a/src/main/java/org/jvnet/hudson/update_center/MavenRepositoryImpl.java
+++ b/src/main/java/org/jvnet/hudson/update_center/MavenRepositoryImpl.java
@@ -66,6 +66,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -161,7 +162,7 @@ public class MavenRepositoryImpl extends MavenRepository {
 
         URLConnection con = url.openConnection();
         if (url.getUserInfo()!=null) {
-            con.setRequestProperty("Authorization","Basic "+new sun.misc.BASE64Encoder().encode(url.getUserInfo().getBytes("UTF-8")));
+            con.setRequestProperty("Authorization", "Basic " + Base64.getEncoder().encodeToString(url.getUserInfo().getBytes("UTF-8")));
         }
 
         if (!expanded.exists() || !local.exists() || (local.lastModified()!=con.getLastModified() && !offlineIndex)) {

--- a/src/main/java/org/jvnet/hudson/update_center/MavenRepositoryImpl.java
+++ b/src/main/java/org/jvnet/hudson/update_center/MavenRepositoryImpl.java
@@ -167,7 +167,7 @@ public class MavenRepositoryImpl extends MavenRepository {
             con.setRequestProperty("Authorization", "Basic " + Base64.getEncoder().encodeToString(url.getUserInfo().getBytes("UTF-8")));
         }
 
-        if (!expanded.exists() || !local.exists() || (local.lastModified()!=con.getLastModified() && !offlineIndex)) {
+        if (!expanded.exists() || !local.exists() || (local.lastModified() < con.getLastModified() && !offlineIndex)) {
             System.out.println("Downloading "+url);
             // if the download fail in the middle, only leave a broken tmp file
             dir.mkdirs();

--- a/src/main/java/org/jvnet/hudson/update_center/Plugin.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Plugin.java
@@ -38,15 +38,30 @@ import org.dom4j.io.SAXReader;
 import org.sonatype.nexus.index.ArtifactInfo;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
 import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Properties;
+import java.util.jar.JarFile;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import org.owasp.html.HtmlSanitizer;
+import org.owasp.html.HtmlStreamRenderer;
+import org.owasp.html.PolicyFactory;
+import org.owasp.html.Sanitizers;
+import org.w3c.dom.NodeList;
 
 /**
  * An entry of a plugin in the update center metadata.
@@ -398,7 +413,9 @@ public class Plugin {
         return name;
     }
 
-    public JSONObject toJSON() throws IOException {
+    private static final PolicyFactory HTML_POLICY = Sanitizers.BLOCKS.and(Sanitizers.FORMATTING).and(Sanitizers.LINKS);
+
+    public JSONObject toJSON() throws Exception {
         JSONObject json = latest.toJSON(artifactId);
 
         SimpleDateFormat fisheyeDateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'.00Z'", Locale.US);
@@ -419,6 +436,26 @@ public class Plugin {
         json.put("labels", getLabels());
 
         String description = plainText2html(selectSingleValue(getPom(), "/project/description"));
+        try (JarFile jf = new JarFile(latest.resolveJar())) {
+            ZipEntry indexJelly = jf.getEntry("index.jelly");
+            if (indexJelly != null) {
+                try (InputStream is = jf.getInputStream(indexJelly)) {
+                    org.w3c.dom.Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(is);
+                    StringWriter sw = new StringWriter();
+                    Transformer transformer = TransformerFactory.newInstance().newTransformer();
+                    transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+                    StreamResult result = new StreamResult(sw);
+                    NodeList nl = doc.getDocumentElement().getChildNodes();
+                    for (int i = 0; i < nl.getLength(); i++) {
+                        transformer.transform(new DOMSource(nl.item(i)), result);
+                    }
+                    StringBuilder b = new StringBuilder();
+                    HtmlStreamRenderer renderer = HtmlStreamRenderer.create(b, Throwable::printStackTrace, html -> System.err.println("Bad HTML: " + html));
+                    HtmlSanitizer.sanitize(sw.toString(), HTML_POLICY.apply(renderer));
+                    description = b.toString().trim();
+                }
+            }
+        }
         if (latest.isAlphaOrBeta()) {
             description = "<b>(This version is experimental and may change in backward-incompatible ways)</b>" + (description == null ? "" : ("<br><br>" + description));
         }

--- a/src/main/java/org/jvnet/hudson/update_center/Plugin.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Plugin.java
@@ -452,7 +452,7 @@ public class Plugin {
                     StringBuilder b = new StringBuilder();
                     HtmlStreamRenderer renderer = HtmlStreamRenderer.create(b, Throwable::printStackTrace, html -> System.err.println("Bad HTML: " + html));
                     HtmlSanitizer.sanitize(sw.toString(), HTML_POLICY.apply(renderer));
-                    description = b.toString().trim();
+                    description = b.toString().trim().replaceAll("\\s+", " ");
                 }
             }
         }


### PR DESCRIPTION
Redoing #204, with a few additional refinements.

I have been trying to reproduce the claimed `jenkins.io` error with `\"` without success. I generated `actual.json` with `-maxPlugins 100`, enough to include some plugins with the supposedly problematic sequence:

```json
"excerpt": "This plugin integrates <a href=\"http://www.accurev.com/\" rel=\"nofollow\">AccuRev SCM</a> to Jenkins."
```

and then copied it to `content/_data/_generated/update_center.yml`. I tried

```bash
make
```

which worked, as did

```bash
make run
```

when I browsed, for example, `http://localhost:4242/security/advisory/2018-04-16/`, based on grepping sources and finding apparent usages in `content/security/advisories.html.haml` & `content/_layouts/advisory.html.haml`.

I suppose the expectation is that, as in [this hint](https://stackoverflow.com/a/24710810/12916), well-formed JSON can be parsed as YAML. Indeed in `irb`

```ruby
require 'yaml'
puts YAML.load('{"excerpt": "Invoke <a href=\"http://www.ansible.com/\" rel=\"nofollow\">Ansible</a> Ad-Hoc commands and playbooks."}')['excerpt']
```

works as expected.

How precisely do I reproduce the stated error?

Presumably the fix will somehow involve making `Makefile` and/or `scripts/fetch-external-resources` a little smarter: rather than copying `update-center.actual.json` verbatim to `update_center.yml`, we could process it a bit with `jq` or whatever to retrieve only the fields we are actually using (just `plugins/*/title` apparently), and ideally convert to regular YAML format.