### PR TITLE
SHA-512 -> SHA-256 (the stupid way)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,12 @@
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-container-default</artifactId>
       <version>1.5.5</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.collections</groupId>
+          <artifactId>google-collections</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
@@ -183,6 +189,11 @@
       <groupId>jetty</groupId>
       <artifactId>jetty-util</artifactId>
       <version>6.0.0rc1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+      <artifactId>owasp-java-html-sanitizer</artifactId>
+      <version>20180219.1</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/src/main/java/org/jvnet/hudson/update_center/MavenArtifact.java
+++ b/src/main/java/org/jvnet/hudson/update_center/MavenArtifact.java
@@ -120,23 +120,23 @@ public class MavenArtifact {
 
     private static class Digests {
         String sha1;
-        String sha512;
+        String sha256;
     }
 
     public Digests getDigests() throws IOException {
         try (FileInputStream fin = new FileInputStream(resolve())) {
             MessageDigest sha1 = DigestUtils.getSha1Digest();
-            MessageDigest sha512 = DigestUtils.getSha512Digest();
+            MessageDigest sha256 = DigestUtils.getSha256Digest();
             byte[] buf = new byte[2048];
             int len;
             while ((len=fin.read(buf,0,buf.length)) >= 0) {
                 sha1.update(buf, 0, len);
-                sha512.update(buf, 0, len);
+                sha256.update(buf, 0, len);
             }
 
             Digests ret = new Digests();
             ret.sha1 = new String(Base64.encodeBase64(sha1.digest()), "UTF-8");
-            ret.sha512 = new String(Base64.encodeBase64(sha512.digest()), "UTF-8");
+            ret.sha256 = new String(Base64.encodeBase64(sha256.digest()), "UTF-8");
             return ret;
         }
     }
@@ -150,7 +150,7 @@ public class MavenArtifact {
         o.put("buildDate", getTimestampAsString());
         Digests d = getDigests();
         o.put("sha1", d.sha1);
-        o.put("sha512", d.sha512);
+        o.put("sha256", d.sha256);
 
         return o;
     }

--- a/src/main/java/org/jvnet/hudson/update_center/MavenArtifact.java
+++ b/src/main/java/org/jvnet/hudson/update_center/MavenArtifact.java
@@ -110,6 +110,14 @@ public class MavenArtifact {
         }
     }
 
+    public File resolveJar() throws IOException {
+        try {
+            return repository.resolve(artifact, "jar", null);
+        } catch (AbstractArtifactResolutionException e) {
+            throw new IOException("Failed to resolve artifact " + artifact + " jar", e);
+        }
+    }
+
     public File resolveSources() throws IOException {
         try {
             return repository.resolve(artifact,"jar","sources");

--- a/src/main/java/org/jvnet/hudson/update_center/Plugin.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Plugin.java
@@ -462,6 +462,8 @@ public class Plugin {
                     LOGGER.warning("Failed to read index.jelly: " + ex.getMessage());
                 }
             }
+        } catch (IOException ex) {
+            LOGGER.warning("Failed to download jar: " + ex.getMessage());
         }
         if (latest.isAlphaOrBeta()) {
             description = "<b>(This version is experimental and may change in backward-incompatible ways)</b>" + (description == null ? "" : ("<br><br>" + description));


### PR DESCRIPTION
Since we have no real way to regression test changes to the update center, this is a simple switch to SHA-256 and the new description excerpts from `index.jelly` without the rest of #206 around it.
