### PR TITLE
Add generation of htaccess file for fallback redirects

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,6 +49,6 @@ node('linux') {
     }
 
     stage('Archive Update Site') {
-        archive 'output/**/*.json, output/htaccess'
+        archive 'output/**/*.json, output/htaccess/*'
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ node('linux') {
             sh 'java -jar target/update-center2-*-bin*/update-center2-*.jar' +
                     ' -id default -connectionCheckUrl http://www.google.com/' +
                     ' -no-experimental -skip-release-history' +
-                    ' -www ./output/latest -cap 2.107.999 -capCore 2.999'
+                    ' -www ./output/latest -download-fallback ./output/htaccess -cap 2.107.999 -capCore 2.999'
         }
     }
 
@@ -49,6 +49,6 @@ node('linux') {
     }
 
     stage('Archive Update Site') {
-        archive 'output/**/*.json'
+        archive 'output/**/*.json, output/htaccess'
     }
 }

--- a/site/generate.sh
+++ b/site/generate.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
 # Usage: SECRET=dirname ./site/generate.sh "./www2" "./download"
-[[ $# -eq 2 ]] || { echo "Usage: $0 <www root dir> <download root dir>" >&2 ; exit 1 ; }
+[[ $# -eq 3 ]] || { echo "Usage: $0 <www root dir> <download root dir>" >&2 ; exit 1 ; }
 [[ -n "$1" ]] || { echo "Non-empty www root dir required" >&2 ; exit 1 ; }
 [[ -n "$2" ]] || { echo "Non-empty download root dir required" >&2 ; exit 1 ; }
+[[ -n "$3" ]] || { echo "Non-empty download root dir required" >&2 ; exit 1 ; }
 
 [[ -n "$SECRET" ]] || { echo "SECRET env var not defined" >&2 ; exit 1 ; }
 [[ -d "$SECRET" ]] || { echo "SECRET env var not a directory" >&2 ; exit 1 ; }
@@ -12,6 +13,7 @@
 
 WWW_ROOT_DIR="$1"
 DOWNLOAD_ROOT_DIR="$2"
+FALLBACK_DIR="$3"
 
 set -o nounset
 set -o pipefail
@@ -99,7 +101,7 @@ done
 #     with symlinks pointing to the 'latest' current versions. So we generate exprimental first, then overwrite current to produce proper symlinks
 
 # experimental update center. this is not a part of the version-based redirection rules
-generate -skip-release-history -skip-plugin-versions -www "$WWW_ROOT_DIR/experimental" -download "$DOWNLOAD_ROOT_DIR"
+generate -skip-release-history -skip-plugin-versions -www "$WWW_ROOT_DIR/experimental" -download "$DOWNLOAD_ROOT_DIR" -download-fallback "$FALLBACK_DIR"
 
 # for the latest without any cap
 # also use this to generae https://updates.jenkins-ci.org/download layout, since this generator run

--- a/site/publish.sh
+++ b/site/publish.sh
@@ -9,7 +9,7 @@ chmod +x jq || { echo "Failed to make jq executable" >&2 ; exit 1; }
 
 export PATH=.:$PATH
 
-"$( dirname "$0" )/generate.sh" ./www2 ./download
+"$( dirname "$0" )/generate.sh" ./www2 ./download ./fallback
 
 # push plugins to mirrors.jenkins-ci.org
 chmod -R a+r download

--- a/src/main/java/org/jvnet/hudson/update_center/ArtifactoryRedirector.java
+++ b/src/main/java/org/jvnet/hudson/update_center/ArtifactoryRedirector.java
@@ -1,0 +1,49 @@
+package org.jvnet.hudson.update_center;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.regex.Pattern;
+
+public class ArtifactoryRedirector {
+    private final File directory;
+
+    private Map<String, MavenArtifact> redirects = new TreeMap<>();
+
+    public ArtifactoryRedirector(File directory) {
+        this.directory = directory;
+    }
+
+    private String getUri(MavenArtifact a) {
+        String basename = a.artifact.artifactId + "-" + a.artifact.version;
+        String filename;
+        if (a.artifact.classifier != null) {
+            filename = basename + "-" + a.artifact.classifier + "." + a.artifact.packaging;
+        } else {
+            filename = basename + "." + a.artifact.packaging;
+        }
+        String ret = "http://repo.jenkins-ci.org/releases/" + a.artifact.groupId.replace(".", "/") + "/" + a.artifact.artifactId + "/" + a.version + "/" + filename;
+        return ret;
+    }
+
+    public void recordRedirect(MavenArtifact a, String path) {
+        this.redirects.put(path, a);
+    }
+
+    private String regexEscape(String path) {
+        // TODO implement RCRE pattern escaping
+        return path;
+    }
+
+    public void writeRedirects() throws IOException {
+        directory.mkdirs();
+        FileWriter writer = new FileWriter(new File(directory, ".htaccess"));
+        writer.write("RewriteEngine on\n\n");
+        for (Map.Entry<String, MavenArtifact> entry : redirects.entrySet()) {
+            writer.write(String.format("RewriteRule ^%s$ %s [NC,L,R]\n", regexEscape(entry.getKey()), getUri(entry.getValue())));
+        }
+        writer.close();
+    }
+}

--- a/src/main/java/org/jvnet/hudson/update_center/ArtifactoryRedirector.java
+++ b/src/main/java/org/jvnet/hudson/update_center/ArtifactoryRedirector.java
@@ -40,9 +40,8 @@ public class ArtifactoryRedirector {
     public void writeRedirects() throws IOException {
         directory.mkdirs();
         FileWriter writer = new FileWriter(new File(directory, ".htaccess"));
-        writer.write("RewriteEngine on\n\n");
         for (Map.Entry<String, MavenArtifact> entry : redirects.entrySet()) {
-            writer.write(String.format("RewriteRule ^%s$ %s [NC,L,R]\n", regexEscape(entry.getKey()), getUri(entry.getValue())));
+            writer.write(String.format("Redirect \"/%s\" \"%s\"\n", regexEscape(entry.getKey()), getUri(entry.getValue())));
         }
         writer.close();
     }


### PR DESCRIPTION
Sample output (excerpt):

~~~~
RewriteEngine on

RewriteRule ^plugins/AnchorChain/1.0/AnchorChain.hpi$ http://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/AnchorChain/1.0/AnchorChain-1.0.hpi [NC,L,R]
RewriteRule ^plugins/ApicaLoadtest/1.0/ApicaLoadtest.hpi$ http://repo.jenkins-ci.org/releases/com/apica/ApicaLoadtest/1.0/ApicaLoadtest-1.0.hpi [NC,L,R]
RewriteRule ^plugins/ApicaLoadtest/1.1/ApicaLoadtest.hpi$ http://repo.jenkins-ci.org/releases/com/apica/ApicaLoadtest/1.1/ApicaLoadtest-1.1.hpi [NC,L,R]
RewriteRule ^plugins/ApicaLoadtest/1.10/ApicaLoadtest.hpi$ http://repo.jenkins-ci.org/releases/com/apica/ApicaLoadtest/1.10/ApicaLoadtest-1.10.hpi [NC,L,R]
RewriteRule ^plugins/ApicaLoadtest/1.4/ApicaLoadtest.hpi$ http://repo.jenkins-ci.org/releases/com/apica/ApicaLoadtest/1.4/ApicaLoadtest-1.4.hpi [NC,L,R]
RewriteRule ^plugins/ApicaLoadtest/1.8/ApicaLoadtest.hpi$ http://repo.jenkins-ci.org/releases/com/apica/ApicaLoadtest/1.8/ApicaLoadtest-1.8.hpi [NC,L,R]
RewriteRule ^plugins/ApicaLoadtest/1.9/ApicaLoadtest.hpi$ http://repo.jenkins-ci.org/releases/com/apica/ApicaLoadtest/1.9/ApicaLoadtest-1.9.hpi [NC,L,R]
~~~~

Tested using Apache docker container:

~~~~
FROM httpd:2.4

COPY .htaccess /usr/local/apache2/htdocs

RUN sed -i '/LoadModule rewrite_module/s/^#//g' /usr/local/apache2/conf/httpd.conf
RUN sed -i '/AllowOverride None/s/None/All/g' /usr/local/apache2/conf/httpd.conf
~~~~