### PR TITLE
Fall back to artifactId when title is empty string

### DIFF
--- a/src/main/java/org/jvnet/hudson/update_center/Plugin.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Plugin.java
@@ -406,7 +406,7 @@ public class Plugin {
     /** @return The plugin name defined in the POM &lt;name> modified by simplication rules (no 'Jenkins', no 'Plugin'); then artifact ID. */
     public String getName() throws IOException {
         String title = readSingleValueFromXmlFile(latest.resolvePOM(), "/project/name");
-        if (title == null) {
+        if (title == null || "".equals(title)) {
             title = artifactId;
         } else {
             title = simplifyPluginName(title);


### PR DESCRIPTION
Probably a side effect of recent changes is that this is now typically an empty string, rather than null. I'm not sure why, but given the surprising number of plugins with undefined title, this needs to be fixed quickly.

      "title": "accelerated-build-now-plugin",
      "title": "anything-goes-formatter",
      "title": "artifact-promotion",
      "title": "beer",
      "title": "behave-testresults-publisher",
      "title": "build-env-propagator",
      "title": "build-metrics",
      "title": "build-name-setter",
      "title": "buildgraph-view",
      "title": "built-on-column",
      "title": "categorized-view",
      "title": "change-assembly-version-plugin",
      "title": "chef-tracking",
      "title": "chosen-views-tabbar",
      "title": "chromedriver",
      "title": "couchdb-statistics",
      "title": "countjobs-viewstabbar",
      "title": "crittercism-dsym",
      "title": "cucumber-perf",
      "title": "cucumber-slack-notifier",
      "title": "CustomHistory",
      "title": "database",
      "title": "database-drizzle",
      "title": "database-h2",
      "title": "database-mysql",
      "title": "database-postgresql",
      "title": "delta-cloud",
      "title": "deploygate-plugin",
      "title": "deployment-notification",
      "title": "diskcheck",
      "title": "docker-build-step",
      "title": "DotCi",
      "title": "DotCi-Plugins-Starter-Pack",
      "title": "drecycler",
      "title": "ease-plugin",
      "title": "ec2-cloud-axis",
      "title": "elastic-axis",
      "title": "elOyente",
      "title": "embeddable-build-status",
      "title": "emotional-jenkins-plugin",
      "title": "enhanced-old-build-discarder",
      "title": "event-announcer",
      "title": "excludeMatrixParent",
      "title": "extension-filter",
      "title": "extreme-feedback",
      "title": "graphiteIntegrator",
      "title": "hckrnews",
      "title": "housekeeper",
      "title": "jenkins-reviewbot",
      "title": "jenkins-testswarm-plugin",
      "title": "jobtemplates",
      "title": "keepSlaveOffline",
      "title": "lingr-plugin",
      "title": "meliora-testlab",
      "title": "mesos",
      "title": "mongodb-document-upload",
      "title": "monitor-remote-job",
      "title": "multi-module-tests-publisher",
      "title": "myst-plugin",
      "title": "next-executions",
      "title": "oki-docki",
      "title": "openid",
      "title": "openJDK-native-plugin",
      "title": "packagecloud",
      "title": "packer",
      "title": "patch-parameter",
      "title": "php",
      "title": "piketec-tpt",
      "title": "pom2config",
      "title": "post-completed-build-result",
      "title": "pry",
      "title": "rallyBuild",
      "title": "rapiddeploy-jenkins",
      "title": "rhnpush-plugin",
      "title": "rpmsign-plugin",
      "title": "ruby-runtime",
      "title": "SBuild",
      "title": "signal-killer",
      "title": "skip-certificate-check",
      "title": "slave-proxy",
      "title": "SSSCM",
      "title": "suite-test-groups-publisher",
      "title": "transifex",
      "title": "TwilioNotifier",
      "title": "unreliable-slave-plugin",
      "title": "vboxwrapper",
      "title": "veracode-scanner",
      "title": "vertx",
      "title": "view-cloner",
      "title": "workplace-notifier",
      "title": "writable-filesystem-monitor",
      "title": "youtrack-plugin",
