### PR TITLE
[INFRA-1730] Upload /output/htaccess/* to an azure file storage

### DIFF
--- a/site/publish.sh
+++ b/site/publish.sh
@@ -20,3 +20,13 @@ rsync -avz --size-only download/plugins/ ${RSYNC_USER}@${UPDATES_SITE}:/srv/rele
 # delete old sites
 chmod -R a+r www2
 rsync -acvz www2/ --exclude=/updates --delete ${RSYNC_USER}@${UPDATES_SITE}:/var/www/${UPDATES_SITE}
+
+# push generated htaccess file on the azure file storage produpdatesproxy
+# This file is used by updates.azure.jenkins.io as fallback service for updates.jenkins.io
+
+az storage file upload-batch \
+    --account-name produpdatesproxy \
+    --account-key "${UPDATESPROXY_STORAGEACCOUNTKEY}" \
+    --source ../output/htaccess \
+    --destination updates-proxy \
+    --validate-content


### PR DESCRIPTION
This PR upload files from output/htaccess/* to an Azure File storage.
Once the htaccess file is generated and uploaded, [updates.azure.jenkins.io](https://updates.azure.jenkins.io) should works.

Ps: I am not sure about this line '../output/htaccess'