### PR TITLE
[JENKINS-53399] Blacklist config-file-provider 3.0

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -274,3 +274,6 @@ reviewboard         # depends on perforce
 # requested by maintainer in https://github.com/jenkins-infra/update-center2/pull/199
 websphere-deployer-1.5.5
 websphere-deployer-1.5.6
+
+# JENKINS-53399 - breaks folder configurations badly enough to break permissions, scripted libraries, etc
+config-file-provider-3.0


### PR DESCRIPTION
This breaks too badly - see
https://issues.jenkins-ci.org/browse/JENKINS-53399. I just helped
someone deal with the result of upgrading from 2.18 to 3.0 - folder
shared libraries and permissions all broke horribly, and were fixed
with a downgrade.