### PR TITLE
Suspend distribution of sge-cloud-plugin

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -269,6 +269,7 @@ liquibase-runner
 perforce
 build-configurator  # depends on copy-to-slave
 lsf-cloud           # depends on copy-to-slave
+sge-cloud-plugin    # depends on copy-to-slave
 reviewboard         # depends on perforce
 
 # requested by maintainer in https://github.com/jenkins-infra/update-center2/pull/199


### PR DESCRIPTION
The first actual release of `sge-cloud-plugin` was performed this week.

Unfortunately, it has a mandatory dependency on [the copy-to-slave plugin we blacklisted in March](https://jenkins.io/security/advisory/2018-03-26/#SECURITY-545), so it cannot actually be installed. Additionally, Jenkins instances will show this warning, even if they have neither mentioned plugin installed:

    WARNING: Could not find dependency copy-to-slave of sge-cloud-plugin

Suspending distribution until this dependency is removed or made optional.

FYI @jmcgeheeiv 