### PR TITLE
Add ui label for calendar-view plugin

### DIFF
--- a/src/main/resources/label-definitions.properties
+++ b/src/main/resources/label-definitions.properties
@@ -126,6 +126,7 @@ built-on-column=listview-column
 bulk-builder=builder misc
 bumblebee=post-build report
 ca-apm=ca-apm
+calendar-view=ui
 campfire=notifier
 capitomcat=upload
 cas-plugin=user


### PR DESCRIPTION
Pull request should be self-explanatory. 

I'm the plugin maintainer, have commit access for the repository and can publish releases if that matters.

Plugin repository: https://github.com/jenkinsci/calendar-view-plugin