### PR TITLE
remove scriptler from list of ignored plugins

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -212,7 +212,6 @@ grails                        # SECURITY-458
 groovyaxis                    # SECURITY-460
 reactor-plugin                # SECURITY-487
 script-scm                    # SECURITY-461
-scriptler                     # SECURITY-367 etc.
 scripttrigger                 # SECURITY-456
 svn-tag                       # SECURITY-298
 tcl                           # SECURITY-379

--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -212,6 +212,25 @@ grails                        # SECURITY-458
 groovyaxis                    # SECURITY-460
 reactor-plugin                # SECURITY-487
 script-scm                    # SECURITY-461
+scriptler-1.0                 # SECURITY-367 etc.
+scriptler-1.1                 # SECURITY-367 etc.
+scriptler-1.2                 # SECURITY-367 etc.
+scriptler-1.3                 # SECURITY-367 etc.
+scriptler-1.4                 # SECURITY-367 etc.
+scriptler-1.5                 # SECURITY-367 etc.
+scriptler-2.0                 # SECURITY-367 etc.
+scriptler-2.1                 # SECURITY-367 etc.
+scriptler-2.2                 # SECURITY-367 etc.
+scriptler-2.2.1               # SECURITY-367 etc.
+scriptler-2.3                 # SECURITY-367 etc.
+scriptler-2.4                 # SECURITY-367 etc.
+scriptler-2.4.1               # SECURITY-367 etc.
+scriptler-2.5                 # SECURITY-367 etc.
+scriptler-2.5.1               # SECURITY-367 etc.
+scriptler-2.6                 # SECURITY-367 etc.
+scriptler-2.6.1               # SECURITY-367 etc.
+scriptler-2.7                 # SECURITY-367 etc.
+scriptler-2.9                 # SECURITY-367 etc.
 scripttrigger                 # SECURITY-456
 svn-tag                       # SECURITY-298
 tcl                           # SECURITY-379


### PR DESCRIPTION
With version 3.0-alpha (Oct. 10, 2018) - scriptler has fixed all its security vulnerabilities.