### PR TITLE
[JENKINS-54073] Suppress workflow-job 2.26 for now

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -279,3 +279,6 @@ websphere-deployer-1.5.6
 
 # JENKINS-53399 - breaks folder configurations badly enough to break permissions, scripted libraries, etc
 config-file-provider-3.0
+
+# JENKINS-54073, claimed performance regression as of yet undiagnosed; plus some more minor issues:
+workflow-job-2.26


### PR DESCRIPTION
Pending investigation whether https://github.com/jenkinsci/workflow-api-plugin/pull/81 or something else helps users. CC @svanoort @dwnusbaum; [release notes](https://wiki.jenkins.io/display/JENKINS/Pipeline+Job+Plugin)