### PR TITLE
Make resolution robust against URL problems

### DIFF
--- a/src/main/java/org/jvnet/hudson/update_center/MavenRepositoryImpl.java
+++ b/src/main/java/org/jvnet/hudson/update_center/MavenRepositoryImpl.java
@@ -36,6 +36,7 @@ import org.apache.maven.artifact.repository.ArtifactRepositoryFactory;
 import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
 import org.apache.maven.artifact.repository.layout.DefaultRepositoryLayout;
 import org.apache.maven.artifact.resolver.AbstractArtifactResolutionException;
+import org.apache.maven.artifact.resolver.ArtifactResolutionException;
 import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.artifact.transform.ArtifactTransformationManager;
 import org.apache.tools.ant.taskdefs.Expand;
@@ -226,7 +227,11 @@ public class MavenRepositoryImpl extends MavenRepository {
         if (!new File(localRepo, local.pathOf(artifact)).isFile()) {
             System.err.println("Downloading " + artifact);
         }
-        ar.resolve(artifact, remoteRepositories, local);
+        try {
+            ar.resolve(artifact, remoteRepositories, local);
+        } catch (RuntimeException e) {
+            throw new ArtifactResolutionException(e.getMessage(), artifact);
+        }
         return artifact.getFile();
     }
 


### PR DESCRIPTION
````
Exception in thread "main" java.lang.IllegalArgumentException: Invalid uri 'http://repo.jenkins-ci.org/public//org/jenkins-ci/plugins/performance/3��.13/performance-3��.13.pom': escaped absolute path not valid
	at org.apache.commons.httpclient.HttpMethodBase.<init>(HttpMethodBase.java:222)
	at org.apache.commons.httpclient.methods.GetMethod.<init>(GetMethod.java:89)
	at org.apache.maven.wagon.shared.http.AbstractHttpClientWagon.fillInputData(AbstractHttpClientWagon.java:465)
	at org.apache.maven.wagon.StreamWagon.getInputStream(StreamWagon.java:116)
	at org.apache.maven.wagon.StreamWagon.getIfNewer(StreamWagon.java:88)
	at org.apache.maven.wagon.StreamWagon.get(StreamWagon.java:61)
	at org.apache.maven.artifact.manager.DefaultWagonManager.getRemoteFile(DefaultWagonManager.java:597)
	at org.apache.maven.artifact.manager.DefaultWagonManager.getArtifact(DefaultWagonManager.java:443)
	at org.apache.maven.artifact.manager.DefaultWagonManager.getArtifact(DefaultWagonManager.java:354)
	at org.apache.maven.artifact.resolver.DefaultArtifactResolver.resolve(DefaultArtifactResolver.java:167)
	at org.apache.maven.artifact.resolver.DefaultArtifactResolver.resolve(DefaultArtifactResolver.java:82)
	at org.jvnet.hudson.update_center.MavenRepositoryImpl.resolve(MavenRepositoryImpl.java:229)
	at org.jvnet.hudson.update_center.MavenArtifact.resolvePOM(MavenArtifact.java:103)
	at org.jvnet.hudson.update_center.Plugin.getName(Plugin.java:408)
	at org.jvnet.hudson.update_center.Main.buildReleaseHistory(Main.java:542)
	at org.jvnet.hudson.update_center.Main.buildFullReleaseHistory(Main.java:519)
	at org.jvnet.hudson.update_center.Main.run(Main.java:262)
	at org.jvnet.hudson.update_center.Main.run(Main.java:191)
	at org.jvnet.hudson.update_center.Main.main(Main.java:166)
````