### PR TITLE
Ignore binary-deployer as deployed by mistake

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -9,6 +9,7 @@ aws-lambda-jenkins-plugin        # renamed to aws-lambda
 aws-lambda-plugin                # renamed to aws-lambda
 aws-yum-paramater                # renamed to package-parameter
 bees-sdk-plugin                  # removal requested by ndeloof: RUN@cloud service no longer exists
+binary-deployer                  # removal requested by alecharp: this plugin was never meant to be deployed. POC project.
 blackduck-installer              # "This plugin is no longer supported and should not be used." -- https://wiki.jenkins-ci.org/display/JENKINS/Black+Duck+Vulnerability+Installer+Plugin
 blitz.io-jenkins                 # renamed to blitz_io-jenkins
 build-node-column                # superseded by Extra Columns Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Build+Node+Column+Plugin


### PR DESCRIPTION
As mentioned by @daniel-beck in jenkins-infra/repository-permissions-updater#943, filling this PR to ignore `binary-deployer`. The project was / is a POC and not meant to be deployed. It's not hosted in `jenkinsci` org either.