### PR TITLE
[JENKINS-55159] Add hpaat plugin 5.6 to the blacklist

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -142,18 +142,19 @@ kubernetes-pipeline-devops-steps-1.3
 kubernetes-pipeline-aggregator-1.3
 
 # specific releases
-active-directory-2.1      # JENKINS-42739
-BlameSubversion-1.121     # big number but not the latest release
-fortify-on-demand-uploader-1.0 # removal requested by Ryan Black, plugin wasn't ready for release
-gradle-1.27               # JENKINS-45126
-matrix-project-1.2.1      # also INFRA-250
-matrix-project-1.4.1      # this specific version is excluded for INFRA-250
-rebuild-1.2               # release troubles.. skip these
-rebuild-1.3               # ??
-ruby-runtime-0.13         # JENKINS-37353, JENKINS-37771 and JENKINS-38145
-jira-2.5.1                # JENKINS-48357 - binary compatibility issues
-qtest-1.2.0               # draft release and not the latest release
-contrast-continuous-application-security-2.7 # backwards compatibility issue
+active-directory-2.1     		    	 # JENKINS-42739
+BlameSubversion-1.121    		    	 # big number but not the latest release
+fortify-on-demand-uploader-1.0 		    	 # removal requested by Ryan Black, plugin wasn't ready for release
+gradle-1.27              		    	 # JENKINS-45126
+matrix-project-1.2.1     		    	 # also INFRA-250
+matrix-project-1.4.1     		    	 # this specific version is excluded for INFRA-250
+rebuild-1.2              		    	 # release troubles.. skip these
+rebuild-1.3              		    	 # ??
+ruby-runtime-0.13        		    	 # JENKINS-37353, JENKINS-37771 and JENKINS-38145
+jira-2.5.1               		    	 # JENKINS-48357 - binary compatibility issues
+qtest-1.2.0              		    	 # draft release and not the latest release
+contrast-continuous-application-security-2.7	 # backwards compatibility issue
+hp-application-automation-tools-plugin-5.6  	 # JENKINS-55159 - Dependency issues
 
 # rogue releases with unknown source
 ez-templates-1.0.0


### PR DESCRIPTION
The name of the plugin "hp-application-automation-tools-plugin" should be written as in the following link?
[repo.jenkins-ci.org](https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/hp-application-automation-tools-plugin/)

Also indented the comments after #.
Let me know if any changes are required.