### PR TITLE
Hide git-client 3.0.0-rc and git 4.0.0-rc

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -304,3 +304,8 @@ config-file-provider-3.0
 
 # JENKINS-54073, claimed performance regression as of yet undiagnosed; plus some more minor issues:
 workflow-job-2.26
+
+# Requested by Mark Waite https://groups.google.com/d/msg/jenkinsci-dev/9MDl1SWeF0o/cvp3_nzjFAAJ
+# mistakenly used -rc suffix thinking it would only be exposed in the experimental update center
+git-4.0.0-rc
+git-client-3.0.0-rc


### PR DESCRIPTION
As requested by @markewaite

The expectation was to land these releases into the experimental UC only.