### PR TITLE
Change WarningsTest output format

### DIFF
--- a/src/test/java/org/jvnet/hudson/update_center/WarningsTest.java
+++ b/src/test/java/org/jvnet/hudson/update_center/WarningsTest.java
@@ -63,7 +63,7 @@ public class WarningsTest {
             }
 
             Warning warning = new Warning();
-            warning.id = o.getString("id");
+            warning.id = o.getString("url") + " / " + o.getString("id");
 
             JSONArray versions = o.getJSONArray("versions");
             for (int j = 0 ; j < versions.size() ; j++) {


### PR DESCRIPTION
@Wadeck Due to consistent URLs, this will allow ASCII-sorting latest warnings to the end in the `WarningsTest-output.txt`