### PR TITLE
Remove the obsolete fortify360 plugin

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -309,3 +309,6 @@ workflow-job-2.26
 # mistakenly used -rc suffix thinking it would only be exposed in the experimental update center
 git-4.0.0-rc
 git-client-3.0.0-rc
+
+# Replaced by the official fortify plugin https://wiki.jenkins.io/display/JENKINS/Fortify+Plugin
+fortify360


### PR DESCRIPTION
We would like to remove or deprecate the old Fortify360 plugin. It's obsolete and has not worked for years. It's been completely replaced with the Fortify plugin that's been open sourced a few days ago [https://github.com/jenkinsci/fortify-plugin](https://github.com/jenkinsci/fortify-plugin)
Fortify360 is the name that's not used by our product management anymore, and having this plugin could be very confusing for our customers. The new plugin's wiki is here [https://wiki.jenkins.io/display/JENKINS/Fortify+Plugin](https://wiki.jenkins.io/display/JENKINS/Fortify+Plugin)
Also, here's the relevant JIRA ticket with more details: [HOSTING-710](https://issues.jenkins-ci.org/browse/HOSTING-710)
