### PR TITLE
ignore JCasC 1.9, failed shading of snakeyaml

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -314,3 +314,7 @@ git-client-3.0.0-rc
 
 # Replaced by the official fortify plugin https://wiki.jenkins.io/display/JENKINS/Fortify+Plugin
 fortify360
+
+# Failed shading Snakeyaml, 1.9 has both shaded and direct dependency inside
+configuration-as-code-1.9
+configuration-as-code-support-1.9


### PR DESCRIPTION
Please ignore configuration-as-code 1.9 plugin from update center :sweat: 

![image](https://user-images.githubusercontent.com/1661688/55422696-865c1c80-557c-11e9-8329-9d73a00d1bc7.png)
