### PR TITLE
Adapt warning for deployhub release with fix

### DIFF
--- a/src/main/resources/warnings.json
+++ b/src/main/resources/warnings.json
@@ -4483,7 +4483,8 @@
     "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-959",
     "versions": [
       {
-        "pattern": ".*"
+        "lastVersion": "8.0.13",
+        "pattern": "8[.]0[.]([0-9]|1[0-3])(|[-.].*)"
       }
     ]
   },


### PR DESCRIPTION
https://github.com/jenkinsci/deployhub-plugin/releases/tag/deployhub-8.0.14 has a fix at https://github.com/jenkinsci/deployhub-plugin/commit/6ad56362087f6d34c3532a0962a881cd8a822394

@sbtaylor15 FYI this will disable the security warning in Jenkins when 8.0.14 is installed, and on the plugin site (https://plugins.jenkins.io/deployhub).

I'd also like to understand what went wrong in notifying you before release, if you're willing to help me with that.