### PR TITLE
Adapt warning for aqua-security-scanner-3.0.16

### DIFF
--- a/src/main/resources/warnings.json
+++ b/src/main/resources/warnings.json
@@ -4123,7 +4123,8 @@
     "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-949",
     "versions": [
       {
-        "pattern": ".*"
+        "lastVersion": "3.0.15",
+        "pattern": "(1|2|3[.]0[.]([0-9]|1[0-5]))(|[-.].*)"
       }
     ]
   },


### PR DESCRIPTION
Update/remove warnings about aqua-security-scanner from https://plugins.jenkins.io/aqua-security-scanner and update center metadata because https://github.com/jenkinsci/aqua-security-scanner-plugin/commit/6468cec53cc4ad32d79aa016631ba441bbf07b4a appears to have fixed the issue in 3.0.16.

FYI @oranmoshai 