### PR TITLE
Disable security warning for klaros-testmanagement-2.1.0

### DIFF
--- a/src/main/resources/warnings.json
+++ b/src/main/resources/warnings.json
@@ -4436,7 +4436,8 @@
     "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-843",
     "versions": [
       {
-        "pattern": ".*"
+        "lastVersion": "2.0.0",
+        "pattern": "(1|2[.]0)(|[-.].*)"
       }
     ]
   },


### PR DESCRIPTION
@stolp FYI

**Not to be merged before 2.1.0 or later is released**