### PR TITLE
Remove bad release for google-compute-engine

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -157,6 +157,7 @@ jira-2.5.1               		    	 # JENKINS-48357 - binary compatibility issues
 qtest-1.2.0              		    	 # draft release and not the latest release
 contrast-continuous-application-security-2.7	 # backwards compatibility issue
 hp-application-automation-tools-plugin-5.6  	 # JENKINS-55159 - Dependency issues
+google-compute-engine-3.1.0                      # Github issue #85 - Regression
 
 # rogue releases with unknown source
 ez-templates-1.0.0


### PR DESCRIPTION
Referencing https://github.com/jenkinsci/google-compute-engine-plugin/issues/85 for the Google compute engine plugin for jenkins: https://github.com/jenkinsci/google-compute-engine-plugin

Regression detected.
There was a bug in which the instance ID for the virtual machine cloud was not being set. Agents could not be launched as a result.

Bug has since been patched (3.1.1). Would like to remove buggy release (3.1.0).