### PR TITLE
Changes release availability of build-name-setter-plugin

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -158,6 +158,7 @@ qtest-1.2.0              		    	 # draft release and not the latest release
 contrast-continuous-application-security-2.7	 # backwards compatibility issue
 hp-application-automation-tools-plugin-5.6  	 # JENKINS-55159 - Dependency issues
 google-compute-engine-3.1.0                      # Github issue #85 - Regression
+build-name-setter-plugin-2.0.0           # breaks builds when using with build-user-vars-plugin https://github.com/jenkinsci/build-name-setter-plugin/issues/39
 
 # rogue releases with unknown source
 ez-templates-1.0.0


### PR DESCRIPTION
Issue https://github.com/jenkinsci/build-name-setter-plugin/issues/39

Release 2.0.0 should not be available to download any more as it is probably broken