### PR TITLE
Update warnings after fixes in Artifactory Plugin 3.2.3 and 3.2.4

### DIFF
--- a/src/main/resources/warnings.json
+++ b/src/main/resources/warnings.json
@@ -4956,7 +4956,7 @@
     "versions": [
       {
         "lastVersion": "3.2.2",
-        "pattern": ".*"
+        "pattern": "([12]|3[.]([01]|2[.][012]))(|[.-].*)"
       }
     ]
   },
@@ -4968,8 +4968,8 @@
     "url": "https://jenkins.io/security/advisory/2019-05-31/#SECURITY-1015%20(2)",
     "versions": [
       {
-        "lastVersion": "3.2.2",
-        "pattern": ".*"
+        "lastVersion": "3.2.3",
+        "pattern": "([12]|3[.]([01]|2[.][0123]))(|[.-].*)"
       }
     ]
   },
@@ -4982,7 +4982,7 @@
     "versions": [
       {
         "lastVersion": "3.2.2",
-        "pattern": ".*"
+        "pattern": "([12]|3[.]([01]|2[.][012]))(|[.-].*)"
       }
     ]
   },


### PR DESCRIPTION
Test output:

```
Warning https://jenkins.io/security/advisory/2019-05-31/#SECURITY-1015%20(1) / SECURITY-1015-1 does NOT match org.jenkins-ci.plugins:artifactory:3.2.3
Warning https://jenkins.io/security/advisory/2019-05-31/#SECURITY-1015%20(1) / SECURITY-1015-1 does NOT match org.jenkins-ci.plugins:artifactory:3.2.4
Warning https://jenkins.io/security/advisory/2019-05-31/#SECURITY-1015%20(2) / SECURITY-1015-2 does NOT match org.jenkins-ci.plugins:artifactory:3.2.4
Warning https://jenkins.io/security/advisory/2019-05-31/#SECURITY-1347 / SECURITY-1347 does NOT match org.jenkins-ci.plugins:artifactory:3.2.3
Warning https://jenkins.io/security/advisory/2019-05-31/#SECURITY-1347 / SECURITY-1347 does NOT match org.jenkins-ci.plugins:artifactory:3.2.4
```

_SECURITY-1015 (2)_ took one release longer than the others, see also https://github.com/CVEProject/cvelist/pull/2145

FYI @eyalbe4