### PR TITLE
mark configuration-as-code-support with deprecation label

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -26,7 +26,6 @@ cloudbees-registration           # "This feature is no longer relevant." -- http
 cloudbees-disk-usage-simple-plugin # renamed to cloudbees-disk-usage-simple several years ago
 ColumnPack-plugin                # renamed to ColumnsPlugin
 ConfigurationSlicing             # renamed into configurationslicing, and this double causes a check out problem on Windows
-configuration-as-code-support    # deprecated
 copyarchiver                     # superseded by ArtifactDeployer Plugin  -- https://wiki.jenkins-ci.org/display/JENKINS/CopyArchiver+Plugin
 cppunit                          # Incompatible with Hudson 1.355+ and superseded by xUnit Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/CppUnit+Plugin
 create-fingerprint-plugin        # renamed to create-fingerprint
@@ -325,3 +324,7 @@ fortify360
 
 # Failed shading Snakeyaml, 1.9 has both shaded and direct dependency inside
 configuration-as-code-1.9
+configuration-as-code-support-1.9
+
+# No Source release of JCasC support 1.19
+configuration-as-code-support-1.19

--- a/src/main/resources/label-definitions.properties
+++ b/src/main/resources/label-definitions.properties
@@ -199,6 +199,7 @@ config-autorefresh-plugin=misc
 config-file-provider=maven external groovy-related
 config-rotator=misc scm post-build
 configurationslicing=misc builder emailext
+configuration-as-code-support=deprecated
 configure-job-column-plugin=listview-column ui misc
 confluence-publisher=upload external
 console-badge=misc ui


### PR DESCRIPTION
Testing out https://github.com/jenkinsci/jenkins/pull/4073 :sweat_smile: 