### PR TITLE
add qtest jenkins plugin version 1.4.1 to blacklist release

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -155,6 +155,7 @@ rebuild-1.3              		    	 # ??
 ruby-runtime-0.13        		    	 # JENKINS-37353, JENKINS-37771 and JENKINS-38145
 jira-2.5.1               		    	 # JENKINS-48357 - binary compatibility issues
 qtest-1.2.0              		    	 # draft release and not the latest release
+qtest-1.4.1              		    	 # unexpected release version - latest release is 1.4.2
 contrast-continuous-application-security-2.7	 # backwards compatibility issue
 hp-application-automation-tools-plugin-5.6  	 # JENKINS-55159 - Dependency issues
 google-compute-engine-3.1.0                      # Github issue #85 - Regression


### PR DESCRIPTION
I had a mistake when releasing plugin version 1.4.2 and want to add qtest jenkins plugin version 1.4.1 to blacklist release.