### PR TITLE
Remove google-compute-engine-3.3.1 after failed deployment

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -328,3 +328,6 @@ configuration-as-code-support-1.9
 
 # No Source release of JCasC support 1.19
 configuration-as-code-support-1.19
+
+# Failed release of Google Compute Engine Plugin 3.3.1
+google-compute-engine-3.3.1


### PR DESCRIPTION
Replaced by [google-compute-engine-3.3.2](https://repo.jenkins-ci.org/webapp/#/artifacts/browse/tree/General/releases/org/jenkins-ci/plugins/google-compute-engine/3.3.2).