### PR TITLE
Suspend distribution of bumblebee plugin

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -328,3 +328,6 @@ configuration-as-code-support-1.9
 
 # No Source release of JCasC support 1.19
 configuration-as-code-support-1.19
+
+# Closed source dependencies
+bumblebee


### PR DESCRIPTION
The dependency `bumblebee-client` at https://github.com/jenkinsci/bumblebee-plugin/blob/22e438062e1aca433b9cea372f89a45ae75e426b/pom.xml#L80 is downloaded through the "agiletestware" repositories on AWS defined further down.

I was unable to find a source code repository (the URL from the [pom](http://public.maven.agiletestware.com.s3-website-us-west-2.amazonaws.com/release/com/agiletestware/bumblebee-client/0.1.1/bumblebee-client-0.1.1.pom) points to a [private repository](https://bitbucket.org/agiletestwareteam/bumblebee-client.git) on Bitbucket), and there is apparently no source archive in the repository on AWS. Additionally, maven-license-plugin is unable to determine the licenses of:

- com.agiletestware--bumblebee-client--0.1.1
- com.agiletestware--bumblebee-shared--0.1.0

(among others)

As we require that plugins are open source "all the way down" in the form distributed to users via update centers, this PR suspends the distribution of this plugin until it is cleaned up.

CC @sergey-oplavin who is the active maintainer, please respond to this ASAP.