### PR TITLE
Blacklist renamed clang-scanbuild-plugin and xltest-plugin

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -19,6 +19,7 @@ buildheroes                      # service discontinued -- https://wiki.jenkins-
 caroline                         # service shut down -- https://wiki.jenkins-ci.org/display/JENKINS/Caroline+Plugin
 ChatRoom                         # junk plugin; developer has been banned
 cifs                             # Superseded by Publish Over CIFS Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/CIFS-Publisher+Plugin
+clang-scanbuild-plugin           # renamed to clang-scanbuild in https://github.com/jenkinsci/clang-scanbuild-plugin/commit/a6d57b67f6fbd0a9893ecf6436c54ecb670d5829
 cloudbees-deployer-plugin        # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Cloudbees+Deployer+Plugin
 cloudbees-enterprise-plugins     # Unsupported and retracted by service provider -- https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Jenkins+Enterprise
 cloudbees-jenkins-advisor        # Service discontinued -- https://wiki.jenkins.io/display/JENKINS/CloudBees+Jenkins+Advisor+Plugin
@@ -134,6 +135,7 @@ vagrant-plugin                   # renamed to vagrant, herpderp
 vessel                           # service discontinued --- https://wiki.jenkins-ci.org/display/JENKINS/Vessel+plugin https://groups.google.com/d/msg/jenkinsci-dev/L34eAMMWA5o/-AxtRdGsAAAJ
 weibo4jenkins                    # renamed to weibo
 wsnotifier                       # renamed to websocket
+xltest-plugin                    # renamed to xltestview-plugin in https://github.com/jenkinsci/xltestview-plugin/commit/ea034f9929b520e63b9ce15aed9bdb62354146cf
 zaproxy                          # superseded by zap -- https://wiki.jenkins-ci.org/display/JENKINS/ZAProxy+Plugin
 zaproxy-jenkins                  # renamed to zaproxy
 zubhium                          # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Zubhium+Plugin


### PR DESCRIPTION
XLTest Plugin was renamed in https://github.com/jenkinsci/xltestview-plugin/commit/ea034f9929b520e63b9ce15aed9bdb62354146cf by @amolenaar with the now obsolete plugin never having been removed from distribution. Confusingly, versioning restarted, XL Test 1.1.0 was released in May 2015, XL TestView 1.0.0 was released in June 2015.

Clang Scan-Build appears to have been accidentally renamed, since @rodrigc did not mention anything about that in https://github.com/jenkinsci/clang-scanbuild-plugin/commit/a6d57b67f6fbd0a9893ecf6436c54ecb670d5829 and the [wiki page](https://wiki.jenkins.io/display/JENKINS/Clang+Scan-Build+Plugin) plugin macro continues to reference the now obsolete artifact ID.