### PR TITLE
Stop distributing gcm-notification as the GCM service is dead

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -335,3 +335,6 @@ configuration-as-code-support-1.19
 
 # Failed release of Google Compute Engine Plugin 3.3.1
 google-compute-engine-3.3.1
+
+# Google Cloud Messaging service is no longer available
+gcm-notification


### PR DESCRIPTION
The Google Cloud Messaging (GCM) service no longer exists, so presumably the plugin no longer works, and hasn't been maintained in years anyway.