### PR TITLE
Add appcenter plugin and labels

### DIFF
--- a/src/main/resources/label-definitions.properties
+++ b/src/main/resources/label-definitions.properties
@@ -21,6 +21,7 @@ antisamy-markup-formatter=security
 anything-goes-formatter=ui
 ApicaLoadtest=builder
 appaloosa-plugin=upload ios android
+appcenter=upload android ios
 appdynamics-dashboard=external report
 appetize=upload ios android
 appio=post-build ios


### PR DESCRIPTION
I am the [AppCenter plugin](https://plugins.jenkins.io/appcenter) maintainer and would like to add the plugin as well as the following labels: `upload` `android` `ios`