### PR TITLE
Remove codescan - 

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -16,6 +16,7 @@ blitz.io-jenkins                 # renamed to blitz_io-jenkins
 build-node-column                # superseded by Extra Columns Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Build+Node+Column+Plugin
 buildcoin-plugin                 # service discontinued: https://github.com/github/github-services/pull/538 -- https://wiki.jenkins-ci.org/display/JENKINS/Buildcoin+Plugin
 buildheroes                      # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Buildheroes
+codescan                         # service discontinued -- see https://www.codescan.io for alternative ways of running
 caroline                         # service shut down -- https://wiki.jenkins-ci.org/display/JENKINS/Caroline+Plugin
 ChatRoom                         # junk plugin; developer has been banned
 cifs                             # Superseded by Publish Over CIFS Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/CIFS-Publisher+Plugin

--- a/src/main/resources/label-definitions.properties
+++ b/src/main/resources/label-definitions.properties
@@ -183,7 +183,6 @@ codecover=report
 codedeploy=upload
 codedx=report
 codefresh=builder external
-codescan=buildwrapper
 codescanner=report
 codesonar=notifier report post-build devops
 collabnet=external


### PR DESCRIPTION
the service has been shut down and replaced with an alternate system.

following instructions from here
https://jenkins.io/doc/developer/publishing/removing-from-distribution/

please indicate if additional steps required