### PR TITLE
Remove veracode-scanner

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -340,3 +340,5 @@ google-compute-engine-3.3.1
 simple-travis-runner
 gcm-notification # maintainer requested, seems the service doesn't exist anymore anyway
 xltestview-plugin # apparently the service no longer exists anyway
+
+veracode-scanner # not actively maintained (https://wiki.jenkins.io/display/JENKINS/Veracode+Scanner+Plugin), replaced by official Veracode plugin https://help.veracode.com/reader/PgbNZUD7j8aY7iG~hQZWxQ/yQtYXnlbLA6wsWodLn5zdw


### PR DESCRIPTION
Per the comment in the file, the veracode-scanner open source plugin is not actively maintained and will cease working later this month when Veracode updates its authentication method. Users should migrate to the supported Veracode Jenkins plugin available directly from [help.veracode.com](https://help.veracode.com/reader/PgbNZUD7j8aY7iG~hQZWxQ/yQtYXnlbLA6wsWodLn5zdw).