### PR TITLE
[INFRA-2292] Read Url from the plugin manifest before looking for pom.xml#/project/url

### DIFF
--- a/src/main/java/org/jvnet/hudson/update_center/Plugin.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Plugin.java
@@ -163,6 +163,11 @@ public class Plugin {
         // Check whether the wiki URL should be overridden
         String url = URL_OVERRIDES.getProperty(artifactId);
 
+        // Otherwise read *.hpi!/META-INF/MANIFEST.MF#Url, if defined
+        if (url == null) {
+            url = latest.getManifestAttributes().getValue("Url");
+        }
+
         // Otherwise read the wiki URL from the POM, if any
         if (url == null) {
             url = readSingleValueFromXmlFile(latest.resolvePOM(), "/project/url");


### PR DESCRIPTION
[INFRA-2292](https://issues.jenkins-ci.org/browse/INFRA-2292)

**Untested**. Do we need to just run CI on it and manually verify?

@oleg-nenashev 