### PR TITLE
Suspend durable-task 1.31 from distribution

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -355,3 +355,5 @@ puppet-enterprise-pipeline
 
 veracode-scanner # not actively maintained (https://wiki.jenkins.io/display/JENKINS/Veracode+Scanner+Plugin), replaced by official Veracode plugin https://help.veracode.com/reader/PgbNZUD7j8aY7iG~hQZWxQ/yQtYXnlbLA6wsWodLn5zdw
 
+# https://issues.jenkins-ci.org/browse/JENKINS-59903 and https://issues.jenkins-ci.org/browse/JENKINS-59907
+durable-task-1.31


### PR DESCRIPTION
Durable task 1.31 introduced a Go binary as an alternative to the existing shell wrapper for some platforms to try to solve some robustness issues with the existing wrapper. Unfortunately, the binary has some issue in various environments, and the detection logic for when the binary should be used instead of the shell wrapper needs to handle some additional cases. 

See [JENKINS-59903](https://issues.jenkins-ci.org/browse/JENKINS-59903) and [JENKINS-59907](https://issues.jenkins-ci.org/browse/JENKINS-59907). There is a system property to disable the new behavior, but we want to stop distributing the new version for now while we work on a fix.

CC @car-roll