### PR TITLE
Remove google-compute-engine-plugin 4.1.0 from distribution

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -357,3 +357,6 @@ veracode-scanner # not actively maintained (https://wiki.jenkins.io/display/JENK
 
 # https://issues.jenkins-ci.org/browse/JENKINS-59903 and https://issues.jenkins-ci.org/browse/JENKINS-59907
 durable-task-1.31
+
+# https://github.com/jenkinsci/google-compute-engine-plugin/issues/153 and https://github.com/jenkinsci/google-compute-engine-plugin/issues/155
+google-compute-engine-4.1.0


### PR DESCRIPTION
Incompatibilities in this version:
* awaitility dependency was changed to a test scope, but should not have been.
* jclouds referencing BaseEncoding.base64() which is not available to the version of guava that Jenkins uses.