### PR TITLE
Remove warnings for gitlab-oauth

### DIFF
--- a/src/main/resources/warnings.json
+++ b/src/main/resources/warnings.json
@@ -5447,7 +5447,7 @@
     "versions": [
       {
         "lastVersion": "1.4",
-        "pattern": ".*"
+        "pattern": "(1[.][0-4])(|[-.].*)"
       }
     ]
   },
@@ -5460,7 +5460,7 @@
     "versions": [
       {
         "lastVersion": "1.4",
-        "pattern": ".*"
+        "pattern": "(1[.][0-4])(|[-.].*)"
       }
     ]
   },


### PR DESCRIPTION
SECURITY-795 => https://github.com/jenkinsci/gitlab-oauth-plugin/pull/16
SECURITY-796 => https://github.com/jenkinsci/gitlab-oauth-plugin/pull/17

both included in the last release: https://github.com/jenkinsci/gitlab-oauth-plugin/releases/tag/gitlab-oauth-1.5

@daniel-beck 