### PR TITLE
Remove Chrome Frame plugin

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -19,6 +19,7 @@ buildheroes                      # service discontinued -- https://wiki.jenkins-
 codescan                         # service discontinued -- see https://www.codescan.io for alternative ways of running
 caroline                         # service shut down -- https://wiki.jenkins-ci.org/display/JENKINS/Caroline+Plugin
 ChatRoom                         # junk plugin; developer has been banned
+chrome-frame-plugin              # service discontinued https://www.chromium.org/developers/how-tos/chrome-frame-getting-started 
 cifs                             # Superseded by Publish Over CIFS Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/CIFS-Publisher+Plugin
 clang-scanbuild-plugin           # renamed to clang-scanbuild in https://github.com/jenkinsci/clang-scanbuild-plugin/commit/a6d57b67f6fbd0a9893ecf6436c54ecb670d5829
 cloudbees-deployer-plugin        # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Cloudbees+Deployer+Plugin


### PR DESCRIPTION
Chrome Frame was discontinued 5 years ago.

CC @jieryn 