### PR TITLE
Hide updates for HockeyApp

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -51,6 +51,7 @@ hall-jenkins                     # service discontinued -- https://wiki.jenkins-
 hello-world                      # people shouldn't actually *publish* the sample project!
 HiddenParameter                  # renamed to hidden-parameter
 hipchat-plugin                   # renamed to hipchat
+hockeyapp                        # service discontinued -- https://wiki.jenkins.io/display/JENKINS/HockeyApp+Plugin
 hudson-logaction-plugin          # renamed to logaction-plugin
 hudson-startup-trigger           # renamed to startup-trigger-plugin
 icon-shim-plugin                 # renamed to icon-shim


### PR DESCRIPTION
Service has been discontinued. https://www.hockeyapp.net/blog/2019/11/16/hockeyApp-is-being-retired.html

Users are advised to migrate to the Jenkins AppCenter plugin instead.