### PR TITLE
Remove warning for octopusdeploy

### DIFF
--- a/src/main/resources/warnings.json
+++ b/src/main/resources/warnings.json
@@ -4148,7 +4148,8 @@
     "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-957",
     "versions": [
       {
-        "pattern": ".*"
+        "lastVersion": "1.9.0",
+        "pattern": "1(|[-.].*)"
       }
     ]
   },


### PR DESCRIPTION
[SECURITY-957](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-957) was corrected in https://github.com/OctopusDeploy/octopus-jenkins-plugin/commit/c087af46b69f32ce8ceeb0bd7a0216f1cb5af577

✔️ Tested manually

@daniel-beck 
@hnrkndrssn (author of the correcting commit)
@tothegills (approver of the correcting commit + requester of this removal)

⚠️ Be careful, the code is not up-to-date between [jenkinsci](https://github.com/jenkinsci/octopusdeploy-plugin) fork and the [original repo](https://github.com/OctopusDeploy/octopus-jenkins-plugin)