### PR TITLE
Reintroduce versioning of the update center

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,6 @@
+# See https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
+_extends: jenkinsci/.github
+# Semantic versioning: https://semver.org/
+version-template: $MAJOR.$MINOR.$PATCH
+tag-template: v$NEXT_MINOR_VERSION
+name-template: v$NEXT_MINOR_VERSION


### PR DESCRIPTION
Update center does not longer require Maven releases since 2.0 by @daniel-beck . But it would be great to have some kind of versioning to have a history of changes and to highlight contributions.

My suggestion:

* We switch to Semver
* We start from a 3.0.0 version or 2.1.0 version
* We use a `v1.2.3` format recommended by GitHub

LKater we can switch to a GitOps mode for the repository to simplify management of the deployments

CC @halkeye @olblak for their opinions