### PR TITLE
Remove warnings for scriptler

### DIFF
--- a/src/main/resources/warnings.json
+++ b/src/main/resources/warnings.json
@@ -417,7 +417,8 @@
     "url": "https://jenkins.io/security/advisory/2017-04-10/",
     "versions": [
       {
-        "pattern": ".*"
+        "lastVersion": "2.9",
+        "pattern": "[12](|[.-].*)"
       }
     ]
   },
@@ -429,7 +430,8 @@
     "url": "https://jenkins.io/security/advisory/2017-04-10/",
     "versions": [
       {
-        "pattern": ".*"
+        "lastVersion": "2.9",
+        "pattern": "[12](|[.-].*)"
       }
     ]
   },
@@ -467,7 +469,8 @@
     "url": "https://jenkins.io/security/advisory/2017-04-10/",
     "versions": [
       {
-        "pattern": ".*"
+        "lastVersion": "2.9",
+        "pattern": "[12](|[.-].*)"
       }
     ]
   },
@@ -479,7 +482,8 @@
     "url": "https://jenkins.io/security/advisory/2017-04-10/",
     "versions": [
       {
-        "pattern": ".*"
+        "lastVersion": "2.9",
+        "pattern": "[12](|[.-].*)"
       }
     ]
   },
@@ -491,7 +495,8 @@
     "url": "https://jenkins.io/security/advisory/2017-04-10/",
     "versions": [
       {
-        "pattern": ".*"
+        "lastVersion": "2.9",
+        "pattern": "[12](|[.-].*)"
       }
     ]
   },


### PR DESCRIPTION
New release out of alpha: https://github.com/jenkinsci/scriptler-plugin/releases/tag/scriptler-3.1

The vulnerabilities were announced in https://jenkins.io/security/advisory/2017-04-10 but they are all corrected now:

✔️ JENKINS-21327 + JENKINS-21336 + SECURITY-367 => https://github.com/jenkinsci/scriptler-plugin/pull/32
✔️ SECURITY-333 => https://github.com/jenkinsci/scriptler-plugin/commit/7873bee3d03ee669d67738feefa347fbe003c5fc
✔️ SECURITY-334 => https://github.com/jenkinsci/scriptler-plugin/pull/34
✔️ SECURITY-365 + SECURITY-366 + SECURITY-678 => https://github.com/jenkinsci/scriptler-plugin/commit/0db5380fe2aea39657f96e27a5ccca79e706e716
✔️ SECURITY-691 => https://github.com/jenkinsci/scriptler-plugin/commit/57567d8944dd255adfdd1d0cd45d85eecc8432e5

@daniel-beck 
@imod 