### PR TITLE
Update artifact-ignores.properties

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -166,6 +166,7 @@ hp-application-automation-tools-plugin-5.6  	 # JENKINS-55159 - Dependency issue
 google-compute-engine-3.1.0                      # Github issue #85 - Regression
 build-name-setter-plugin-2.0.0           # breaks builds when using with build-user-vars-plugin https://github.com/jenkinsci/build-name-setter-plugin/issues/39
 hp-application-automation-tools-plugin-6.0.1-beta  	 # unexpected release version - latest release is 5.9
+ibm-application-security-1.2.7    # Bug that breaks existing jobs from previous versions
 
 # rogue releases with unknown source
 ez-templates-1.0.0


### PR DESCRIPTION
Version 1.2.7 of the ibm-application-security plugin contains a bug that breaks existing jobs that were configured with previous versions of the plugin.  We want to disable this version until we're able to fix the bug and publish a new version.