### PR TITLE
Expose `issueTracker`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ www
 .htaccess
 .idea
 output
+githubCache/

--- a/pom.xml
+++ b/pom.xml
@@ -218,6 +218,11 @@
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>2.2</version>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/main/java/org/jvnet/hudson/update_center/Plugin.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Plugin.java
@@ -90,7 +90,7 @@ public class Plugin {
 
     static {
         JIRA_ISSUE_TRACKER = new JSONObject();
-        JIRA_ISSUE_TRACKER.put("name", "Jenkins JIRA");
+        JIRA_ISSUE_TRACKER.put("name", "Jenkins Jira");
         JIRA_ISSUE_TRACKER.put("url", "https://issues.jenkins-ci.org/");
     }
 
@@ -380,7 +380,7 @@ public class Plugin {
                 System.out.println("Failed to check if issues are enabled: " + e.getMessage());
             }
         } else {
-            System.out.println("SCM url is empty, defaulting to Jenkins JIRA for issue tracking");
+            System.out.println("SCM url is empty, defaulting to Jenkins Jira for issue tracking");
         }
 
         return JIRA_ISSUE_TRACKER;

--- a/src/main/java/org/jvnet/hudson/update_center/util/UrlToGitHubSlugConverter.java
+++ b/src/main/java/org/jvnet/hudson/update_center/util/UrlToGitHubSlugConverter.java
@@ -1,0 +1,30 @@
+package org.jvnet.hudson.update_center.util;
+
+import javax.annotation.Nonnull;
+import org.apache.commons.lang3.StringUtils;
+
+public final class UrlToGitHubSlugConverter {
+
+    private UrlToGitHubSlugConverter() {
+    }
+
+    /**
+     * Converts a github url to its 'slug'
+     * @param url a url like: https://github.com/jenkinsci/blueocean-plugin
+     * @return the github slug, jenkinsci/blueocean-plugin
+     */
+    public static String convert(@Nonnull String url) {
+        if (StringUtils.isBlank(url)) {
+            throw new IllegalArgumentException("URL must be present");
+        }
+
+        if (!url.contains("github.com")) {
+            throw new IllegalArgumentException("Invalid url: " + url);
+        }
+
+        String slug = StringUtils.remove(url, "https://github.com/");
+        String slugWithNoGit = StringUtils.remove(slug, ".git");
+
+        return StringUtils.stripEnd(slugWithNoGit, "/");
+    }
+}

--- a/src/test/java/org/jvnet/hudson/update_center/util/UrlToGitHubSlugConverterTest.java
+++ b/src/test/java/org/jvnet/hudson/update_center/util/UrlToGitHubSlugConverterTest.java
@@ -1,0 +1,80 @@
+package org.jvnet.hudson.update_center.util;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class UrlToGitHubSlugConverterTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void convert_simple_url_passes() {
+        String given = "https://github.com/jenkinsci/blueocean-plugin";
+
+        String then = UrlToGitHubSlugConverter.convert(given);
+
+        assertThat(then, is("jenkinsci/blueocean-plugin"));
+    }
+
+    @Test
+    public void convert_url_with_slash_suffix_passes() {
+        String given = "https://github.com/jenkinsci/blueocean-plugin/";
+
+        String then = UrlToGitHubSlugConverter.convert(given);
+
+        assertThat(then, is("jenkinsci/blueocean-plugin"));
+    }
+
+    @Test
+    public void convert_with_git_suffix_passes() {
+        String given = "https://github.com/jenkinsci/blueocean-plugin.git";
+
+        String then = UrlToGitHubSlugConverter.convert(given);
+
+        assertThat(then, is("jenkinsci/blueocean-plugin"));
+    }
+
+    @Test
+    public void convert_with_non_jenkinsci_org_passes() {
+        String given = "https://github.com/jenkins-infra/some-repo.git";
+
+        String then = UrlToGitHubSlugConverter.convert(given);
+
+        assertThat(then, is("jenkins-infra/some-repo"));
+    }
+
+    @Test
+    public void convert_with_non_github_url_throws_expected_exception() {
+        String given = "https://issues.jenkins-ci.org";
+
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Invalid url: " + given);
+
+        String then = UrlToGitHubSlugConverter.convert(given);
+    }
+
+    @Test
+    public void convert_with_null_throws_expected_exception() {
+        String given = "";
+
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("URL must be present");
+
+        String then = UrlToGitHubSlugConverter.convert(given);
+    }
+
+    @Test
+    public void convert_with_empty_throws_expected_exception() {
+        String given = null;
+
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("URL must be present");
+
+        String then = UrlToGitHubSlugConverter.convert(given);
+    }
+}


### PR DESCRIPTION
Ref:
https://groups.google.com/d/msg/jenkinsci-dev/haFTYlhp7h8/hkApal9WAgAJ

Uses the github api to check if GitHub issues are enabled, else sets
Jenkins JIRA, if there's any error it will fallback to Jenkins JIRA as
well.

Samples:

```
      "issueTracker": {
        "name": "Jenkins Jira",
        "url": "https://issues.jenkins-ci.org/"
      },
```
```
      "issueTracker": {
        "name": "GitHub Issues",
        "url": "https://github.com/jenkinsci/configuration-as-code-plugin/issues"
      },
```

For testing I patched:
`TruncatedMavenRepository` locally in `listHudsonPlugins`
with:
```java
        PluginHistory pluginHistory = base.listHudsonPlugins()
                .stream()
                .filter(plugin -> StringUtils.equals(plugin.artifactId, "configuration-as-code"))
                .findAny()
                .orElseThrow(IllegalArgumentException::new);

        return Collections.singletonList(pluginHistory);
```
and for jira:
```java
                .filter(plugin -> StringUtils.equals(plugin.artifactId, "mailer"))
```

Ran with:

```shell
mvn package appassembler:assemble -DskipTests
sh target/appassembler/bin/app -id com.example.jenkins -www www -maxPlugins 1
```