### PR TITLE
[SECURITY-1177] Limit affected versions

### DIFF
--- a/src/main/resources/warnings.json
+++ b/src/main/resources/warnings.json
@@ -5058,7 +5058,7 @@
     "url": "https://jenkins.io/security/advisory/2019-07-11/#SECURITY-1177",
     "versions": [
       {
-        "lastVersion": "0.14",
+        "lastVersion": "0.13",
         "pattern": "0[.]([1-9]|1[0-3])(|[.-].*)"
       }
     ]

--- a/src/main/resources/warnings.json
+++ b/src/main/resources/warnings.json
@@ -5058,8 +5058,8 @@
     "url": "https://jenkins.io/security/advisory/2019-07-11/#SECURITY-1177",
     "versions": [
       {
-        "lastVersion": "0.13",
-        "pattern": ".*"
+        "lastVersion": "0.14",
+        "pattern": "0[.]([1-9]|1[0-3])(|[.-].*)"
       }
     ]
   },


### PR DESCRIPTION
Limit security warning to [0.1,0.13.*], 0.14 released with fix:
https://github.com/jenkinsci/depgraph-view-plugin/pull/18

Advisory: 
https://jenkins.io/security/advisory/2019-07-11/#SECURITY-1177