### PR TITLE
Remove groovy-events-listener-plugin-master

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -50,6 +50,7 @@ girls                            # no... just... no -- https://wiki.jenkins-ci.o
 gitorious                        # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Gitorious+Plugin
 google-desktop-gadget            # Google Desktop has been discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Hudson+Google+Desktop+Gadget
 googlecode                       # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Google+Code+Plugin
+groovy-events-listener-plugin-master # unintentional fork of groovy-events-listener-plugin
 hall-jenkins                     # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Hall+Plugin
 hello-world                      # people shouldn't actually *publish* the sample project!
 HiddenParameter                  # renamed to hidden-parameter


### PR DESCRIPTION
It seems a copy of this plugin was released with a wrong artifact ID because Gradle infers project name from folder unless specified (hopefully fixed in https://github.com/jenkinsci/groovy-events-listener-plugin/pull/59/commits/f7f58b5cf56446c9ae1aa79370909ccb68c5cbd4 )

CC @markyjackson-taulia