### PR TITLE
[JENKINS-59136] Deprecation support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -30,6 +30,7 @@ The generator pulls information from:
 * link:resources/[Local resource files in this repository]
   - GitHub topic whitelist (`resources/allowed-github-topics.properties`)
   - Artifact ignore list (`resources/artifact-ignores.properties`)
+  - Deprecations (`resources/deprecations.properties`)
   - Label assignments (`resources/label-definitions.properties`)
   - Security warnings (`resources/warnings.json`)
   - Plugin URL overrides (`resources/wiki-overrides.properties`)
@@ -58,7 +59,7 @@ To add the label `matrix` for your plugin, you would add either `matrix` or `jen
 
 ==== Resource File
 
-As an alternative to the above, plugin labels can be defined in the file https://github.com/jenkins-infra/update-center2/edit/master/src/main/resources/label-definitions.properties[`label-definitions.properties`] in this repository.
+As an alternative to the above, plugin labels can be defined in the file https://github.com/jenkins-infra/update-center2/edit/master/src/main/resources/label-definitions.properties[`resources/label-definitions.properties`] in this repository.
 
 This is the preferable approach when a plugin isn't in the `jenkinsci` GitHub organization, or a GitHub repository contains multiple plugins whose labels should be different.
 
@@ -74,6 +75,29 @@ This requirement no longer exists, but it may still be useful to define a docume
 The file `resources/wiki-overrides.properties` defines these wiki page overrides.
 
 
+=== Deprecations
+
+// TODO Once https://github.com/jenkinsci/jenkins/pull/4073 is merged, specify which version is the first one.
+Plugins are considered _deprecated_ by Jenkins when either the update site metadata does one or both of the following:
+
+* Uses the label `deprecated` for the plugin.
+  This can be done via GitHub repository topics, or the `resources/label-definitions.properties` described above.
+  Jenkins will use the plugin URL as the reference URL for the deprecation notice.
+* Lists an entry with the plugin ID as key in the top-level `deprecations` map in `update-center.json`.
+  This can be done through entries in the https://github.com/jenkins-infra/update-center2/edit/master/src/main/resources/deprecations.properties[`resources/deprecations.properties`] file.
+  The value from the properties file will be used as the URL for the deprecation notice in Jenkins.
+  This entry and URL take precedence over a `deprecated` label, i.e. when both are set, the URL from the top-level element shall be used.
+
+These two different approaches to plugin deprecation accomplish complementary goals:
+
+* The label approach is very simple and can easily be done by plugin maintainers themselves via GitHub labels.
+  It is also backward compatible with any earlier version of Jenkins -- it will just show the deprecation as a regular label.
+  Additionally, it doesn't bloat the JSON file size at all, since no special URL is needed.
+* The top-level `deprecations` element allows specifying a URL different from the plugin documentation URL as well as deprecating plugins no longer being distributed.
+  Especially the latter is a common requirement when plugins integrate with services that no longer exist:
+  It makes no sense to continue distributing them, but everyone having them already installed should be informed about it.
+
+
 === Removing plugins from distribution
 
 The update center generator allows to specify that certain plugins, or plugin releases, should not be included in the output.
@@ -85,6 +109,8 @@ There are various reasons to need to do this, such as:
 
 Both use cases (entire plugins, or specific versions) are controlled via the file `resources/artifact-ignores.properties`.
 See that file for usage examples.
+
+Such plugins typically should get a corresponding deprecation entry in `resources/deprecations.properties`.
 
 
 === Security warnings

--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -3,73 +3,134 @@
 # This file allows marking plugins as deprecated while not publishing them otherwise.
 # Additionally, this file allows referencing deprecation notices outside of (obsolete or non-existing) plugin documentation.
 
-appthwack = https://wiki.jenkins.io/display/JENKINS/AppThwack+Plugin
+# https://wiki.jenkins.io/display/JENKINS/AppThwack+Plugin
+appthwack = https://wiki.jenkins.io/x/cwchB
 assembla-oauth = https://groups.google.com/d/msg/jenkinsci-dev/TVz-D5etsUM/Knx9zXtEnSwJ
-blackduck-hub = https://github.com/jenkins-infra/update-center2/pull/261
-blackduck-installer = https://wiki.jenkins-ci.org/display/JENKINS/Black+Duck+Vulnerability+Installer+Plugin
+# https://github.com/jenkins-infra/update-center2/pull/261
+blackduck-hub = https://git.io/JfaQa
+# https://wiki.jenkins-ci.org/display/JENKINS/Black+Duck+Vulnerability+Installer+Plugin
+blackduck-installer = https://wiki.jenkins.io/x/nYHHB
 build-flow-extensions-plugin = https://groups.google.com/d/msg/jenkinsci-dev/YKfydxnpvyE/mMN7LNBoBgAJ
 build-flow-test-aggregator = https://groups.google.com/d/msg/jenkinsci-dev/YKfydxnpvyE/mMN7LNBoBgAJ
 build-flow-toolbox-plugin = https://groups.google.com/d/msg/jenkinsci-dev/YKfydxnpvyE/mMN7LNBoBgAJ
-build-node-column = https://wiki.jenkins-ci.org/display/JENKINS/Build+Node+Column+Plugin
-buildcoin-plugin = https://wiki.jenkins-ci.org/display/JENKINS/Buildcoin+Plugin
-buildheroes = https://wiki.jenkins-ci.org/display/JENKINS/Buildheroes
-caroline = https://wiki.jenkins-ci.org/display/JENKINS/Caroline+Plugin
+# https://wiki.jenkins-ci.org/display/JENKINS/Build+Node+Column+Plugin
+build-node-column = https://wiki.jenkins.io/x/1QiMAw
+# https://wiki.jenkins-ci.org/display/JENKINS/Buildcoin+Plugin
+buildcoin-plugin = https://wiki.jenkins.io/x/KoyhAw
+# https://wiki.jenkins-ci.org/display/JENKINS/Buildheroes
+buildheroes = https://wiki.jenkins.io/x/_AD8Aw
+# https://wiki.jenkins-ci.org/display/JENKINS/Caroline+Plugin
+caroline = https://wiki.jenkins.io/x/AwOMAw
 chrome-frame-plugin = https://www.chromium.org/developers/how-tos/chrome-frame-getting-started
-cifs = https://wiki.jenkins-ci.org/display/JENKINS/CIFS-Publisher+Plugin
-clang-scanbuild-plugin = https://github.com/jenkinsci/clang-scanbuild-plugin/commit/a6d57b67f6fbd0a9893ecf6436c54ecb670d5829
-cloudbees-deployer-plugin = https://wiki.jenkins-ci.org/display/JENKINS/Cloudbees+Deployer+Plugin
-cloudbees-disk-usage-simple-plugin = https://github.com/jenkins-infra/update-center2/pull/179
-cloudbees-enterprise-plugins = https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Jenkins+Enterprise
-cloudbees-registration = https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Registration+Plugin
-codescan = https://github.com/jenkins-infra/update-center2/pull/299
-copyarchiver = https://wiki.jenkins-ci.org/display/JENKINS/CopyArchiver+Plugin
-cppunit = https://wiki.jenkins-ci.org/display/JENKINS/CppUnit+Plugin
-dockerhub = https://github.com/jenkins-infra/update-center2/commit/e5a138873113d0e2d6af59d5699215a1835c15b7
-emotional-hudson = https://wiki.jenkins-ci.org/display/JENKINS/Emotional+Hudson+Plugin
-external-scheduler = https://github.com/jenkins-infra/update-center2/pull/257
+# https://wiki.jenkins-ci.org/display/JENKINS/CIFS-Publisher+Plugin
+cifs = https://wiki.jenkins.io/x/lwC2Ag
+# https://github.com/jenkinsci/clang-scanbuild-plugin/commit/a6d57b67f6fbd0a9893ecf6436c54ecb670d5829
+clang-scanbuild-plugin = https://git.io/JfaQr
+# https://wiki.jenkins-ci.org/display/JENKINS/Cloudbees+Deployer+Plugin
+cloudbees-deployer-plugin = https://wiki.jenkins.io/x/24RoAw
+# https://github.com/jenkins-infra/update-center2/pull/179
+cloudbees-disk-usage-simple-plugin = https://git.io/JfaQN
+# https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Jenkins+Enterprise
+cloudbees-enterprise-plugins = https://wiki.jenkins.io/x/3gX8Aw
+# https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Registration+Plugin
+cloudbees-registration = https://wiki.jenkins.io/x/z4FLB
+# https://github.com/jenkins-infra/update-center2/pull/299
+codescan = https://git.io/JfaQb
+# https://wiki.jenkins-ci.org/display/JENKINS/CopyArchiver+Plugin
+copyarchiver = https://wiki.jenkins.io/x/ywJAAg
+# https://wiki.jenkins-ci.org/display/JENKINS/CppUnit+Plugin
+cppunit = https://wiki.jenkins.io/x/6oE5Ag
+# https://github.com/jenkins-infra/update-center2/commit/e5a138873113d0e2d6af59d5699215a1835c15b7
+dockerhub = https://git.io/JfaQF
+# https://wiki.jenkins-ci.org/display/JENKINS/Emotional+Hudson+Plugin
+emotional-hudson = https://wiki.jenkins.io/x/C4DX
+# https://github.com/jenkins-infra/update-center2/pull/257
+external-scheduler = https://git.io/JfaQ5
 externalresource-dispatcher = https://groups.google.com/d/msg/jenkinsci-dev/YKfydxnpvyE/mMN7LNBoBgAJ
-gerrit = https://wiki.jenkins-ci.org/display/JENKINS/Gerrit+Plugin
-girls = https://wiki.jenkins-ci.org/display/JENKINS/Girls+Plugin
-gitorious = https://wiki.jenkins-ci.org/display/JENKINS/Gitorious+Plugin
-google-desktop-gadget = https://wiki.jenkins-ci.org/display/JENKINS/Hudson+Google+Desktop+Gadget
-googlecode = https://wiki.jenkins-ci.org/display/JENKINS/Google+Code+Plugin
-hall-jenkins = https://wiki.jenkins-ci.org/display/JENKINS/Hall+Plugin
-hockeyapp = https://wiki.jenkins.io/display/JENKINS/HockeyApp+Plugin
-ion-deployer-plugin = https://wiki.jenkins-ci.org/display/JENKINS/iON+Deployer+Plugin
-javanet = https://wiki.jenkins-ci.org/display/JENKINS/Java.net+Plugin
-javanet-uploader = https://wiki.jenkins-ci.org/display/JENKINS/java.net+uploader+Plugin
+# https://wiki.jenkins-ci.org/display/JENKINS/Gerrit+Plugin
+gerrit = https://wiki.jenkins.io/x/9ICVAg
+# https://wiki.jenkins-ci.org/display/JENKINS/Girls+Plugin
+girls = https://wiki.jenkins.io/x/OAWbAg
+# https://wiki.jenkins-ci.org/display/JENKINS/Gitorious+Plugin
+gitorious = https://wiki.jenkins.io/x/ngDiAw
+# https://wiki.jenkins-ci.org/display/JENKINS/Hudson+Google+Desktop+Gadget
+google-desktop-gadget = https://wiki.jenkins.io/x/E4A3AQ
+# https://wiki.jenkins-ci.org/display/JENKINS/Google+Code+Plugin
+googlecode = https://wiki.jenkins.io/x/DQC7
+# https://wiki.jenkins-ci.org/display/JENKINS/Hall+Plugin
+hall-jenkins = https://wiki.jenkins.io/x/qQghB
+# https://wiki.jenkins.io/display/JENKINS/HockeyApp+Plugin
+hockeyapp = https://wiki.jenkins.io/x/7oPPAw
+# https://wiki.jenkins-ci.org/display/JENKINS/iON+Deployer+Plugin
+ion-deployer-plugin = https://wiki.jenkins.io/x/FhOMAw
+# https://wiki.jenkins-ci.org/display/JENKINS/Java.net+Plugin
+javanet = https://wiki.jenkins.io/x/AgDL
+# https://wiki.jenkins-ci.org/display/JENKINS/java.net+uploader+Plugin
+javanet-uploader = https://wiki.jenkins.io/x/ZoAL
 jenkins-tracker = https://issues.jenkins-ci.org/browse/INFRA-1531
-jenkow-activiti-designer = https://wiki.jenkins-ci.org/display/JENKINS/Jenkow+Activiti+Designer
-jenkow-activiti-explorer = https://wiki.jenkins-ci.org/display/JENKINS/Jenkow+Activiti+Explorer
-jenkow-plugin = https://wiki.jenkins-ci.org/display/JENKINS/Jenkow+Plugin
-kanboard-publisher = https://github.com/jenkins-infra/update-center2/pull/94
-m2-extra-steps = https://wiki.jenkins-ci.org/display/JENKINS/M2+Extra+Steps+Plugin
-mansion-cloud = https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Cloud+Connector+Plugin
-mcap-eas-plugin = https://github.com/mwaylabs/jenkins-mcap-eas-plugin#jenkins-mcap-eas-plugin
-mypeople = https://wiki.jenkins-ci.org/display/JENKINS/MyPeople+Plugin
-nabaztag = https://wiki.jenkins-ci.org/display/JENKINS/Nabaztag+Plugin
-netio-plugin = https://wiki.jenkins-ci.org/display/JENKINS/Netio-Plugin
-nodeofflinenotification = https://wiki.jenkins-ci.org/display/JENKINS/Node+Offline+Notification+Plugin
-notifo = https://wiki.jenkins-ci.org/display/JENKINS/Notifo+Plugin
-origo-issue-notifier = https://wiki.jenkins-ci.org/display/JENKINS/Origo+Issue+Notifier
-paranoia = https://github.com/jenkins-infra/update-center2/pull/291
-pipeline-editor = https://github.com/jenkinsci/pipeline-editor-plugin
-poll-mailbox-trigger = https://github.com/jenkins-infra/update-center2/pull/42
-pretest-commit = https://wiki.jenkins-ci.org/display/JENKINS/Pretest+Commit+Plugin
-PUCM = https://wiki.jenkins-ci.org/display/JENKINS/pucm+plugin
-rtc = https://github.com/jenkins-infra/update-center2/pull/13
-schedule-failed-builds = https://wiki.jenkins-ci.org/display/JENKINS/Retry+Failed+Builds+Plugin
-scis-ad = https://github.com/jenkins-infra/update-center2/commit/5f3f5ae66ea0e819c27d6d1fed9fdb00781f636c
+# https://wiki.jenkins-ci.org/display/JENKINS/Jenkow+Activiti+Designer
+jenkow-activiti-designer = https://wiki.jenkins.io/x/ngnqAw
+# https://wiki.jenkins-ci.org/display/JENKINS/Jenkow+Activiti+Explorer
+jenkow-activiti-explorer = https://wiki.jenkins.io/x/yQH8Aw
+# https://wiki.jenkins-ci.org/display/JENKINS/Jenkow+Plugin
+jenkow-plugin = https://wiki.jenkins.io/x/WIuhAw
+# https://github.com/jenkins-infra/update-center2/pull/94
+kanboard-publisher = https://git.io/JfaQH
+# https://wiki.jenkins-ci.org/display/JENKINS/M2+Extra+Steps+Plugin
+m2-extra-steps = https://wiki.jenkins.io/x/FIc5Ag
+# https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Cloud+Connector+Plugin
+mansion-cloud = https://wiki.jenkins.io/x/YwdRB
+# https://github.com/mwaylabs/jenkins-mcap-eas-plugin#jenkins-mcap-eas-plugin
+mcap-eas-plugin = https://git.io/JfaQ9
+# https://wiki.jenkins-ci.org/display/JENKINS/MyPeople+Plugin
+mypeople = https://wiki.jenkins.io/x/xQRCB
+# https://wiki.jenkins-ci.org/display/JENKINS/Nabaztag+Plugin
+nabaztag = https://wiki.jenkins.io/x/dIEuAg
+# https://wiki.jenkins-ci.org/display/JENKINS/Netio-Plugin
+netio-plugin = https://wiki.jenkins.io/x/7gMHB
+# https://wiki.jenkins-ci.org/display/JENKINS/Node+Offline+Notification+Plugin
+nodeofflinenotification = https://wiki.jenkins.io/x/0IKhAw
+# https://wiki.jenkins-ci.org/display/JENKINS/Notifo+Plugin
+notifo = https://wiki.jenkins.io/x/0ADDAg
+# https://wiki.jenkins-ci.org/display/JENKINS/Origo+Issue+Notifier
+origo-issue-notifier = https://wiki.jenkins.io/x/qgabAg
+# https://github.com/jenkins-infra/update-center2/pull/291
+paranoia = https://git.io/JfaQS
+# https://github.com/jenkinsci/pipeline-editor-plugin
+pipeline-editor = https://git.io/JfaQy
+# https://github.com/jenkins-infra/update-center2/pull/42
+poll-mailbox-trigger = https://git.io/JfaQM
+# https://wiki.jenkins-ci.org/display/JENKINS/Pretest+Commit+Plugin
+pretest-commit = https://wiki.jenkins.io/x/5gB-B
+# https://wiki.jenkins-ci.org/display/JENKINS/pucm+plugin
+PUCM = https://wiki.jenkins.io/x/fIBVAw
+# https://github.com/jenkins-infra/update-center2/pull/13
+rtc = https://git.io/JfaQ1
+# https://wiki.jenkins-ci.org/display/JENKINS/Retry+Failed+Builds+Plugin
+schedule-failed-builds = https://wiki.jenkins.io/x/roM5Ag
+# https://github.com/jenkins-infra/update-center2/commit/5f3f5ae66ea0e819c27d6d1fed9fdb00781f636c
+scis-ad = https://git.io/JfaQX
 scm-branch-pr-filter = https://issues.jenkins-ci.org/browse/INFRA-1358
-SCTMExecutor = https://github.com/jenkins-infra/update-center2/pull/324
-secret = https://wiki.jenkins-ci.org/display/JENKINS/Build+Secret+Plugin
-setenv = https://wiki.jenkins-ci.org/display/JENKINS/Setenv+Plugin
-sonatype-ci = https://wiki.jenkins.io/pages/viewpage.action?pageId=63930505
-tepco = https://wiki.jenkins-ci.org/display/JENKINS/TEPCO+Plugin
-tepco-epuw = https://wiki.jenkins-ci.org/display/JENKINS/TEPCO+Electric+Power+Usage+Widget
-testflight = https://wiki.jenkins-ci.org/display/JENKINS/Testflight+Plugin
-url-change-trigger = https://wiki.jenkins-ci.org/display/JENKINS/URL+Change+Trigger
-veracode-scanner = https://github.com/jenkins-infra/update-center2/pull/302
+# https://github.com/jenkins-infra/update-center2/pull/324
+SCTMExecutor = https://git.io/JfaQP
+# https://wiki.jenkins-ci.org/display/JENKINS/Build+Secret+Plugin
+secret = https://wiki.jenkins.io/x/9ghSAg
+# https://wiki.jenkins-ci.org/display/JENKINS/Setenv+Plugin
+setenv = https://wiki.jenkins.io/x/YAtSAg
+# https://wiki.jenkins.io/pages/viewpage.action?pageId=63930505
+sonatype-ci = https://wiki.jenkins.io/x/iYDPAw
+# https://wiki.jenkins-ci.org/display/JENKINS/TEPCO+Plugin
+tepco = https://wiki.jenkins.io/x/zoBoAw
+# https://wiki.jenkins-ci.org/display/JENKINS/TEPCO+Electric+Power+Usage+Widget
+tepco-epuw = https://wiki.jenkins.io/x/vohoAw
+# https://wiki.jenkins-ci.org/display/JENKINS/Testflight+Plugin
+testflight = https://wiki.jenkins.io/x/pwZ1Aw
+# https://wiki.jenkins-ci.org/display/JENKINS/URL+Change+Trigger
+url-change-trigger = https://wiki.jenkins.io/x/BQBJ
+# https://github.com/jenkins-infra/update-center2/pull/302
+veracode-scanner = https://git.io/JfaQ6
 vessel = https://groups.google.com/d/msg/jenkinsci-dev/L34eAMMWA5o/-AxtRdGsAAAJ
-xltest-plugin = https://github.com/jenkinsci/xltestview-plugin/commit/ea034f9929b520e63b9ce15aed9bdb62354146cf
-zaproxy = https://wiki.jenkins-ci.org/display/JENKINS/ZAProxy+Plugin
+# https://github.com/jenkinsci/xltestview-plugin/commit/ea034f9929b520e63b9ce15aed9bdb62354146cf
+xltest-plugin = https://git.io/JfaQK
+# https://wiki.jenkins-ci.org/display/JENKINS/ZAProxy+Plugin
+zaproxy = https://wiki.jenkins.io/x/JgCsB

--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -1,0 +1,4 @@
+# This file contains deprecated plugins (keys) and the URL the deprecation notice should link to (value).
+# While plugins can be deprecated through labels, that requires that the plugins continue being published.
+# This file allows marking plugins as deprecated while not publishing them otherwise.
+i-am-an-invalid-plugin-id=https://github.com/jenkins-infra/update-center2

--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -8,93 +8,93 @@ appthwack = https://wiki.jenkins.io/x/cwchB
 assembla-oauth = https://groups.google.com/d/msg/jenkinsci-dev/TVz-D5etsUM/Knx9zXtEnSwJ
 # https://github.com/jenkins-infra/update-center2/pull/261
 blackduck-hub = https://git.io/JfaQa
-# https://wiki.jenkins-ci.org/display/JENKINS/Black+Duck+Vulnerability+Installer+Plugin
+# https://wiki.jenkins.io/display/JENKINS/Black+Duck+Vulnerability+Installer+Plugin
 blackduck-installer = https://wiki.jenkins.io/x/nYHHB
 build-flow-extensions-plugin = https://groups.google.com/d/msg/jenkinsci-dev/YKfydxnpvyE/mMN7LNBoBgAJ
 build-flow-test-aggregator = https://groups.google.com/d/msg/jenkinsci-dev/YKfydxnpvyE/mMN7LNBoBgAJ
 build-flow-toolbox-plugin = https://groups.google.com/d/msg/jenkinsci-dev/YKfydxnpvyE/mMN7LNBoBgAJ
-# https://wiki.jenkins-ci.org/display/JENKINS/Build+Node+Column+Plugin
+# https://wiki.jenkins.io/display/JENKINS/Build+Node+Column+Plugin
 build-node-column = https://wiki.jenkins.io/x/1QiMAw
-# https://wiki.jenkins-ci.org/display/JENKINS/Buildcoin+Plugin
+# https://wiki.jenkins.io/display/JENKINS/Buildcoin+Plugin
 buildcoin-plugin = https://wiki.jenkins.io/x/KoyhAw
-# https://wiki.jenkins-ci.org/display/JENKINS/Buildheroes
+# https://wiki.jenkins.io/display/JENKINS/Buildheroes
 buildheroes = https://wiki.jenkins.io/x/_AD8Aw
-# https://wiki.jenkins-ci.org/display/JENKINS/Caroline+Plugin
+# https://wiki.jenkins.io/display/JENKINS/Caroline+Plugin
 caroline = https://wiki.jenkins.io/x/AwOMAw
 chrome-frame-plugin = https://www.chromium.org/developers/how-tos/chrome-frame-getting-started
-# https://wiki.jenkins-ci.org/display/JENKINS/CIFS-Publisher+Plugin
+# https://wiki.jenkins.io/display/JENKINS/CIFS-Publisher+Plugin
 cifs = https://wiki.jenkins.io/x/lwC2Ag
 # https://github.com/jenkinsci/clang-scanbuild-plugin/commit/a6d57b67f6fbd0a9893ecf6436c54ecb670d5829
 clang-scanbuild-plugin = https://git.io/JfaQr
-# https://wiki.jenkins-ci.org/display/JENKINS/Cloudbees+Deployer+Plugin
+# https://wiki.jenkins.io/display/JENKINS/Cloudbees+Deployer+Plugin
 cloudbees-deployer-plugin = https://wiki.jenkins.io/x/24RoAw
 # https://github.com/jenkins-infra/update-center2/pull/179
 cloudbees-disk-usage-simple-plugin = https://git.io/JfaQN
-# https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Jenkins+Enterprise
+# https://wiki.jenkins.io/display/JENKINS/CloudBees+Jenkins+Enterprise
 cloudbees-enterprise-plugins = https://wiki.jenkins.io/x/3gX8Aw
-# https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Registration+Plugin
+# https://wiki.jenkins.io/display/JENKINS/CloudBees+Registration+Plugin
 cloudbees-registration = https://wiki.jenkins.io/x/z4FLB
 # https://github.com/jenkins-infra/update-center2/pull/299
 codescan = https://git.io/JfaQb
 # https://github.com/jenkinsci/configuration-as-code-plugin/releases/tag/configuration-as-code-1.18
 configuration-as-code-support = https://git.io/JfaHz
-# https://wiki.jenkins-ci.org/display/JENKINS/CopyArchiver+Plugin
+# https://wiki.jenkins.io/display/JENKINS/CopyArchiver+Plugin
 copyarchiver = https://wiki.jenkins.io/x/ywJAAg
-# https://wiki.jenkins-ci.org/display/JENKINS/CppUnit+Plugin
+# https://wiki.jenkins.io/display/JENKINS/CppUnit+Plugin
 cppunit = https://wiki.jenkins.io/x/6oE5Ag
 # https://github.com/jenkins-infra/update-center2/commit/e5a138873113d0e2d6af59d5699215a1835c15b7
 dockerhub = https://git.io/JfaQF
-# https://wiki.jenkins-ci.org/display/JENKINS/Emotional+Hudson+Plugin
+# https://wiki.jenkins.io/display/JENKINS/Emotional+Hudson+Plugin
 emotional-hudson = https://wiki.jenkins.io/x/C4DX
 # https://github.com/jenkins-infra/update-center2/pull/257
 external-scheduler = https://git.io/JfaQ5
 externalresource-dispatcher = https://groups.google.com/d/msg/jenkinsci-dev/YKfydxnpvyE/mMN7LNBoBgAJ
-# https://wiki.jenkins-ci.org/display/JENKINS/Gerrit+Plugin
+# https://wiki.jenkins.io/display/JENKINS/Gerrit+Plugin
 gerrit = https://wiki.jenkins.io/x/9ICVAg
-# https://wiki.jenkins-ci.org/display/JENKINS/Girls+Plugin
+# https://wiki.jenkins.io/display/JENKINS/Girls+Plugin
 girls = https://wiki.jenkins.io/x/OAWbAg
-# https://wiki.jenkins-ci.org/display/JENKINS/Gitorious+Plugin
+# https://wiki.jenkins.io/display/JENKINS/Gitorious+Plugin
 gitorious = https://wiki.jenkins.io/x/ngDiAw
-# https://wiki.jenkins-ci.org/display/JENKINS/Hudson+Google+Desktop+Gadget
+# https://wiki.jenkins.io/display/JENKINS/Hudson+Google+Desktop+Gadget
 google-desktop-gadget = https://wiki.jenkins.io/x/E4A3AQ
-# https://wiki.jenkins-ci.org/display/JENKINS/Google+Code+Plugin
+# https://wiki.jenkins.io/display/JENKINS/Google+Code+Plugin
 googlecode = https://wiki.jenkins.io/x/DQC7
-# https://wiki.jenkins-ci.org/display/JENKINS/Hall+Plugin
+# https://wiki.jenkins.io/display/JENKINS/Hall+Plugin
 hall-jenkins = https://wiki.jenkins.io/x/qQghB
 # https://wiki.jenkins.io/display/JENKINS/HockeyApp+Plugin
 hockeyapp = https://wiki.jenkins.io/x/7oPPAw
-# https://wiki.jenkins-ci.org/display/JENKINS/iON+Deployer+Plugin
+# https://wiki.jenkins.io/display/JENKINS/iON+Deployer+Plugin
 ion-deployer-plugin = https://wiki.jenkins.io/x/FhOMAw
-# https://wiki.jenkins-ci.org/display/JENKINS/Java.net+Plugin
+# https://wiki.jenkins.io/display/JENKINS/Java.net+Plugin
 javanet = https://wiki.jenkins.io/x/AgDL
-# https://wiki.jenkins-ci.org/display/JENKINS/java.net+uploader+Plugin
+# https://wiki.jenkins.io/display/JENKINS/java.net+uploader+Plugin
 javanet-uploader = https://wiki.jenkins.io/x/ZoAL
 jenkins-tracker = https://issues.jenkins-ci.org/browse/INFRA-1531
-# https://wiki.jenkins-ci.org/display/JENKINS/Jenkow+Activiti+Designer
+# https://wiki.jenkins.io/display/JENKINS/Jenkow+Activiti+Designer
 jenkow-activiti-designer = https://wiki.jenkins.io/x/ngnqAw
-# https://wiki.jenkins-ci.org/display/JENKINS/Jenkow+Activiti+Explorer
+# https://wiki.jenkins.io/display/JENKINS/Jenkow+Activiti+Explorer
 jenkow-activiti-explorer = https://wiki.jenkins.io/x/yQH8Aw
-# https://wiki.jenkins-ci.org/display/JENKINS/Jenkow+Plugin
+# https://wiki.jenkins.io/display/JENKINS/Jenkow+Plugin
 jenkow-plugin = https://wiki.jenkins.io/x/WIuhAw
 # https://github.com/jenkins-infra/update-center2/pull/94
 kanboard-publisher = https://git.io/JfaQH
-# https://wiki.jenkins-ci.org/display/JENKINS/M2+Extra+Steps+Plugin
+# https://wiki.jenkins.io/display/JENKINS/M2+Extra+Steps+Plugin
 m2-extra-steps = https://wiki.jenkins.io/x/FIc5Ag
-# https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Cloud+Connector+Plugin
+# https://wiki.jenkins.io/display/JENKINS/CloudBees+Cloud+Connector+Plugin
 mansion-cloud = https://wiki.jenkins.io/x/YwdRB
 # https://github.com/mwaylabs/jenkins-mcap-eas-plugin#jenkins-mcap-eas-plugin
 mcap-eas-plugin = https://git.io/JfaQ9
-# https://wiki.jenkins-ci.org/display/JENKINS/MyPeople+Plugin
+# https://wiki.jenkins.io/display/JENKINS/MyPeople+Plugin
 mypeople = https://wiki.jenkins.io/x/xQRCB
-# https://wiki.jenkins-ci.org/display/JENKINS/Nabaztag+Plugin
+# https://wiki.jenkins.io/display/JENKINS/Nabaztag+Plugin
 nabaztag = https://wiki.jenkins.io/x/dIEuAg
-# https://wiki.jenkins-ci.org/display/JENKINS/Netio-Plugin
+# https://wiki.jenkins.io/display/JENKINS/Netio-Plugin
 netio-plugin = https://wiki.jenkins.io/x/7gMHB
-# https://wiki.jenkins-ci.org/display/JENKINS/Node+Offline+Notification+Plugin
+# https://wiki.jenkins.io/display/JENKINS/Node+Offline+Notification+Plugin
 nodeofflinenotification = https://wiki.jenkins.io/x/0IKhAw
-# https://wiki.jenkins-ci.org/display/JENKINS/Notifo+Plugin
+# https://wiki.jenkins.io/display/JENKINS/Notifo+Plugin
 notifo = https://wiki.jenkins.io/x/0ADDAg
-# https://wiki.jenkins-ci.org/display/JENKINS/Origo+Issue+Notifier
+# https://wiki.jenkins.io/display/JENKINS/Origo+Issue+Notifier
 origo-issue-notifier = https://wiki.jenkins.io/x/qgabAg
 # https://github.com/jenkins-infra/update-center2/pull/291
 paranoia = https://git.io/JfaQS
@@ -102,37 +102,37 @@ paranoia = https://git.io/JfaQS
 pipeline-editor = https://git.io/JfaQy
 # https://github.com/jenkins-infra/update-center2/pull/42
 poll-mailbox-trigger = https://git.io/JfaQM
-# https://wiki.jenkins-ci.org/display/JENKINS/Pretest+Commit+Plugin
+# https://wiki.jenkins.io/display/JENKINS/Pretest+Commit+Plugin
 pretest-commit = https://wiki.jenkins.io/x/5gB-B
-# https://wiki.jenkins-ci.org/display/JENKINS/pucm+plugin
+# https://wiki.jenkins.io/display/JENKINS/pucm+plugin
 PUCM = https://wiki.jenkins.io/x/fIBVAw
 # https://github.com/jenkins-infra/update-center2/pull/13
 rtc = https://git.io/JfaQ1
-# https://wiki.jenkins-ci.org/display/JENKINS/Retry+Failed+Builds+Plugin
+# https://wiki.jenkins.io/display/JENKINS/Retry+Failed+Builds+Plugin
 schedule-failed-builds = https://wiki.jenkins.io/x/roM5Ag
 # https://github.com/jenkins-infra/update-center2/commit/5f3f5ae66ea0e819c27d6d1fed9fdb00781f636c
 scis-ad = https://git.io/JfaQX
 scm-branch-pr-filter = https://issues.jenkins-ci.org/browse/INFRA-1358
 # https://github.com/jenkins-infra/update-center2/pull/324
 SCTMExecutor = https://git.io/JfaQP
-# https://wiki.jenkins-ci.org/display/JENKINS/Build+Secret+Plugin
+# https://wiki.jenkins.io/display/JENKINS/Build+Secret+Plugin
 secret = https://wiki.jenkins.io/x/9ghSAg
-# https://wiki.jenkins-ci.org/display/JENKINS/Setenv+Plugin
+# https://wiki.jenkins.io/display/JENKINS/Setenv+Plugin
 setenv = https://wiki.jenkins.io/x/YAtSAg
 # https://wiki.jenkins.io/pages/viewpage.action?pageId=63930505
 sonatype-ci = https://wiki.jenkins.io/x/iYDPAw
-# https://wiki.jenkins-ci.org/display/JENKINS/TEPCO+Plugin
+# https://wiki.jenkins.io/display/JENKINS/TEPCO+Plugin
 tepco = https://wiki.jenkins.io/x/zoBoAw
-# https://wiki.jenkins-ci.org/display/JENKINS/TEPCO+Electric+Power+Usage+Widget
+# https://wiki.jenkins.io/display/JENKINS/TEPCO+Electric+Power+Usage+Widget
 tepco-epuw = https://wiki.jenkins.io/x/vohoAw
-# https://wiki.jenkins-ci.org/display/JENKINS/Testflight+Plugin
+# https://wiki.jenkins.io/display/JENKINS/Testflight+Plugin
 testflight = https://wiki.jenkins.io/x/pwZ1Aw
-# https://wiki.jenkins-ci.org/display/JENKINS/URL+Change+Trigger
+# https://wiki.jenkins.io/display/JENKINS/URL+Change+Trigger
 url-change-trigger = https://wiki.jenkins.io/x/BQBJ
 # https://github.com/jenkins-infra/update-center2/pull/302
 veracode-scanner = https://git.io/JfaQ6
 vessel = https://groups.google.com/d/msg/jenkinsci-dev/L34eAMMWA5o/-AxtRdGsAAAJ
 # https://github.com/jenkinsci/xltestview-plugin/commit/ea034f9929b520e63b9ce15aed9bdb62354146cf
 xltest-plugin = https://git.io/JfaQK
-# https://wiki.jenkins-ci.org/display/JENKINS/ZAProxy+Plugin
+# https://wiki.jenkins.io/display/JENKINS/ZAProxy+Plugin
 zaproxy = https://wiki.jenkins.io/x/JgCsB

--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -36,6 +36,8 @@ cloudbees-enterprise-plugins = https://wiki.jenkins.io/x/3gX8Aw
 cloudbees-registration = https://wiki.jenkins.io/x/z4FLB
 # https://github.com/jenkins-infra/update-center2/pull/299
 codescan = https://git.io/JfaQb
+# https://github.com/jenkinsci/configuration-as-code-plugin/releases/tag/configuration-as-code-1.18
+configuration-as-code-support = https://git.io/JfaHz
 # https://wiki.jenkins-ci.org/display/JENKINS/CopyArchiver+Plugin
 copyarchiver = https://wiki.jenkins.io/x/ywJAAg
 # https://wiki.jenkins-ci.org/display/JENKINS/CppUnit+Plugin

--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -2,6 +2,7 @@
 # While plugins can be deprecated through labels, that requires that the plugins continue being published.
 # This file allows marking plugins as deprecated while not publishing them otherwise.
 # Additionally, this file allows referencing deprecation notices outside of (obsolete or non-existing) plugin documentation.
+# Shorten URLs if and only if the URLs are to github.com (git.io) or wiki.jenkins.io. Record the real URL in a comment.
 
 # https://wiki.jenkins.io/display/JENKINS/AppThwack+Plugin
 appthwack = https://wiki.jenkins.io/x/cwchB

--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -1,4 +1,75 @@
 # This file contains deprecated plugins (keys) and the URL the deprecation notice should link to (value).
 # While plugins can be deprecated through labels, that requires that the plugins continue being published.
 # This file allows marking plugins as deprecated while not publishing them otherwise.
-i-am-an-invalid-plugin-id=https://github.com/jenkins-infra/update-center2
+# Additionally, this file allows referencing deprecation notices outside of (obsolete or non-existing) plugin documentation.
+
+appthwack = https://wiki.jenkins.io/display/JENKINS/AppThwack+Plugin
+assembla-oauth = https://groups.google.com/d/msg/jenkinsci-dev/TVz-D5etsUM/Knx9zXtEnSwJ
+blackduck-hub = https://github.com/jenkins-infra/update-center2/pull/261
+blackduck-installer = https://wiki.jenkins-ci.org/display/JENKINS/Black+Duck+Vulnerability+Installer+Plugin
+build-flow-extensions-plugin = https://groups.google.com/d/msg/jenkinsci-dev/YKfydxnpvyE/mMN7LNBoBgAJ
+build-flow-test-aggregator = https://groups.google.com/d/msg/jenkinsci-dev/YKfydxnpvyE/mMN7LNBoBgAJ
+build-flow-toolbox-plugin = https://groups.google.com/d/msg/jenkinsci-dev/YKfydxnpvyE/mMN7LNBoBgAJ
+build-node-column = https://wiki.jenkins-ci.org/display/JENKINS/Build+Node+Column+Plugin
+buildcoin-plugin = https://wiki.jenkins-ci.org/display/JENKINS/Buildcoin+Plugin
+buildheroes = https://wiki.jenkins-ci.org/display/JENKINS/Buildheroes
+caroline = https://wiki.jenkins-ci.org/display/JENKINS/Caroline+Plugin
+chrome-frame-plugin = https://www.chromium.org/developers/how-tos/chrome-frame-getting-started
+cifs = https://wiki.jenkins-ci.org/display/JENKINS/CIFS-Publisher+Plugin
+clang-scanbuild-plugin = https://github.com/jenkinsci/clang-scanbuild-plugin/commit/a6d57b67f6fbd0a9893ecf6436c54ecb670d5829
+cloudbees-deployer-plugin = https://wiki.jenkins-ci.org/display/JENKINS/Cloudbees+Deployer+Plugin
+cloudbees-disk-usage-simple-plugin = https://github.com/jenkins-infra/update-center2/pull/179
+cloudbees-enterprise-plugins = https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Jenkins+Enterprise
+cloudbees-registration = https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Registration+Plugin
+codescan = https://github.com/jenkins-infra/update-center2/pull/299
+copyarchiver = https://wiki.jenkins-ci.org/display/JENKINS/CopyArchiver+Plugin
+cppunit = https://wiki.jenkins-ci.org/display/JENKINS/CppUnit+Plugin
+dockerhub = https://github.com/jenkins-infra/update-center2/commit/e5a138873113d0e2d6af59d5699215a1835c15b7
+emotional-hudson = https://wiki.jenkins-ci.org/display/JENKINS/Emotional+Hudson+Plugin
+external-scheduler = https://github.com/jenkins-infra/update-center2/pull/257
+externalresource-dispatcher = https://groups.google.com/d/msg/jenkinsci-dev/YKfydxnpvyE/mMN7LNBoBgAJ
+gerrit = https://wiki.jenkins-ci.org/display/JENKINS/Gerrit+Plugin
+girls = https://wiki.jenkins-ci.org/display/JENKINS/Girls+Plugin
+gitorious = https://wiki.jenkins-ci.org/display/JENKINS/Gitorious+Plugin
+google-desktop-gadget = https://wiki.jenkins-ci.org/display/JENKINS/Hudson+Google+Desktop+Gadget
+googlecode = https://wiki.jenkins-ci.org/display/JENKINS/Google+Code+Plugin
+hall-jenkins = https://wiki.jenkins-ci.org/display/JENKINS/Hall+Plugin
+hockeyapp = https://wiki.jenkins.io/display/JENKINS/HockeyApp+Plugin
+ion-deployer-plugin = https://wiki.jenkins-ci.org/display/JENKINS/iON+Deployer+Plugin
+javanet = https://wiki.jenkins-ci.org/display/JENKINS/Java.net+Plugin
+javanet-uploader = https://wiki.jenkins-ci.org/display/JENKINS/java.net+uploader+Plugin
+jenkins-tracker = https://issues.jenkins-ci.org/browse/INFRA-1531
+jenkow-activiti-designer = https://wiki.jenkins-ci.org/display/JENKINS/Jenkow+Activiti+Designer
+jenkow-activiti-explorer = https://wiki.jenkins-ci.org/display/JENKINS/Jenkow+Activiti+Explorer
+jenkow-plugin = https://wiki.jenkins-ci.org/display/JENKINS/Jenkow+Plugin
+kanboard-publisher = https://github.com/jenkins-infra/update-center2/pull/94
+m2-extra-steps = https://wiki.jenkins-ci.org/display/JENKINS/M2+Extra+Steps+Plugin
+mansion-cloud = https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Cloud+Connector+Plugin
+mcap-eas-plugin = https://github.com/mwaylabs/jenkins-mcap-eas-plugin#jenkins-mcap-eas-plugin
+mypeople = https://wiki.jenkins-ci.org/display/JENKINS/MyPeople+Plugin
+nabaztag = https://wiki.jenkins-ci.org/display/JENKINS/Nabaztag+Plugin
+netio-plugin = https://wiki.jenkins-ci.org/display/JENKINS/Netio-Plugin
+nodeofflinenotification = https://wiki.jenkins-ci.org/display/JENKINS/Node+Offline+Notification+Plugin
+notifo = https://wiki.jenkins-ci.org/display/JENKINS/Notifo+Plugin
+origo-issue-notifier = https://wiki.jenkins-ci.org/display/JENKINS/Origo+Issue+Notifier
+paranoia = https://github.com/jenkins-infra/update-center2/pull/291
+pipeline-editor = https://github.com/jenkinsci/pipeline-editor-plugin
+poll-mailbox-trigger = https://github.com/jenkins-infra/update-center2/pull/42
+pretest-commit = https://wiki.jenkins-ci.org/display/JENKINS/Pretest+Commit+Plugin
+PUCM = https://wiki.jenkins-ci.org/display/JENKINS/pucm+plugin
+rtc = https://github.com/jenkins-infra/update-center2/pull/13
+schedule-failed-builds = https://wiki.jenkins-ci.org/display/JENKINS/Retry+Failed+Builds+Plugin
+scis-ad = https://github.com/jenkins-infra/update-center2/commit/5f3f5ae66ea0e819c27d6d1fed9fdb00781f636c
+scm-branch-pr-filter = https://issues.jenkins-ci.org/browse/INFRA-1358
+SCTMExecutor = https://github.com/jenkins-infra/update-center2/pull/324
+secret = https://wiki.jenkins-ci.org/display/JENKINS/Build+Secret+Plugin
+setenv = https://wiki.jenkins-ci.org/display/JENKINS/Setenv+Plugin
+sonatype-ci = https://wiki.jenkins.io/pages/viewpage.action?pageId=63930505
+tepco = https://wiki.jenkins-ci.org/display/JENKINS/TEPCO+Plugin
+tepco-epuw = https://wiki.jenkins-ci.org/display/JENKINS/TEPCO+Electric+Power+Usage+Widget
+testflight = https://wiki.jenkins-ci.org/display/JENKINS/Testflight+Plugin
+url-change-trigger = https://wiki.jenkins-ci.org/display/JENKINS/URL+Change+Trigger
+veracode-scanner = https://github.com/jenkins-infra/update-center2/pull/302
+vessel = https://groups.google.com/d/msg/jenkinsci-dev/L34eAMMWA5o/-AxtRdGsAAAJ
+xltest-plugin = https://github.com/jenkinsci/xltestview-plugin/commit/ea034f9929b520e63b9ce15aed9bdb62354146cf
+zaproxy = https://wiki.jenkins-ci.org/display/JENKINS/ZAProxy+Plugin

--- a/src/main/java/io/jenkins/update_center/Deprecations.java
+++ b/src/main/java/io/jenkins/update_center/Deprecations.java
@@ -1,0 +1,30 @@
+package io.jenkins.update_center;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+public class Deprecations {
+    private Deprecations() {}
+
+    public static String getCustomDeprecationUri(String pluginName) {
+        return DEPRECATIONS.getProperty(pluginName);
+    }
+
+    public static List<String> getDeprecatedPlugins() {
+        return DEPRECATIONS.keySet().stream().map(Object::toString).collect(Collectors.toList());
+    }
+
+    private static final Properties DEPRECATIONS = new Properties();
+
+    static {
+        try {
+            DEPRECATIONS.load(Files.newInputStream(new File(Main.resourcesDir, "deprecations.properties").toPath()));
+        } catch (IOException e) {
+            throw new Error(e);
+        }
+    }
+}

--- a/src/main/java/io/jenkins/update_center/json/UpdateCenterDeprecation.java
+++ b/src/main/java/io/jenkins/update_center/json/UpdateCenterDeprecation.java
@@ -1,0 +1,13 @@
+package io.jenkins.update_center.json;
+
+import com.alibaba.fastjson.annotation.JSONField;
+
+public class UpdateCenterDeprecation {
+
+    @JSONField
+    public final String url;
+
+    public UpdateCenterDeprecation(String url) {
+        this.url = url;
+    }
+}

--- a/src/main/java/io/jenkins/update_center/json/UpdateCenterRoot.java
+++ b/src/main/java/io/jenkins/update_center/json/UpdateCenterRoot.java
@@ -2,6 +2,8 @@ package io.jenkins.update_center.json;
 
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.annotation.JSONField;
+import com.google.common.base.Functions;
+import io.jenkins.update_center.Deprecations;
 import io.jenkins.update_center.MavenRepository;
 import io.jenkins.update_center.PluginUpdateCenterEntry;
 import io.jenkins.update_center.Plugin;
@@ -14,6 +16,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 public class UpdateCenterRoot extends WithSignature {
     @JSONField
@@ -34,10 +37,16 @@ public class UpdateCenterRoot extends WithSignature {
     @JSONField
     public List<UpdateCenterWarning> warnings;
 
+    @JSONField
+    public Map<String, UpdateCenterDeprecation> deprecations;
+
     public UpdateCenterRoot(MavenRepository repo, File warningsJsonFile) throws IOException {
         // load warnings
         final String warningsJsonText = String.join("", Files.readAllLines(warningsJsonFile.toPath(), StandardCharsets.UTF_8));
         warnings = Arrays.asList(JSON.parseObject(warningsJsonText, UpdateCenterWarning[].class));
+
+        // load deprecations
+        deprecations = Deprecations.getDeprecatedPlugins().stream().collect(Collectors.toMap(Functions.identity(), it -> new UpdateCenterDeprecation(Deprecations.getCustomDeprecationUri(it))));
 
         for (Plugin plugin : repo.listJenkinsPlugins()) {
             PluginUpdateCenterEntry entry = new PluginUpdateCenterEntry(plugin);

--- a/src/main/java/io/jenkins/update_center/json/UpdateCenterRoot.java
+++ b/src/main/java/io/jenkins/update_center/json/UpdateCenterRoot.java
@@ -46,7 +46,7 @@ public class UpdateCenterRoot extends WithSignature {
         warnings = Arrays.asList(JSON.parseObject(warningsJsonText, UpdateCenterWarning[].class));
 
         // load deprecations
-        deprecations = Deprecations.getDeprecatedPlugins().stream().collect(Collectors.toMap(Functions.identity(), it -> new UpdateCenterDeprecation(Deprecations.getCustomDeprecationUri(it))));
+        deprecations = new TreeMap<>(Deprecations.getDeprecatedPlugins().stream().collect(Collectors.toMap(Functions.identity(), UpdateCenterRoot::deprecationForPlugin)));
 
         for (Plugin plugin : repo.listJenkinsPlugins()) {
             PluginUpdateCenterEntry entry = new PluginUpdateCenterEntry(plugin);
@@ -54,5 +54,9 @@ public class UpdateCenterRoot extends WithSignature {
         }
 
         core = new UpdateCenterCore(repo.getJenkinsWarsByVersionNumber());
+    }
+
+    private static UpdateCenterDeprecation deprecationForPlugin(String artifactId) {
+        return new UpdateCenterDeprecation(Deprecations.getCustomDeprecationUri(artifactId));
     }
 }


### PR DESCRIPTION
Companion PR to https://github.com/jenkinsci/jenkins/pull/4073 for a basic implementation of [JENKINS-59136](https://issues.jenkins-ci.org/browse/JENKINS-59136).

---

Add support for marking any plugin artifact ID as deprecated, even those not currently published.

Broadly speaking, there are now two supported mechanisms for marking as deprecated:

* The label `deprecated`.
* Entries in a new top-level object `deprecations`, keys are plugin IDs, and values are objects with a key `url` whose value is a String.

The former requires no changes to the `update-center.json` format. This implements the latter.

There are two use cases for the top-level `deprecations` element:

* Deprecating plugins that are no longer published.
* Using a different deprecation reference URL than just the regular plugin URL (on plugins.jenkins.io). URLs can be mailing list archives, Jira issues, PR discussions, whatever makes sense. 

A new resource file `deprecations.properties` can be used to define deprecations for the top-level element.

For now this implementation does not add "duplicate" entries to the top-level `deprecations` map from regular labels, but that could be added in the future for easier consumption. We probably need to continue defining the regular `deprecated` label for backwards compatibility.

Sample data:

```
"deprecations": {
  "i-am-an-invalid-plugin-id": {
    "url":"https://github.com/jenkins-infra/update-center2"
  }
}
```

This format allows for some future extensibility at a fairly low complexity cost (as opposed to the minimal `{ "pluginId": "url" }`).