### PR TITLE
Override URLs for plugins replaced by Warnings NG

### DIFF
--- a/src/main/resources/wiki-overrides.properties
+++ b/src/main/resources/wiki-overrides.properties
@@ -69,3 +69,13 @@ github-scm-trait-notification-context=https://wiki.jenkins.io/display/JENKINS/Gi
 ca-apm=https://wiki.jenkins.io/display/JENKINS/CA+APM+Plugin+1.x
 comments-remover=https://wiki.jenkins.io/display/JENKINS/XComment.io+-+Comments+Remover+Plugin
 qtest=https://github.com/jenkinsci/qtest-plugin
+
+# Deprecated plugins (replaced by warnings-ng)
+pmd=https://github.com/jenkinsci/pmd-plugin
+dry=https://github.com/jenkinsci/dry-plugin
+findbugs=https://github.com/jenkinsci/findbugs-plugin 
+analysis-core=https://github.com/jenkinsci/analysis-core-plugin 
+analysis-collector=https://github.com/jenkinsci/analysis-collector-plugin 
+warnings=https://github.com/jenkinsci/warnings-plugin
+tasks=https://github.com/jenkinsci/tasks-plugin
+checkstyle=https://github.com/jenkinsci/checkstyle-plugin 


### PR DESCRIPTION
The GitHub readme for these plugins contains a reasonable explanation, OTOH the Wiki page extraction for them is quite unstable so e.g. https://plugins.jenkins.io/pmd/ shows just a link to the wiki and that redirects back to plugins.jenkins.io.

I hope this is compatible with the current improvements of deprecation warnings.

CC @uhafner @daniel-beck @oleg-nenashev 