### PR TITLE
Permit the API Plugin label

### DIFF
--- a/src/main/resources/allowed-labels.properties
+++ b/src/main/resources/allowed-labels.properties
@@ -9,6 +9,7 @@ administrative-monitor
 agent
 analysis
 android
+api-plugin
 aws
 bitbucket
 bitbucket-server


### PR DESCRIPTION
The change adds official support for the https://github.com/topics/jenkins-api-plugin GitHub topic which represents the "API Plugin" term we were using recently for plugins which do not provide their own user-facing functionality. 

Problem: it collides with https://plugins.jenkins.io/ui/search/?labels=library which used to be used for such purpose in Wiki. IMHO "library" is a bit confusing, e.g. see https://github.com/topics/jenkins-library which refers Pipeline or Groovy script libraries. Needs discussion with interested parties to decide.

CC @uhafner @jglick @bitwiseman @jeffret-b @jvz @kuisathaverat @wadeck  who maintain API plugins from the lists