### PR TITLE
Whitelist the email plugin label

### DIFF
--- a/src/main/resources/allowed-labels.properties
+++ b/src/main/resources/allowed-labels.properties
@@ -29,6 +29,7 @@ deployment
 devops
 dotnet
 docker
+email
 emailext
 external
 file


### PR DESCRIPTION
https://github.com/search?q=topic%3Aemail+org%3Ajenkinsci&type=Repositories . There are actualy more plugins, but looks like we hit an issue with forked repositories which do not get listed. FYI @daniel-beck 