### PR TITLE
Add "openshift" to the list of allowed GitHub labels

### DIFF
--- a/src/main/resources/allowed-labels.properties
+++ b/src/main/resources/allowed-labels.properties
@@ -50,6 +50,7 @@ misc
 notification
 notifier
 npm
+openshift
 page-decorator
 parameter
 performance


### PR DESCRIPTION
There are at least 5 plugins for OpenShift now: https://github.com/jenkinsci?q=openshift&type=&language= , so I think it would be nice to have a label on the plugin site

CC @olivergondza @akram 