### PR TITLE
Remove warning for openid

### DIFF
--- a/src/main/resources/warnings.json
+++ b/src/main/resources/warnings.json
@@ -4103,7 +4103,8 @@
     "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1084",
     "versions": [
       {
-        "pattern": ".*"
+        "lastVersion": "2.3.0",
+        "pattern": "(1|2[.][0-3])(|[-.].*)"
       }
     ]
   },


### PR DESCRIPTION
advisory: https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1084
correction: https://github.com/jenkinsci/openid-plugin/pull/18
new release: https://github.com/jenkinsci/openid-plugin/releases/tag/openid-2.4
artifact: https://repo.jenkins-ci.org/webapp/#/artifacts/browse/tree/General/releases/org/jenkins-ci/plugins/openid/2.4