### PR TITLE
[SECURITY-1423] Update pattern after fix in 2.0.0

### DIFF
--- a/src/main/resources/warnings.json
+++ b/src/main/resources/warnings.json
@@ -6026,7 +6026,7 @@
     "versions": [
       {
         "lastVersion": "1.9",
-        "pattern": ".*"
+        "pattern": "1[.].*"
       }
     ]
   },


### PR DESCRIPTION
The plugin had used `Secret`   to save sensitive information after version 2.0.0 .