### PR TITLE
Add readme for deprected plugin (pipeline-model-declarative-agent)

### DIFF
--- a/src/main/resources/wiki-overrides.properties
+++ b/src/main/resources/wiki-overrides.properties
@@ -69,6 +69,7 @@ github-scm-trait-notification-context=https://wiki.jenkins.io/display/JENKINS/Gi
 ca-apm=https://wiki.jenkins.io/display/JENKINS/CA+APM+Plugin+1.x
 comments-remover=https://wiki.jenkins.io/display/JENKINS/XComment.io+-+Comments+Remover+Plugin
 qtest=https://github.com/jenkinsci/qtest-plugin
+pipeline-model-declarative-agent=https://github.com/jenkinsci/pipeline-model-definition-plugin/blob/master/pipeline-model-declarative-agent/README.md
 
 # Deprecated plugins (replaced by warnings-ng)
 pmd=https://github.com/jenkinsci/pmd-plugin


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/386 (on hold until that one is merged)