### PR TITLE
Fix popularity: Actually create float output

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <dependency>
       <groupId>org.kohsuke.stapler</groupId>
       <artifactId>json-lib</artifactId>
-      <version>2.1-rev7</version>
+      <version>2.4-jenkins-2</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/src/main/java/org/jvnet/hudson/update_center/Popularities.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Popularities.java
@@ -63,8 +63,8 @@ public class Popularities {
         return instance;
     }
 
-    public double getPopularity(String pluginId) {
+    public float getPopularity(String pluginId) {
         // TODO divide by maxPopularity again once we've identified and resolved the problem with inconsistent number of fractional digits
-        return this.popularities.getOrDefault(pluginId, 0).doubleValue();
+        return this.popularities.getOrDefault(pluginId, 0).floatValue() / Integer.valueOf(maxPopularity).floatValue();
     }
 }

--- a/src/main/java/org/jvnet/hudson/update_center/Popularities.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Popularities.java
@@ -64,6 +64,7 @@ public class Popularities {
     }
 
     public double getPopularity(String pluginId) {
+        // TODO divide by maxPopularity again once we've identified and resolved the problem with inconsistent number of fractional digits
         return this.popularities.getOrDefault(pluginId, 0).doubleValue();
     }
 }

--- a/src/main/java/org/jvnet/hudson/update_center/Popularities.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Popularities.java
@@ -63,7 +63,7 @@ public class Popularities {
         return instance;
     }
 
-    public float getPopularity(String pluginId) {
-        return (float)this.popularities.getOrDefault(pluginId, 0) / (float)maxPopularity;
+    public double getPopularity(String pluginId) {
+        return this.popularities.getOrDefault(pluginId, 0).doubleValue();
     }
 }


### PR DESCRIPTION
This addresses the problem encountered after merging #356: It looks like Jenkins will always create floats when deserializing / serializing JSON using json-lib.

These changes ensure that the update center creates the expected format.