### PR TITLE
Suspend distribution of plugins with non OSI license

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -388,3 +388,7 @@ configuration-as-code-1.37
 # https://github.com/jenkinsci/kubesphere-extension-plugin/pull/4#pullrequestreview-386832816
 kubesphere-extension-0.1.0
 kubesphere-extension-0.2.0
+
+# Non OSI license: These plugins use a custom license (3 clause BSD + 4th clause about trademark use)
+ci-with-toad-edge
+ci-with-toad-devops-toolkit


### PR DESCRIPTION
Per https://jenkins.io/project/governance/#license we only distribute plugins with OSI approved licenses, and these plugins don't:

https://github.com/jenkinsci/ci-with-toad-devops-toolkit-plugin/blob/master/LICENSE
https://github.com/jenkinsci/ci-with-toad-edge-plugin/blob/master/LICENSE

FYI @jlibo-quest, @PChudani-Quest, @kdalton-Quest, @hamermike.