### PR TITLE
Suspend distribution of aliyun-container-service-deploy due to ambiguity

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -422,6 +422,10 @@ urltrigger-0.42
 uipath-automation-package-1.0
 node-iterator-api-1.5
 
+# Released with different groupIds
+aliyun-container-service-deploy-0.1.0
+aliyun-container-service-deploy-0.1.1
+
 # Non OSI license: These plugins use a custom license (3 clause BSD + 4th clause about trademark use)
 ci-with-toad-edge
 ci-with-toad-devops-toolkit


### PR DESCRIPTION
Pick up a plugin suspension from https://github.com/jenkins-infra/update-center2/pull/365 to make current builds comparable; when I tried to use the new code I got checksum problems. This is the only effective change to current `update-center.*` in that PR.