### PR TITLE
Removing Fortify Cloudscan plugin from distribution

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -334,6 +334,7 @@ git-client-3.0.0-rc
 
 # Replaced by the official fortify plugin https://wiki.jenkins.io/display/JENKINS/Fortify+Plugin
 fortify360
+fortify-cloudscan-jenkins-plugin
 
 # Failed shading Snakeyaml, 1.9 has both shaded and direct dependency inside
 configuration-as-code-1.9


### PR DESCRIPTION
Removing Fortify Cloudscan plugin from distribution in favor of vendor supported plugin