### PR TITLE
Remove trailing spaces

### DIFF
--- a/resources/wiki-overrides.properties
+++ b/resources/wiki-overrides.properties
@@ -74,12 +74,12 @@ pipeline-model-declarative-agent=https://github.com/jenkinsci/pipeline-model-def
 # Deprecated plugins (replaced by warnings-ng)
 pmd=https://github.com/jenkinsci/pmd-plugin
 dry=https://github.com/jenkinsci/dry-plugin
-findbugs=https://github.com/jenkinsci/findbugs-plugin 
-analysis-core=https://github.com/jenkinsci/analysis-core-plugin 
-analysis-collector=https://github.com/jenkinsci/analysis-collector-plugin 
+findbugs=https://github.com/jenkinsci/findbugs-plugin
+analysis-core=https://github.com/jenkinsci/analysis-core-plugin
+analysis-collector=https://github.com/jenkinsci/analysis-collector-plugin
 warnings=https://github.com/jenkinsci/warnings-plugin
 tasks=https://github.com/jenkinsci/tasks-plugin
-checkstyle=https://github.com/jenkinsci/checkstyle-plugin 
+checkstyle=https://github.com/jenkinsci/checkstyle-plugin
 
 # JS Libs plugins
 ace-editor=https://github.com/jenkinsci/js-libs/blob/master/ace-editor/README.md


### PR DESCRIPTION
Trailing spaces are kept in https://updates.jenkins.io/current/plugin-documentation-urls.json and cause the documentation extractor to fail.