### PR TITLE
Stop distributing play-autotest plugin

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -470,3 +470,6 @@ ci-with-toad-devops-toolkit
 
 # Delayed release of Qualys API security module, so suspend until then
 qualys-api-security
+
+# Depublished as agreed with maintainer after SECURITY-1879 in 2020-06-03 security advisory
+play-autotest-plugin


### PR DESCRIPTION
Apparently the plugin doesn't work anymore anyway.

https://www.jenkins.io/security/advisory/2020-06-03/