### PR TITLE
blacklist configuration-as-code-support

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -28,6 +28,7 @@ cloudbees-registration           # "This feature is no longer relevant." -- http
 cloudbees-disk-usage-simple-plugin # renamed to cloudbees-disk-usage-simple several years ago
 ColumnPack-plugin                # renamed to ColumnsPlugin
 ConfigurationSlicing             # renamed into configurationslicing, and this double causes a check out problem on Windows
+configuration-as-code-support    # deprecated
 convert-to-declarative           # renamed to declarative-pipeline-migration-assistant-plugin
 convert-to-declarative-api       # renamed to declarative-pipeline-migration-assistant-plugin
 copyarchiver                     # superseded by ArtifactDeployer Plugin  -- https://wiki.jenkins-ci.org/display/JENKINS/CopyArchiver+Plugin
@@ -337,10 +338,6 @@ fortify360
 
 # Failed shading Snakeyaml, 1.9 has both shaded and direct dependency inside
 configuration-as-code-1.9
-configuration-as-code-support-1.9
-
-# No Source release of JCasC support 1.19
-configuration-as-code-support-1.19
 
 # Failed release of Google Compute Engine Plugin 3.3.1
 google-compute-engine-3.3.1


### PR DESCRIPTION
Since the release of 1.18 which is a year ago: https://github.com/jenkinsci/configuration-as-code-plugin/releases/tag/configuration-as-code-1.18
The code that was moved to other plugins where it belonged have had time to adopt.

I suggest we blacklist.

cc @timja