### PR TITLE
[SECURITY-1686] Disable warning for 2.5.1+

### DIFF
--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -8165,8 +8165,8 @@
     "url": "https://jenkins.io/security/advisory/2020-07-02/#SECURITY-1686",
     "versions": [
       {
-        "lastVersion": "2.4.1",
-        "pattern": ".*"
+        "lastVersion": "2.5",
+        "pattern": "(1|2[.][0-4])(|[.-].+)|(2[.]5)"
       }
     ]
   },

--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -8165,8 +8165,8 @@
     "url": "https://jenkins.io/security/advisory/2020-07-02/#SECURITY-1686",
     "versions": [
       {
-        "lastVersion": "2.5",
-        "pattern": "(1|2[.][0-4])(|[.-].+)|(2[.]5)"
+        "lastVersion": "2.5.1",
+        "pattern": "(1|2[.][0-4]|2[.]5[.]1)(|[.-].+)|(2[.]5)"
       }
     ]
   },


### PR DESCRIPTION
CC @Igor-Filin

We'll need to confirm the issue is fully resolved first, and if it is, we'll merge this to disable the active security warning.