### PR TITLE
Suspend distribution of sideex-1.0.0

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -411,6 +411,9 @@ elastest-1.0.0-beta1
 # ambiguous version numbers: 0.1.0-alpha-1 is preferred
 git-forensics-0.1-alpha-1
 
+# ambiguous version numbers: Prefer 1.0
+sideex-1.0.0
+
 # Released with different groupIds
 contrast-continuous-application-security-1.0
 dependency-check-jenkins-plugin-1.0.1


### PR DESCRIPTION
Looks like both 1.0 and 1.0.0 were released and that creates ambiguity in what we publish:
https://github.com/jenkinsci/sideex-plugin/commits/master

From build logs and https://updates.jenkins.io/download/plugins/sideex/ it looks like 1.0 is currently being published at least fairly consistently, so choose that over 1.0.0.

FYI @kiam123, please don't create releases whose precedence is ambiguous (`X` and `X.0`).