### PR TITLE
Identify which plugin releases have non-existing core dependencies

### DIFF
--- a/src/main/java/io/jenkins/update_center/json/TieredUpdateSitesGenerator.java
+++ b/src/main/java/io/jenkins/update_center/json/TieredUpdateSitesGenerator.java
@@ -99,7 +99,14 @@ public class TieredUpdateSitesGenerator extends WithoutSignature {
         for (VersionNumber dependencyVersion : coreDependencyVersions) {
             final JenkinsWar war = allJenkinsWarsByVersionNumber.get(dependencyVersion);
             if (war == null) {
-                LOGGER.log(Level.INFO, "Did not find declared core dependency version among all core releases: " + dependencyVersion.toString());
+                LOGGER.log(Level.INFO, "Did not find declared core dependency version among all core releases: " + dependencyVersion.toString() + ". It is used by " + allPluginReleases.stream().filter( p -> {
+                    try {
+                        return p.getRequiredJenkinsVersion().equals(dependencyVersion.toString());
+                    } catch (IOException e) {
+                        // ignore
+                        return false;
+                    }
+                }).map(HPI::getGavId).collect(Collectors.joining(", ")));
                 continue;
             }
             final boolean releaseRecentEnough = isReleaseRecentEnough(war);


### PR DESCRIPTION
Sample output:

> `2020-08-03 17:50:08.774+0000 [id=1]     INFO    i.j.u.j.TieredUpdateSitesGenerator#update: Did not find declared core dependency version among all core releases: 2.185-rc28469.6af78cb11bf8. It is used by io.jenkins.plugins:build-symlink:1.0`