### PR TITLE
[INFRA-2615] Deprecate fixed tiers, don't generate for 2.249.x+

### DIFF
--- a/site/generate.sh
+++ b/site/generate.sh
@@ -104,6 +104,12 @@ done
 # Workaround for https://github.com/jenkinsci/docker/issues/954 -- still generate fixed tier update sites
 for ltsv in "${RELEASES[@]}" ; do
   v="${ltsv/%.1/}"
+
+  if [[ ${v/./} -gt 2240 ]] ; then # TODO Make 3.x safe
+    echo "INFRA-2615: Skipping generation of $v / stable-$v"
+    continue
+  fi
+
   # For mainline up to $v, advertising the latest core
   generate --limit-plugin-core-dependency "$v.999" --write-latest-core --latest-links-directory "$WWW_ROOT_DIR/$v/latest" --www-dir "$WWW_ROOT_DIR/$v"
 


### PR DESCRIPTION
This implements the suggestion in https://github.com/jenkinsci/docker/issues/954#issuecomment-646254122 and  will result in the gradual retirement of fixed tiers.

Currently, all five latest fixed tiers are still generated for tools and scripts accessing them directly. With 2.249.x coming in ~5 weeks, 2.176.x will be retired, but 2.249.x would _not_ be added with this change. This would continue until, after about a year, no fixed tiers are generated anymore.

https://github.com/jenkinsci/docker/issues/954 should be implemented so the Docker image doesn't require these directories anymore. CC @slide 