### PR TITLE
Revert "Nest dynamic tier directories into common top-level directory"

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -24,7 +24,7 @@ So we generate several update centers targeted for different version ranges.
 
 To accommodate all recent Jenkins releases, we first inspect all plugin releases for their Jenkins core dependencies.
 We then generate tiered update sites for all releases identified this way that are more recent than a cutoff (~3 months).
-Directories containing these tiered update sites are nested inside the `dynamic/` folder.
+Directories containing these tiered update sites have the prefix `dynamic-`.
 
 mod_rewrite rules in an `.htaccess` file are then used to redirect requests from Jenkins versions to the next lower update site.
 It will serve the newest release of each plugin that is compatible with the specified Jenkins version.

--- a/site/generate-htaccess.sh
+++ b/site/generate-htaccess.sh
@@ -46,16 +46,16 @@ for (( i = n-1 ; i >= 0 ; i-- )) ; do
 # If major > ${major} or major = ${major} and minor > ${minor} or major = ${major} and minor = ${minor} and patch >= ${patch}, use this LTS update site
 RewriteCond %{QUERY_STRING} ^.*version=(\d)\.(\d+)\.(\d+)$ [NC]
 RewriteCond %1 >${major}
-RewriteRule ^(update\-center.*\.(json|html)+) /dynamic/stable-${major}\.${minor}\.${patch}%{REQUEST_URI}? [NC,L,R]
+RewriteRule ^(update\-center.*\.(json|html)+) /dynamic-stable-${major}\.${minor}\.${patch}%{REQUEST_URI}? [NC,L,R]
 RewriteCond %{QUERY_STRING} ^.*version=(\d)\.(\d+)\.(\d+)$ [NC]
 RewriteCond %1 =${major}
 RewriteCond %2 >${minor}
-RewriteRule ^(update\-center.*\.(json|html)+) /dynamic/stable-${major}\.${minor}\.${patch}%{REQUEST_URI}? [NC,L,R]
+RewriteRule ^(update\-center.*\.(json|html)+) /dynamic-stable-${major}\.${minor}\.${patch}%{REQUEST_URI}? [NC,L,R]
 RewriteCond %{QUERY_STRING} ^.*version=(\d)\.(\d+)\.(\d+)$ [NC]
 RewriteCond %1 =${major}
 RewriteCond %2 =${minor}
 RewriteCond %3 >=${patch}
-RewriteRule ^(update\-center.*\.(json|html)+) /dynamic/stable-${major}\.${minor}\.${patch}%{REQUEST_URI}? [NC,L,R]
+RewriteRule ^(update\-center.*\.(json|html)+) /dynamic-stable-${major}\.${minor}\.${patch}%{REQUEST_URI}? [NC,L,R]
 EOF
     oldestStable="$version"
   else
@@ -68,11 +68,11 @@ EOF
 # If major > ${major} or major = ${major} and minor >= ${minor}, use this weekly update site
 RewriteCond %{QUERY_STRING} ^.*version=(\d)\.(\d+)$ [NC]
 RewriteCond %1 >${major}
-RewriteRule ^(update\-center.*\.(json|html)+) /dynamic/${major}\.${minor}%{REQUEST_URI}? [NC,L,R]
+RewriteRule ^(update\-center.*\.(json|html)+) /dynamic-${major}\.${minor}%{REQUEST_URI}? [NC,L,R]
 RewriteCond %{QUERY_STRING} ^.*version=(\d)\.(\d+)$ [NC]
 RewriteCond %1 =${major}
 RewriteCond %2 >=${minor}
-RewriteRule ^(update\-center.*\.(json|html)+) /dynamic/${major}\.${minor}%{REQUEST_URI}? [NC,L,R]
+RewriteRule ^(update\-center.*\.(json|html)+) /dynamic-${major}\.${minor}%{REQUEST_URI}? [NC,L,R]
 EOF
 
   fi
@@ -84,17 +84,17 @@ cat <<EOF
 # First LTS update site (stable-$oldestStable) gets all older LTS releases
 
 RewriteCond %{QUERY_STRING} ^.*version=\d\.(\d+)\.\d+$ [NC]
-RewriteRule ^(update\-center.*\.(json|html)+) /dynamic/stable-${oldestStable}%{REQUEST_URI}? [NC,L,R]
+RewriteRule ^(update\-center.*\.(json|html)+) /dynamic-stable-${oldestStable}%{REQUEST_URI}? [NC,L,R]
 
 RewriteCond %{QUERY_STRING} ^.*version=\d\.(\d+)+$ [NC]
-RewriteRule ^(update\-center.*\.(json|html)+) /dynamic/${oldestWeekly}%{REQUEST_URI}? [NC,L,R]
+RewriteRule ^(update\-center.*\.(json|html)+) /dynamic-${oldestWeekly}%{REQUEST_URI}? [NC,L,R]
 
 EOF
 
 
 echo "# Add a RewriteRule for /stable which will always rewrite to the last LTS site we have"
 cat <<EOF
-RewriteRule ^stable/(.+) "/dynamic/stable-${newestStable}/\$1" [NC,L,R]
+RewriteRule ^stable/(.+) "/dynamic-stable-${newestStable}/\$1" [NC,L,R]
 
 EOF
 

--- a/site/generate.sh
+++ b/site/generate.sh
@@ -99,12 +99,12 @@ function sanity-check {
 # This supports updating Jenkins (core) once a year while getting offered compatible plugin updates.
 for version in "${WEEKLY_RELEASES[@]}" ; do
   # For mainline, advertising the latest core
-  generate --limit-plugin-core-dependency "$version" --write-latest-core --latest-links-directory "$WWW_ROOT_DIR/dynamic/$version/latest" --www-dir "$WWW_ROOT_DIR/dynamic/$version"
+  generate --limit-plugin-core-dependency "$version" --write-latest-core --latest-links-directory "$WWW_ROOT_DIR/dynamic-$version/latest" --www-dir "$WWW_ROOT_DIR/dynamic-$version"
 done
 
 for version in "${STABLE_RELEASES[@]}" ; do
   # For LTS, advertising the latest LTS core
-  generate --limit-plugin-core-dependency "$version" --write-latest-core --latest-links-directory "$WWW_ROOT_DIR/dynamic/stable-$version/latest" --www-dir "$WWW_ROOT_DIR/dynamic/stable-$version" --only-stable-core
+  generate --limit-plugin-core-dependency "$version" --write-latest-core --latest-links-directory "$WWW_ROOT_DIR/dynamic-stable-$version/latest" --www-dir "$WWW_ROOT_DIR/dynamic-stable-$version" --only-stable-core
 done
 
 # Workaround for https://github.com/jenkinsci/docker/issues/954 -- still generate fixed tier update sites
@@ -147,13 +147,13 @@ for ltsv in "${RELEASES[@]}" ; do
 done
 
 for version in "${WEEKLY_RELEASES[@]}" ; do
-  sanity-check "$WWW_ROOT_DIR/dynamic/$version"
-  ln -sf ../updates "$WWW_ROOT_DIR/dynamic/$version/updates"
+  sanity-check "$WWW_ROOT_DIR/dynamic-$version"
+  ln -sf ../updates "$WWW_ROOT_DIR/dynamic-$version/updates"
 done
 
 for version in "${STABLE_RELEASES[@]}" ; do
-  sanity-check "$WWW_ROOT_DIR/dynamic/stable-$version"
-  ln -sf ../updates "$WWW_ROOT_DIR/dynamic/stable-$version/updates"
+  sanity-check "$WWW_ROOT_DIR/dynamic-stable-$version"
+  ln -sf ../updates "$WWW_ROOT_DIR/dynamic-stable-$version/updates"
 done
 
 sanity-check "$WWW_ROOT_DIR/experimental"
@@ -171,5 +171,4 @@ pushd "$WWW_ROOT_DIR"
 popd
 
 # copy other static resource files
-cp -av "$( dirname "$0" )/static/readme.html" "$WWW_ROOT_DIR/readme.html"
-cp -av "$( dirname "$0" )/static/dynamic.html" "$WWW_ROOT_DIR/dynamic/readme.html"
+cp -av "$( dirname "$0" )/static/readme.html" "$WWW_ROOT_DIR"

--- a/site/static/dynamic.html
+++ b/site/static/dynamic.html
@@ -1,6 +1,0 @@
-<p>
-    <strong>Important:</strong>
-    Do not rely on the existence or layout of subdirectories shown here.
-    To obtain versioned metadata for a specific Jenkins version, add a <code>?version=</code> query parameter, for example <code>/update-center.json?version=2.234</code>.
-    Jenkins does this automatically, so the update site URL configured in Jenkins should always be just <code>https://updates.jenkins.io/update-center.json</code>.
-</p>

--- a/site/test/test.sh
+++ b/site/test/test.sh
@@ -50,45 +50,45 @@ test_redirect "$TEST_BASE_URL/plugin-documentation-urls.json" "$TEST_BASE_URL/cu
 test_redirect "$TEST_BASE_URL/latestCore.txt" "$TEST_BASE_URL/current/latestCore.txt"
 
 
-test_redirect "$TEST_BASE_URL/stable/update-center.json" "$TEST_BASE_URL/dynamic/stable-2.222.1/update-center.json"
+test_redirect "$TEST_BASE_URL/stable/update-center.json" "$TEST_BASE_URL/dynamic-stable-2.222.1/update-center.json"
 
 # Accessed by https://github.com/jenkins-infra/jenkins.io/blob/3892ea2ad4b4a67e1f8aebbfab261ae88628c176/scripts/fetch-external-resources#L24
-test_redirect "$TEST_BASE_URL/stable/latestCore.txt" "$TEST_BASE_URL/dynamic/stable-2.222.1/latestCore.txt"
+test_redirect "$TEST_BASE_URL/stable/latestCore.txt" "$TEST_BASE_URL/dynamic-stable-2.222.1/latestCore.txt"
 
-test_redirect "$TEST_BASE_URL/update-center.json?version=2.246" "$TEST_BASE_URL/dynamic/2.240/update-center.json"
-test_redirect "$TEST_BASE_URL/update-center.json?version=2.240" "$TEST_BASE_URL/dynamic/2.240/update-center.json"
-test_redirect "$TEST_BASE_URL/update-center.json?version=2.225" "$TEST_BASE_URL/dynamic/2.223/update-center.json"
-test_redirect "$TEST_BASE_URL/update-center.json?version=2.223" "$TEST_BASE_URL/dynamic/2.223/update-center.json"
-test_redirect "$TEST_BASE_URL/update-center.json?version=2.222" "$TEST_BASE_URL/dynamic/2.222/update-center.json"
-test_redirect "$TEST_BASE_URL/update-center.json?version=2.222.1" "$TEST_BASE_URL/dynamic/stable-2.222.1/update-center.json"
-test_redirect "$TEST_BASE_URL/update-center.json?version=2.55" "$TEST_BASE_URL/dynamic/2.172/update-center.json" # TODO Fix
-test_redirect "$TEST_BASE_URL/update-center.json?version=2.6" "$TEST_BASE_URL/dynamic/2.172/update-center.json" # TODO Fix
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.246" "$TEST_BASE_URL/dynamic-2.240/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.240" "$TEST_BASE_URL/dynamic-2.240/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.225" "$TEST_BASE_URL/dynamic-2.223/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.223" "$TEST_BASE_URL/dynamic-2.223/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.222" "$TEST_BASE_URL/dynamic-2.222/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.222.1" "$TEST_BASE_URL/dynamic-stable-2.222.1/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.55" "$TEST_BASE_URL/dynamic-2.172/update-center.json" # TODO Fix
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.6" "$TEST_BASE_URL/dynamic-2.172/update-center.json" # TODO Fix
 
 
-test_redirect "$TEST_BASE_URL/update-center.json?version=2.204.1" "$TEST_BASE_URL/dynamic/stable-2.204.1/update-center.json"
-test_redirect "$TEST_BASE_URL/update-center.json?version=2.204.2" "$TEST_BASE_URL/dynamic/stable-2.204.2/update-center.json"
-test_redirect "$TEST_BASE_URL/update-center.json?version=2.204.3" "$TEST_BASE_URL/dynamic/stable-2.204.2/update-center.json"
-test_redirect "$TEST_BASE_URL/update-center.json?version=2.204.4" "$TEST_BASE_URL/dynamic/stable-2.204.4/update-center.json"
-test_redirect "$TEST_BASE_URL/update-center.json?version=2.204.5" "$TEST_BASE_URL/dynamic/stable-2.204.4/update-center.json"
-test_redirect "$TEST_BASE_URL/update-center.json?version=2.204.6" "$TEST_BASE_URL/dynamic/stable-2.204.6/update-center.json"
-test_redirect "$TEST_BASE_URL/update-center.json?version=2.204.7" "$TEST_BASE_URL/dynamic/stable-2.204.6/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.204.1" "$TEST_BASE_URL/dynamic-stable-2.204.1/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.204.2" "$TEST_BASE_URL/dynamic-stable-2.204.2/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.204.3" "$TEST_BASE_URL/dynamic-stable-2.204.2/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.204.4" "$TEST_BASE_URL/dynamic-stable-2.204.4/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.204.5" "$TEST_BASE_URL/dynamic-stable-2.204.4/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.204.6" "$TEST_BASE_URL/dynamic-stable-2.204.6/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.204.7" "$TEST_BASE_URL/dynamic-stable-2.204.6/update-center.json"
 
-test_redirect "$TEST_BASE_URL/update-center.actual.json?version=2.222" "$TEST_BASE_URL/dynamic/2.222/update-center.actual.json"
-test_redirect "$TEST_BASE_URL/update-center.actual.json?version=2.222.1" "$TEST_BASE_URL/dynamic/stable-2.222.1/update-center.actual.json"
+test_redirect "$TEST_BASE_URL/update-center.actual.json?version=2.222" "$TEST_BASE_URL/dynamic-2.222/update-center.actual.json"
+test_redirect "$TEST_BASE_URL/update-center.actual.json?version=2.222.1" "$TEST_BASE_URL/dynamic-stable-2.222.1/update-center.actual.json"
 
 # No more redirects to tiers
 test_redirect "$TEST_BASE_URL/plugin-documentation-urls.json?version=2.222.1" "$TEST_BASE_URL/current/plugin-documentation-urls.json"
 test_redirect "$TEST_BASE_URL/latestCore.txt?version=2.222.1" "$TEST_BASE_URL/current/latestCore.txt"
 
 # Jenkins 1.x gets the oldest update sites
-test_redirect "$TEST_BASE_URL/update-center.json?version=1.650" "$TEST_BASE_URL/dynamic/2.172/update-center.json" # TODO Fix
-test_redirect "$TEST_BASE_URL/update-center.json?version=1.580" "$TEST_BASE_URL/dynamic/2.172/update-center.json" # TODO Fix
-test_redirect "$TEST_BASE_URL/update-center.json?version=1.580.1" "$TEST_BASE_URL/dynamic/stable-2.164.2/update-center.json"
-test_redirect "$TEST_BASE_URL/update-center.json?version=2.46.1" "$TEST_BASE_URL/dynamic/stable-2.164.2/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=1.650" "$TEST_BASE_URL/dynamic-2.172/update-center.json" # TODO Fix
+test_redirect "$TEST_BASE_URL/update-center.json?version=1.580" "$TEST_BASE_URL/dynamic-2.172/update-center.json" # TODO Fix
+test_redirect "$TEST_BASE_URL/update-center.json?version=1.580.1" "$TEST_BASE_URL/dynamic-stable-2.164.2/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.46.1" "$TEST_BASE_URL/dynamic-stable-2.164.2/update-center.json"
 
 # This would probably be ideal: Drop down if older than newest LTS baseline, this instance isn't getting updates weekly
-test_redirect "$TEST_BASE_URL/update-center.json?version=2.200" "$TEST_BASE_URL/dynamic/2.199/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.200" "$TEST_BASE_URL/dynamic-2.199/update-center.json"
 
 # Future major releases go to the most recent update sites:
-test_redirect "$TEST_BASE_URL/update-center.json?version=3.0" "$TEST_BASE_URL/dynamic/2.240/update-center.json"
-test_redirect "$TEST_BASE_URL/update-center.json?version=3.0.1" "$TEST_BASE_URL/dynamic/stable-2.222.1/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=3.0" "$TEST_BASE_URL/dynamic-2.240/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=3.0.1" "$TEST_BASE_URL/dynamic-stable-2.222.1/update-center.json"


### PR DESCRIPTION
This reverts commit 1a365ed13daa4de631c4023a55310221e9478704.

----

The mirroring script `sync.sh` does not supported update sites in nested folders (something like `for FILE in */update-center.json`). Rather than touch that, revert this change from #416. It seems to have weird performance effects anyway.
