### PR TITLE
Add index page (from jenkins.io site build) and tiers.json to updates…

### DIFF
--- a/site/LAYOUT.md
+++ b/site/LAYOUT.md
@@ -71,9 +71,15 @@ The top level directory provides that file and several others.
 
 The top level update site will forward requests to the best matching _tiered_ update site, or the `current` update site based on the `version` query parameter sent by Jenkins.
 
-The files in this directory are copies of/symlinks to `current` to create clickable links.
+The files in this directory are usually copies of/symlinks to `current` to create clickable links.
 Actual requests are redirected to tiered sites, or the `current` site (with no query parameters).
 This way, at least the file properties shown in the directory listing match the eventually served file after clicking the link.
+
+### Tier List
+
+The file `tiers.json` is generated as part of update-center2 execution and published in the root directory.
+
+It allows programmatically determining which versions of Jenkins get served which update site.
 
 
 ## Regular tiered update sites (LTS and weekly)

--- a/site/generate-htaccess.sh
+++ b/site/generate-htaccess.sh
@@ -119,8 +119,7 @@ RewriteRule ^plugin\-documentation\-urls\.json+ /current%{REQUEST_URI}? [NC,L,R=
 RewriteRule ^plugin\-versions\.json+ /current%{REQUEST_URI}? [NC,L,R=301]
 
 
-ReadmeName readme.html
-IndexIgnore readme.html
+DirectoryIndex index.html
 
 # TODO: properly handle HTTPS in redirector
 

--- a/site/generate-htaccess.sh
+++ b/site/generate-htaccess.sh
@@ -107,16 +107,18 @@ cat <<EOF
 # These are static rules
 
 # If that all failed, but we have an update center, let's go to current
-RewriteRule ^(update\-center.*\.(json|html)+|latestCore\.txt) /current%{REQUEST_URI}? [NC,L,R=301]
+RewriteRule ^update\-center.*\.(json|html)+ /current%{REQUEST_URI}? [NC,L,R=301]
+
+RewriteRule ^latestCore\.txt /current%{REQUEST_URI}? [NC,L,R=301]
 
 # Ensure /release-history.json goes to the right place
-RewriteRule ^release\-history\.json+ /current%{REQUEST_URI}? [NC,L,R=301]
+RewriteRule ^release\-history\.json$ /current%{REQUEST_URI}? [NC,L,R=301]
 
 # Ensure /plugin-documentation-urls.json goes to the right place
-RewriteRule ^plugin\-documentation\-urls\.json+ /current%{REQUEST_URI}? [NC,L,R=301]
+RewriteRule ^plugin\-documentation\-urls\.json$ /current%{REQUEST_URI}? [NC,L,R=301]
 
 # Ensure /plugin-versions.json goes to the right place
-RewriteRule ^plugin\-versions\.json+ /current%{REQUEST_URI}? [NC,L,R=301]
+RewriteRule ^plugin\-versions\.json$ /current%{REQUEST_URI}? [NC,L,R=301]
 
 
 DirectoryIndex index.html

--- a/site/generate.sh
+++ b/site/generate.sh
@@ -171,4 +171,5 @@ pushd "$WWW_ROOT_DIR"
 popd
 
 # copy other static resource files
-cp -av "$( dirname "$0" )/static/readme.html" "$WWW_ROOT_DIR"
+curl --location --fail https://www.jenkins.io/templates/updates/index.html > "$WWW_ROOT_DIR/index.html"
+cp -av "tmp/tiers.json" "$WWW_ROOT_DIR/tiers.json"


### PR DESCRIPTION
….jenkins.io

In the future, when browsing to https://updates.jenkins.io, it will look like this: https://www.jenkins.io/templates/updates/index.html

Additionally, `tiers.json` will help understand what dynamic tiers are currently supported.

WDYT?