### PR TITLE
Properly mark sonargraph-plugin as deprecated

### DIFF
--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -124,6 +124,8 @@ SCTMExecutor = https://git.io/JfaQP
 secret = https://wiki.jenkins.io/x/9ghSAg
 # https://wiki.jenkins.io/display/JENKINS/Setenv+Plugin
 setenv = https://wiki.jenkins.io/x/YAtSAg
+# https://github.com/jenkins-infra/update-center2/pull/405#issue-455150640
+sonargraph-plugin = https://git.io/JJ5h1
 # https://wiki.jenkins.io/pages/viewpage.action?pageId=63930505
 sonatype-ci = https://wiki.jenkins.io/x/iYDPAw
 # https://wiki.jenkins.io/display/JENKINS/TEPCO+Plugin

--- a/resources/label-definitions.properties
+++ b/resources/label-definitions.properties
@@ -918,7 +918,6 @@ snsnotify=notifier post-build
 sonar-gerrit=external
 sonar=external report
 sonargraph-integration=external post-build report
-sonargraph-plugin=deprecated
 sounds=notifier
 speaks=notifier
 splunk-devops=post-build notifier report


### PR DESCRIPTION
Followup to #405, supersedes #422.

I'd like a better URL, but the wiki page is out (thanks redirect rules!), and https://github.com/jenkinsci/sonargraph-plugin/ has nothing.

Perhaps @andreashoyerh2m can provide a better reference, e.g. update the old plugin's readme in the repo, but for now, this will do.