### PR TITLE
Add recent-releases.json to inform selective sync of new stuff only

### DIFF
--- a/site/generate.sh
+++ b/site/generate.sh
@@ -120,12 +120,12 @@ done
 # Experimental update center without version caps, including experimental releases.
 # This is not a part of the version-based redirection rules, admins need to manually configure it.
 # Generate this first, including --downloads-directory, as this includes all releases, experimental and otherwise.
-generate --www-dir "$WWW_ROOT_DIR/experimental" --with-experimental --downloads-directory "$DOWNLOAD_ROOT_DIR" --latest-links-directory "$WWW_ROOT_DIR/experimental/latest"
+generate --www-dir "$WWW_ROOT_DIR/experimental" --generate-recent-releases --with-experimental --downloads-directory "$DOWNLOAD_ROOT_DIR" --latest-links-directory "$WWW_ROOT_DIR/experimental/latest"
 
 # Current update site without version caps, excluding experimental releases.
 # This generates -download after the experimental update site above to change the 'latest' symlinks to the latest released version.
 # This also generates --download-links-directory to only visibly show real releases on index.html pages.
-generate --generate-release-history --generate-plugin-versions --generate-plugin-documentation-urls \
+generate --generate-release-history --generate-recent-releases --generate-plugin-versions --generate-plugin-documentation-urls \
     --write-latest-core --write-plugin-count \
     --www-dir "$WWW_ROOT_DIR/current" --download-links-directory "$WWW_ROOT_DIR/download" --downloads-directory "$DOWNLOAD_ROOT_DIR" --latest-links-directory "$WWW_ROOT_DIR/current/latest"
 

--- a/src/main/java/io/jenkins/update_center/Main.java
+++ b/src/main/java/io/jenkins/update_center/Main.java
@@ -27,6 +27,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.util.VersionNumber;
 import io.jenkins.lib.support_log_formatter.SupportLogFormatter;
 import io.jenkins.update_center.args4j.LevelOptionHandler;
+import io.jenkins.update_center.json.RecentReleasesRoot;
 import io.jenkins.update_center.json.TieredUpdateSitesGenerator;
 import io.jenkins.update_center.json.PluginDocumentationUrlsRoot;
 import io.jenkins.update_center.wrappers.AlphaBetaOnlyRepository;
@@ -126,6 +127,9 @@ public class Main {
 
     @Option(name = "--generate-plugin-documentation-urls", usage = "Generate plugin documentation URL mapping (for plugins.jenkins.io)")
     public boolean generatePluginDocumentationUrls;
+
+    @Option(name = "--generate-recent-releases", usage = "Generate recent releases file (as input to targeted rsync etc.)")
+    public boolean generateRecentReleases;
 
 
     /* Configure options modifying output */
@@ -257,8 +261,12 @@ public class Main {
         if (generateReleaseHistory) {
             new ReleaseHistoryRoot(repo).write(new File(www, RELEASE_HISTORY_JSON_FILENAME), prettyPrint);
         }
-        directoryTreeBuilder.build(repo);
 
+        if (generateRecentReleases) {
+            new RecentReleasesRoot(repo).write(new File(www, RECENT_RELEASES_JSON_FILENAME), prettyPrint);
+        }
+
+        directoryTreeBuilder.build(repo);
     }
 
     private String updateCenterPostCallJson(String updateCenterJson) {
@@ -345,6 +353,7 @@ public class Main {
     private static final String PLUGIN_DOCUMENTATION_URLS_JSON_FILENAME = "plugin-documentation-urls.json";
     private static final String PLUGIN_VERSIONS_JSON_FILENAME = "plugin-versions.json";
     private static final String RELEASE_HISTORY_JSON_FILENAME = "release-history.json";
+    private static final String RECENT_RELEASES_JSON_FILENAME = "recent-releases.json";
     private static final String EOL = System.getProperty("line.separator");
 
     private static final Logger LOGGER = Logger.getLogger(Main.class.getName());

--- a/src/main/java/io/jenkins/update_center/json/RecentReleasesEntry.java
+++ b/src/main/java/io/jenkins/update_center/json/RecentReleasesEntry.java
@@ -1,0 +1,18 @@
+package io.jenkins.update_center.json;
+
+import io.jenkins.update_center.HPI;
+
+public class RecentReleasesEntry {
+    private HPI hpi;
+    public RecentReleasesEntry(HPI hpi) {
+        this.hpi = hpi;
+    }
+
+    public String getName() {
+        return hpi.artifact.artifactId;
+    }
+
+    public String getVersion() {
+        return hpi.version;
+    }
+}

--- a/src/main/java/io/jenkins/update_center/json/RecentReleasesRoot.java
+++ b/src/main/java/io/jenkins/update_center/json/RecentReleasesRoot.java
@@ -1,0 +1,31 @@
+package io.jenkins.update_center.json;
+
+import com.alibaba.fastjson.annotation.JSONField;
+import io.jenkins.update_center.HPI;
+import io.jenkins.update_center.MavenRepository;
+import io.jenkins.update_center.Plugin;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+public class RecentReleasesRoot extends WithoutSignature {
+    @JSONField
+    public List<RecentReleasesEntry> releases = new ArrayList<>();
+
+    public RecentReleasesRoot(MavenRepository repository) throws IOException {
+        for (Plugin plugin : repository.listJenkinsPlugins()) {
+            for (HPI release : plugin.getArtifacts().values()) {
+                if (Instant.ofEpochMilli(release.getTimestamp()).isBefore(Instant.now().minus(MAX_AGE))) {
+                    // too old, ignore
+                    continue;
+                }
+                releases.add(new RecentReleasesEntry(release));
+            }
+        }
+    }
+
+    private static final Duration MAX_AGE = Duration.ofHours(24);
+}


### PR DESCRIPTION
**Work in progress**

Sample content:

> `{"releases":[{"name":"checkmarx","version":"2020.3.3"},{"name":"Parameterized-Remote-Trigger","version":"3.1.4"},{"name":"reqtify","version":"2.0.0"},{"name":"xray-connector","version":"2.3.1"}]}`

Generate only this file:

> `java -Dfile.encoding=UTF-8 -jar target/update-center2-3.*-SNAPSHOT-bin/update-center2-3.*-SNAPSHOT.jar --generate-recent-releases --www-dir output-dir --skip-update-center`