### PR TITLE
Prepare for HTTPS download URLs, override in wrapper script

### DIFF
--- a/site/generate.sh
+++ b/site/generate.sh
@@ -58,7 +58,7 @@ unzip -q "$MAIN_DIR"/tmp/generator.zip -d "$MAIN_DIR"/tmp/generator/
 function execute {
   # To use a locally built snapshot, use the following line instead:
   # java -Dfile.encoding=UTF-8 -jar target/update-center2-*-bin/update-center2-*.jar "$@"
-  java -Dfile.encoding=UTF-8 -jar "$MAIN_DIR"/tmp/generator/update-center2-*.jar "$@"
+  java -Dfile.encoding=UTF-8 -DDOWNLOADS_ROOT_URL=http://updates.jenkins-ci.org/download -jar "$MAIN_DIR"/tmp/generator/update-center2-*.jar "$@"
 }
 
 execute --dynamic-tier-list-file tmp/tiers.json

--- a/src/main/java/io/jenkins/update_center/HPI.java
+++ b/src/main/java/io/jenkins/update_center/HPI.java
@@ -67,7 +67,6 @@ import java.net.MalformedURLException;
  * For version independent metadata, see {@link Plugin}.
  */
 public class HPI extends MavenArtifact {
-    private static final String DOWNLOADS_ROOT_URL = Environment.getString("DOWNLOADS_ROOT_URL", "http://updates.jenkins-ci.org/download");
     private static final Pattern DEVELOPERS_PATTERN = Pattern.compile("([^:]*):([^:]*):([^,]*),?");
 
     private final Plugin plugin;

--- a/src/main/java/io/jenkins/update_center/JenkinsWar.java
+++ b/src/main/java/io/jenkins/update_center/JenkinsWar.java
@@ -24,6 +24,8 @@
 package io.jenkins.update_center;
 
 import hudson.util.VersionNumber;
+import io.jenkins.update_center.util.Environment;
+import org.apache.commons.lang.StringUtils;
 
 import java.net.URL;
 import java.net.MalformedURLException;
@@ -38,7 +40,7 @@ public class JenkinsWar extends MavenArtifact {
 
     @Override
     public URL getDownloadUrl() throws MalformedURLException {
-        return new URL("http://updates.jenkins-ci.org/download/war/"+version+"/"+ getFileName());
+        return new URL(StringUtils.removeEnd(DOWNLOADS_ROOT_URL, "/") + "/war/" + version + "/" +  getFileName());
     }
 
     public String getFileName() {

--- a/src/main/java/io/jenkins/update_center/MavenArtifact.java
+++ b/src/main/java/io/jenkins/update_center/MavenArtifact.java
@@ -24,6 +24,7 @@
 package io.jenkins.update_center;
 
 import hudson.util.VersionNumber;
+import io.jenkins.update_center.util.Environment;
 
 import javax.annotation.Nonnull;
 import java.io.File;
@@ -44,6 +45,7 @@ import java.util.jar.Manifest;
  * @author Kohsuke Kawaguchi
  */
 public class MavenArtifact {
+    protected static final String DOWNLOADS_ROOT_URL = Environment.getString("DOWNLOADS_ROOT_URL", "https://updates.jenkins.io/download");
     /**
      * Where did this plugin come from?
      */


### PR DESCRIPTION
* Make war base URL configurable (just like plugins)
* Make the internal code default use `https://updates.jenkins.io` (from `http://updates.jenkins-ci.org`)
* But override in the wrapper script to not change behavior for now

Upstream of https://github.com/jenkins-infra/update-center2/pull/429