### PR TITLE
Simplify HTTPS redirects

### DIFF
--- a/site/generate-htaccess.sh
+++ b/site/generate-htaccess.sh
@@ -123,10 +123,6 @@ RewriteRule ^plugin\-versions\.json$ /current%{REQUEST_URI}? [NC,L,R=301]
 
 DirectoryIndex index.html
 
-# For other tool installations under updates/
-RewriteCond %{HTTPS} off
-RewriteRule (.*\.json(\.html)?)$ http://mirrors.jenkins-ci.org/updates/\$1 [NC,L,R]
-
 # download/* directories contain virtual URL spaces for redirecting download traffic to mirrors.
 RedirectMatch 302 /download/war/([0-9]*\.[0-9]*\.[0-9]*/jenkins)\.war$ https://get.jenkins.io/war-stable/\$1.war
 RedirectMatch 302 /download/war/(.*)\.war$ https://get.jenkins.io/war/\$1.war


### PR DESCRIPTION
Supersedes https://github.com/jenkins-infra/update-center2/pull/431

This hopefully addresses the problems with the current `master` branch state creating 404. I don't know why, but this is basically the same code as before, just with unconditional HTTPS redirects.

Effective diff over what is currently live: https://github.com/jenkins-infra/update-center2/compare/cae9fbcbabe82317d7478c165452adbb9655c59c...daniel-beck:simplify-https-redirects