### PR TITLE
Only immediately sync releases of the last 3 hours, not 24

### DIFF
--- a/src/main/java/io/jenkins/update_center/json/RecentReleasesRoot.java
+++ b/src/main/java/io/jenkins/update_center/json/RecentReleasesRoot.java
@@ -27,5 +27,5 @@ public class RecentReleasesRoot extends WithoutSignature {
         }
     }
 
-    private static final Duration MAX_AGE = Duration.ofHours(24);
+    private static final Duration MAX_AGE = Duration.ofHours(3);
 }


### PR DESCRIPTION
Depends on https://github.com/jenkins-infra/mirror-scripts/pull/2 to not regularly result in a full sync.