### PR TITLE
Add fingerprint to allowed-github-topics

### DIFF
--- a/resources/allowed-github-topics.properties
+++ b/resources/allowed-github-topics.properties
@@ -35,6 +35,7 @@ email
 emailext
 external
 file
+fingerprint
 git
 github
 gitlab


### PR DESCRIPTION
Add `fingerprint` to allowed-github-topics.properties

CC @oleg-nenashev @afalko @mikecirioli