### PR TITLE
Add redis to allowed-github-topics

### DIFF
--- a/resources/allowed-github-topics.properties
+++ b/resources/allowed-github-topics.properties
@@ -67,6 +67,7 @@ plugin-test
 post-build
 python
 queue
+redis
 report
 ruby
 runcondition


### PR DESCRIPTION
Add `redis` to allowed-github-topics.properties

CC @oleg-nenashev @afalko @mikecirioli