### PR TITLE
Add local redirect to make 'latest' links work even with bad mirrors

### DIFF
--- a/site/generate-htaccess.sh
+++ b/site/generate-htaccess.sh
@@ -126,5 +126,6 @@ DirectoryIndex index.html
 # download/* directories contain virtual URL spaces for redirecting download traffic to mirrors.
 RedirectMatch 302 /download/war/([0-9]*\.[0-9]*\.[0-9]*/jenkins)\.war$ https://get.jenkins.io/war-stable/\$1.war
 RedirectMatch 302 /download/war/(.*)\.war$ https://get.jenkins.io/war/\$1.war
+RedirectMatch 302 /download/plugins/(.*)/latest/(.*)\.hpi$ https://updates.jenkins.io/latest/\$2.hpi
 RedirectMatch 302 /download/plugins/(.*)\.hpi$ https://get.jenkins.io/plugins/\$1.hpi
 EOF


### PR DESCRIPTION
````
$ curl -IL http://localhost:8080/download/plugins/git/latest/git.hpi
HTTP/1.1 302 Found
Date: Mon, 24 Aug 2020 20:33:07 GMT
Server: Apache/2.4.43 (Unix)
Location: https://updates.jenkins.io/latest/git.hpi
Content-Type: text/html; charset=iso-8859-1

HTTP/1.1 302 Found
Date: Mon, 24 Aug 2020 20:33:08 GMT
Server: Apache/2.4.29 (Ubuntu)
Location: https://updates.jenkins.io/download/plugins/git/4.3.0/git.hpi
Content-Type: text/html; charset=iso-8859-1

HTTP/1.1 302 Found
Date: Mon, 24 Aug 2020 20:33:08 GMT
Server: Apache/2.4.29 (Ubuntu)
Location: https://get.jenkins.io/plugins/git/4.3.0/git.hpi
Content-Type: text/html; charset=iso-8859-1

HTTP/2 302 
server: nginx/1.19.1
date: Mon, 24 Aug 2020 20:33:09 GMT
content-type: text/html; charset=utf-8
location: https://mirror.serverion.com/jenkins/plugins/git/4.3.0/git.hpi
cache-control: private, no-cache
link: <https://mirror.gruenehoelle.nl/jenkins/plugins/git/4.3.0/git.hpi>; rel=duplicate; pri=1; geo=nl
strict-transport-security: max-age=15724800; includeSubDomains

HTTP/1.1 200 OK
Date: Mon, 24 Aug 2020 20:37:12 GMT
Server: Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips PHP/7.3.21
Last-Modified: Fri, 19 Jun 2020 18:45:38 GMT
ETag: "af741-5a8744c941880"
Accept-Ranges: bytes
Content-Length: 718657
Content-Type: application/vnd.hp-hpid
