### PR TITLE
Add redirect for /download/war/latest/jenkins.war (which should be un…

### DIFF
--- a/site/generate-htaccess.sh
+++ b/site/generate-htaccess.sh
@@ -124,8 +124,12 @@ RewriteRule ^plugin\-versions\.json$ /current%{REQUEST_URI}? [NC,L,R=301]
 DirectoryIndex index.html
 
 # download/* directories contain virtual URL spaces for redirecting download traffic to mirrors.
-RedirectMatch 302 /download/war/([0-9]*\.[0-9]*\.[0-9]*/jenkins)\.war$ https://get.jenkins.io/war-stable/\$1.war
-RedirectMatch 302 /download/war/(.*)\.war$ https://get.jenkins.io/war/\$1.war
-RedirectMatch 302 /download/plugins/(.*)/latest/(.*)\.hpi$ https://updates.jenkins.io/latest/\$2.hpi
-RedirectMatch 302 /download/plugins/(.*)\.hpi$ https://get.jenkins.io/plugins/\$1.hpi
+
+# 'latest' need special handling here since they're not getting mirrored properly to get.jenkins.io
+RedirectMatch 302 /download/war/latest/jenkins[.]war$ https://updates.jenkins.io/latest/jenkins.war
+RedirectMatch 302 /download/plugins/(.*)/latest/(.+)[.]hpi$ https://updates.jenkins.io/latest/\$2.hpi
+
+RedirectMatch 302 /download/war/([0-9]+[.][0-9]+[.][0-9]+/jenkins)[.]war$ https://get.jenkins.io/war-stable/\$1.war
+RedirectMatch 302 /download/war/(.+)[.]war$ https://get.jenkins.io/war/\$1.war
+RedirectMatch 302 /download/plugins/(.+)[.]hpi$ https://get.jenkins.io/plugins/\$1.hpi
 EOF

--- a/site/test/test.sh
+++ b/site/test/test.sh
@@ -67,8 +67,8 @@ test_redirect "$TEST_BASE_URL/update-center.json?version=2.225" "$TEST_BASE_URL/
 test_redirect "$TEST_BASE_URL/update-center.json?version=2.223" "$TEST_BASE_URL/dynamic-2.223/update-center.json"
 test_redirect "$TEST_BASE_URL/update-center.json?version=2.222" "$TEST_BASE_URL/dynamic-2.222/update-center.json"
 test_redirect "$TEST_BASE_URL/update-center.json?version=2.222.1" "$TEST_BASE_URL/dynamic-stable-2.222.1/update-center.json"
-test_redirect "$TEST_BASE_URL/update-center.json?version=2.55" "$TEST_BASE_URL/dynamic-2.172/update-center.json" # TODO Fix
-test_redirect "$TEST_BASE_URL/update-center.json?version=2.6" "$TEST_BASE_URL/dynamic-2.172/update-center.json" # TODO Fix
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.55" "$TEST_BASE_URL/dynamic-2.172/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.6" "$TEST_BASE_URL/dynamic-2.172/update-center.json"
 
 
 test_redirect "$TEST_BASE_URL/update-center.json?version=2.204.1" "$TEST_BASE_URL/dynamic-stable-2.204.1/update-center.json"
@@ -87,8 +87,8 @@ test_redirect "$TEST_BASE_URL/plugin-documentation-urls.json?version=2.222.1" "$
 test_redirect "$TEST_BASE_URL/latestCore.txt?version=2.222.1" "$TEST_BASE_URL/current/latestCore.txt"
 
 # Jenkins 1.x gets the oldest update sites
-test_redirect "$TEST_BASE_URL/update-center.json?version=1.650" "$TEST_BASE_URL/dynamic-2.172/update-center.json" # TODO Fix
-test_redirect "$TEST_BASE_URL/update-center.json?version=1.580" "$TEST_BASE_URL/dynamic-2.172/update-center.json" # TODO Fix
+test_redirect "$TEST_BASE_URL/update-center.json?version=1.650" "$TEST_BASE_URL/dynamic-2.172/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=1.580" "$TEST_BASE_URL/dynamic-2.172/update-center.json"
 test_redirect "$TEST_BASE_URL/update-center.json?version=1.580.1" "$TEST_BASE_URL/dynamic-stable-2.164.2/update-center.json"
 test_redirect "$TEST_BASE_URL/update-center.json?version=2.46.1" "$TEST_BASE_URL/dynamic-stable-2.164.2/update-center.json"
 
@@ -98,3 +98,8 @@ test_redirect "$TEST_BASE_URL/update-center.json?version=2.200" "$TEST_BASE_URL/
 # Future major releases go to the most recent update sites:
 test_redirect "$TEST_BASE_URL/update-center.json?version=3.0" "$TEST_BASE_URL/dynamic-2.240/update-center.json"
 test_redirect "$TEST_BASE_URL/update-center.json?version=3.0.1" "$TEST_BASE_URL/dynamic-stable-2.222.1/update-center.json"
+
+# Workaround, see generate-htaccess.sh
+test_redirect "$TEST_BASE_URL/download/war/latest/jenkins.war" "https://updates.jenkins.io/latest/jenkins.war"
+test_redirect "$TEST_BASE_URL/download/plugins/git/latest/git.hpi" "https://updates.jenkins.io/latest/git.hpi"
+test_redirect "$TEST_BASE_URL/download/plugins/lolwut/latest/git.hpi" "https://updates.jenkins.io/latest/git.hpi" # Fun side effect of the redirect rule


### PR DESCRIPTION
…used)

---

Followup to #436

As requested by @timja this would redirect users from `/download/war/latest/jenkins/war` to `/latest/jenkins.war` rather than go to the mirror directly. While nothing "official" seems to link there, including https://updates.jenkins.io/download/war/, people may access URLs directly.
