### PR TITLE
Suspend distribution of JSGames plugin

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -486,3 +486,6 @@ kubernetes-ci
 
 # Depublishing for deliberate protection mechanism bypass, see https://www.jenkins.io/security/advisory/2020-07-02/#SECURITY-1811
 zap-pipeline
+
+# Depublishing for reflected XSS vulnerability while bringing no real benefits, see https://www.jenkins.io/security/advisory/2020-09-01/#SECURITY-1905
+jsgames


### PR DESCRIPTION
https://www.jenkins.io/security/advisory/2020-09-01/#SECURITY-1905 is pretty serious, and the plugin doesn't really matter, so best to suspend it. Didn't get this prepared in time for the advisory publication earlier today.

Related to https://github.com/jenkins-infra/jenkins.io/pull/3681 (which will fix up the plugin name once this is merged)