### PR TITLE
[INFRA-2622] Selectively suspend old liquibase-runner for licensing i…

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -314,12 +314,24 @@ azure-slave-plugin
 
 # Plugins not fixed in https://jenkins.io/security/advisory/2018-03-26/
 copy-to-slave
-liquibase-runner
 perforce
 build-configurator  # depends on copy-to-slave
 lsf-cloud           # depends on copy-to-slave
 sge-cloud-plugin    # depends on copy-to-slave
 reviewboard         # depends on perforce
+
+# Licensing issue, see INFRA-2622
+liquibase-runner-1.0.0
+liquibase-runner-1.0.1
+liquibase-runner-1.0.2
+liquibase-runner-1.1.0
+liquibase-runner-1.2.0
+liquibase-runner-1.2.1
+liquibase-runner-1.3.0
+liquibase-runner-1.4.2
+liquibase-runner-1.4.3
+liquibase-runner-1.4.4
+liquibase-runner-1.4.5
 
 # requested by maintainer in https://github.com/jenkins-infra/update-center2/pull/199
 websphere-deployer-1.5.5


### PR DESCRIPTION
…ssue

----

See [INFRA-2622](https://issues.jenkins-ci.org/browse/INFRA-2622). Liquibase Runner 1.4.7 (1.4.6 was skipped) no longer contains this library, instead using the tool installer facility to allow downloads, and uses the CLI for tool invocations.