### PR TITLE
[JENKINS-56773] Add deprecation for blueocean-executor-info

### DIFF
--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -11,6 +11,7 @@ assembla-oauth = https://groups.google.com/d/msg/jenkinsci-dev/TVz-D5etsUM/Knx9z
 blackduck-hub = https://git.io/JfaQa
 # https://wiki.jenkins.io/display/JENKINS/Black+Duck+Vulnerability+Installer+Plugin
 blackduck-installer = https://wiki.jenkins.io/x/nYHHB
+blueocean-executor-info = https://issues.jenkins-ci.org/browse/JENKINS-56773
 build-flow-extensions-plugin = https://groups.google.com/d/msg/jenkinsci-dev/YKfydxnpvyE/mMN7LNBoBgAJ
 build-flow-test-aggregator = https://groups.google.com/d/msg/jenkinsci-dev/YKfydxnpvyE/mMN7LNBoBgAJ
 build-flow-toolbox-plugin = https://groups.google.com/d/msg/jenkinsci-dev/YKfydxnpvyE/mMN7LNBoBgAJ


### PR DESCRIPTION
See [JENKINS-56773](https://issues.jenkins-ci.org/browse/JENKINS-56773).
