### PR TITLE
Suspend distribution of qualys-api-security-2.1.0 due to ambiguous version

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -496,5 +496,8 @@ kubernetes-ci
 # Depublishing for deliberate protection mechanism bypass, see https://www.jenkins.io/security/advisory/2020-07-02/#SECURITY-1811
 zap-pipeline
 
+# 2.1 existed before
+qualys-api-security-2.1.0
+
 # Depublishing for reflected XSS vulnerability while bringing no real benefits, see https://www.jenkins.io/security/advisory/2020-09-01/#SECURITY-1905
 jsgames


### PR DESCRIPTION
Reference: https://github.com/jenkinsci/qualys-api-security-plugin/commits/master

I really need to get #412 over the finish line.

FYI @nikita-bedmutha please re-release 2.1.0 as 2.1.1.