### PR TITLE
[JENKINS-63877] Suspend distribution of tics plugin

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -496,6 +496,9 @@ kubernetes-ci
 # Depublishing for deliberate protection mechanism bypass, see https://www.jenkins.io/security/advisory/2020-07-02/#SECURITY-1811
 zap-pipeline
 
+# Depublishing for having a dependency on itself, causing JENKINS-63877
+tics
+
 # 2.1 existed before
 qualys-api-security-2.1.0
 


### PR DESCRIPTION
[JENKINS-63877](https://issues.jenkins-ci.org/browse/JENKINS-63877)

Temporary measure to restore plugin manager operation.

@jglick 