### PR TITLE
[INFRA-2487] Mark brakeman plugin as deprecated

### DIFF
--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -12,6 +12,8 @@ blackduck-hub = https://git.io/JfaQa
 # https://wiki.jenkins.io/display/JENKINS/Black+Duck+Vulnerability+Installer+Plugin
 blackduck-installer = https://wiki.jenkins.io/x/nYHHB
 blueocean-executor-info = https://issues.jenkins-ci.org/browse/JENKINS-56773
+# https://github.com/jenkinsci/brakeman-plugin/issues/23
+brakeman = https://git.io/JT2XI
 build-flow-extensions-plugin = https://groups.google.com/d/msg/jenkinsci-dev/YKfydxnpvyE/mMN7LNBoBgAJ
 build-flow-test-aggregator = https://groups.google.com/d/msg/jenkinsci-dev/YKfydxnpvyE/mMN7LNBoBgAJ
 build-flow-toolbox-plugin = https://groups.google.com/d/msg/jenkinsci-dev/YKfydxnpvyE/mMN7LNBoBgAJ


### PR DESCRIPTION
This will add a deprecation warning to https://plugins.jenkins.io/brakeman/ (and inside Jenkins) similar to https://plugins.jenkins.io/analysis-core/

It's a bit redundant, given the dependency, but cannot hurt. It also links to the issue that explains what users can do instead now (and will continue to show up even once distribution has been suspended for INFRA-2487).

@presidentbeef @uhafner 