### PR TITLE
Ignore spotinst version 2.0.26

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -510,3 +510,6 @@ nerrvana
 
 # Arbitrary file read vulnerability while bringing no real benefits, see https://www.jenkins.io/security/advisory/2020-10-08/#SECURITY-2046
 persona
+
+# Suppress a release with regression that causes node's computer to be null
+spotinst-2.0.26


### PR DESCRIPTION
Ignore spotinst version 2.0.26
This release update node details and by that causing Jenkins to reset its computer