### PR TITLE
[SECURITY-1520] Update warning for repository-connector

### DIFF
--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -7395,8 +7395,8 @@
     "url": "https://jenkins.io/security/advisory/2020-03-09/#SECURITY-1520",
     "versions": [
       {
-        "lastVersion": "1.2.6",
-        "pattern": ".*"
+        "lastVersion": "1.3.1",
+        "pattern": "([01])(|[.-].+)"
       }
     ]
   },


### PR DESCRIPTION
According to the maintainer, SECURITY-1520 is resolved in the 2.0.0 release of the plugin.