### PR TITLE
Remove app.io plugin from distribution

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -1,6 +1,7 @@
 # This file lists artifactId or artifactId-version values to hide in update center.
 
 AntepediaReporter-CI-plugin      # closed-souce plugin; removal confirmed with owner, Guillaume Rousseau
+appio                            # service discontinued. Alternative: https://plugins.jenkins.io/appetize/
 appthwack                        # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/AppThwack+Plugin
 assembla-oauth                   # renamed to assembla-auth https://groups.google.com/d/msg/jenkinsci-dev/TVz-D5etsUM/Knx9zXtEnSwJ
 assembla-jenkins                 # Renamed to assembla

--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -4,6 +4,8 @@
 # Additionally, this file allows referencing deprecation notices outside of (obsolete or non-existing) plugin documentation.
 # Shorten URLs if and only if the URLs are to github.com (git.io) or wiki.jenkins.io. Record the real URL in a comment.
 
+# https://github.com/jenkins-infra/update-center2/pull/465
+appio = https://git.io/JT9ZT
 # https://wiki.jenkins.io/display/JENKINS/AppThwack+Plugin
 appthwack = https://wiki.jenkins.io/x/cwchB
 assembla-oauth = https://groups.google.com/d/msg/jenkinsci-dev/TVz-D5etsUM/Knx9zXtEnSwJ


### PR DESCRIPTION
The app.io service was discontinued. Based on alternatives suggested in [a Quora thread](https://www.quora.com/What-is-a-good-alternative-to-replace-App-io-embedded-demo-pages-which-have-been-discontinued) the users of this plugin may be interested in using appetize.io and the [Appetize.io Jenkins Plugin](https://plugins.jenkins.io/appetize/) instead.