### PR TITLE
[INFRA-2487] Suspend analysis-core and all dependent plugins

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -512,5 +512,26 @@ nerrvana
 # Arbitrary file read vulnerability while bringing no real benefits, see https://www.jenkins.io/security/advisory/2020-10-08/#SECURITY-2046
 persona
 
+# INFRA-2487 -- suspend analysis-core and all plugins with a non-optional dependency on it
+analysis-collector
+analysis-core
+android-lint
+brakeman
+ccm
+CFLint
+checkstyle
+ci-game
+codeclimate-plugin
+codescanner
+cpptest
+DotCi-Plugins-Starter-Pack
+dry
+findbugs
+php
+pmd
+swamp
+tasks
+warnings
+
 # Suppress a release with regression that causes node's computer to be null
 spotinst-2.0.26

--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -4,6 +4,9 @@
 # Additionally, this file allows referencing deprecation notices outside of (obsolete or non-existing) plugin documentation.
 # Shorten URLs if and only if the URLs are to github.com (git.io) or wiki.jenkins.io. Record the real URL in a comment.
 
+analysis-collector = https://issues.jenkins-ci.org/browse/INFRA-2487
+analysis-core = https://issues.jenkins-ci.org/browse/INFRA-2487
+android-lint = https://issues.jenkins-ci.org/browse/INFRA-2487
 # https://github.com/jenkins-infra/update-center2/pull/465
 appio = https://git.io/JT9ZT
 # https://wiki.jenkins.io/display/JENKINS/AppThwack+Plugin
@@ -27,8 +30,12 @@ buildcoin-plugin = https://wiki.jenkins.io/x/KoyhAw
 buildheroes = https://wiki.jenkins.io/x/_AD8Aw
 # https://wiki.jenkins.io/display/JENKINS/Caroline+Plugin
 caroline = https://wiki.jenkins.io/x/AwOMAw
+ccm = https://issues.jenkins-ci.org/browse/INFRA-2487
+CFLint = https://issues.jenkins-ci.org/browse/INFRA-2487
+checkstyle = https://issues.jenkins-ci.org/browse/INFRA-2487
 chrome-frame-plugin = https://www.chromium.org/developers/how-tos/chrome-frame-getting-started
 # https://wiki.jenkins.io/display/JENKINS/CIFS-Publisher+Plugin
+ci-game = https://issues.jenkins-ci.org/browse/INFRA-2487
 cifs = https://wiki.jenkins.io/x/lwC2Ag
 # https://github.com/jenkinsci/clang-scanbuild-plugin/commit/a6d57b67f6fbd0a9893ecf6436c54ecb670d5829
 clang-scanbuild-plugin = https://git.io/JfaQr
@@ -40,21 +47,27 @@ cloudbees-disk-usage-simple-plugin = https://git.io/JfaQN
 cloudbees-enterprise-plugins = https://wiki.jenkins.io/x/3gX8Aw
 # https://wiki.jenkins.io/display/JENKINS/CloudBees+Registration+Plugin
 cloudbees-registration = https://wiki.jenkins.io/x/z4FLB
+codeclimate-plugin = https://issues.jenkins-ci.org/browse/INFRA-2487
 # https://github.com/jenkins-infra/update-center2/pull/299
+codescanner = https://issues.jenkins-ci.org/browse/INFRA-2487
 codescan = https://git.io/JfaQb
 # https://github.com/jenkinsci/configuration-as-code-plugin/releases/tag/configuration-as-code-1.18
 configuration-as-code-support = https://git.io/JfaHz
 # https://wiki.jenkins.io/display/JENKINS/CopyArchiver+Plugin
 copyarchiver = https://wiki.jenkins.io/x/ywJAAg
+cpptest = https://issues.jenkins-ci.org/browse/INFRA-2487
 # https://wiki.jenkins.io/display/JENKINS/CppUnit+Plugin
 cppunit = https://wiki.jenkins.io/x/6oE5Ag
 # https://github.com/jenkins-infra/update-center2/commit/e5a138873113d0e2d6af59d5699215a1835c15b7
 dockerhub = https://git.io/JfaQF
+DotCi-Plugins-Starter-Pack = https://issues.jenkins-ci.org/browse/INFRA-2487
+dry = https://issues.jenkins-ci.org/browse/INFRA-2487
 # https://wiki.jenkins.io/display/JENKINS/Emotional+Hudson+Plugin
 emotional-hudson = https://wiki.jenkins.io/x/C4DX
 # https://github.com/jenkins-infra/update-center2/pull/257
 external-scheduler = https://git.io/JfaQ5
 externalresource-dispatcher = https://groups.google.com/d/msg/jenkinsci-dev/YKfydxnpvyE/mMN7LNBoBgAJ
+findbugs = https://issues.jenkins-ci.org/browse/INFRA-2487
 # https://github.com/jenkinsci/fortify-cloudscan-plugin#deprecation-notice
 fortify-cloudscan-jenkins-plugin = https://git.io/JfhPD
 # https://wiki.jenkins.io/display/JENKINS/Gerrit+Plugin
@@ -108,8 +121,10 @@ origo-issue-notifier = https://wiki.jenkins.io/x/qgabAg
 paranoia = https://git.io/JfaQS
 # https://plugins.jenkins.io/perfectomobile/
 perfectomobile = https://developers.perfectomobile.com/display/PD/Legacy+%7C+Jenkins+plugin
+php = https://issues.jenkins-ci.org/browse/INFRA-2487
 # https://github.com/jenkinsci/pipeline-editor-plugin
 pipeline-editor = https://git.io/JfaQy
+pmd = https://issues.jenkins-ci.org/browse/INFRA-2487
 # https://github.com/jenkins-infra/update-center2/pull/42
 poll-mailbox-trigger = https://git.io/JfaQM
 # https://wiki.jenkins.io/display/JENKINS/Pretest+Commit+Plugin
@@ -133,6 +148,8 @@ setenv = https://wiki.jenkins.io/x/YAtSAg
 sonargraph-plugin = https://git.io/JJ5h1
 # https://wiki.jenkins.io/pages/viewpage.action?pageId=63930505
 sonatype-ci = https://wiki.jenkins.io/x/iYDPAw
+swamp = https://issues.jenkins-ci.org/browse/INFRA-2487
+tasks = https://issues.jenkins-ci.org/browse/INFRA-2487
 # https://wiki.jenkins.io/display/JENKINS/TEPCO+Plugin
 tepco = https://wiki.jenkins.io/x/zoBoAw
 # https://wiki.jenkins.io/display/JENKINS/TEPCO+Electric+Power+Usage+Widget
@@ -144,6 +161,7 @@ url-change-trigger = https://wiki.jenkins.io/x/BQBJ
 # https://github.com/jenkins-infra/update-center2/pull/302
 veracode-scanner = https://git.io/JfaQ6
 vessel = https://groups.google.com/d/msg/jenkinsci-dev/L34eAMMWA5o/-AxtRdGsAAAJ
+warnings = https://issues.jenkins-ci.org/browse/INFRA-2487
 # https://github.com/jenkinsci/xltestview-plugin/commit/ea034f9929b520e63b9ce15aed9bdb62354146cf
 xltest-plugin = https://git.io/JfaQK
 # https://wiki.jenkins.io/display/JENKINS/ZAProxy+Plugin


### PR DESCRIPTION
This will remove the plugins from update sites, and all instances with one of these plugins installed will show a deprecation message linking to INFRA-2487.

@uhafner @MarkEWaite @oleg-nenashev 