### PR TITLE
Stop overriding the expected validity duration of the signing cert

### DIFF
--- a/site/generate.sh
+++ b/site/generate.sh
@@ -67,8 +67,7 @@ unzip -q "$MAIN_DIR"/tmp/generator-$version.zip -d "$MAIN_DIR"/tmp/generator/
 function execute {
   # To use a locally built snapshot, use the following line instead:
   # java -Dfile.encoding=UTF-8 -jar target/update-center2-*-bin/update-center2-*.jar "$@"
-  java -DCERTIFICATE_MINIMUM_VALID_DAYS=14 -Dfile.encoding=UTF-8 -jar "$MAIN_DIR"/tmp/generator/update-center2-*.jar "$@"
-  # TODO once we have a new cert, no longer override the duration
+  java -Dfile.encoding=UTF-8 -jar "$MAIN_DIR"/tmp/generator/update-center2-*.jar "$@"
 }
 
 execute --dynamic-tier-list-file tmp/tiers.json


### PR DESCRIPTION
Part of the workaround when the cert expired the last time.

This should change the date the build will start failing next from 2021-04-02 to 2021-03-17. Then we'll need a new yearly cert based on the new root cert https://github.com/jenkins-infra/update-center2/tree/master/resources/certificates#jenkins-update-center-root-ca-2