### PR TITLE
[INFRA-2838] Block broken releases of nexus-jenkins-plugin

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -542,4 +542,4 @@ spotinst-2.0.26
 # INFRA-2838 - no pom published, causes update center generation to break
 nexus-jenkins-plugin-3.9.20201203-135942.e9f4ebc
 nexus-jenkins-plugin-3.9.20201203-151437.f2f6b16
-nexus-jenkins-plugin-3.9.20201203-120425.a87655e # useless pom
+nexus-jenkins-plugin-3.9.20201203-120425.a87655e

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -542,4 +542,4 @@ spotinst-2.0.26
 # INFRA-2838 - no pom published, causes update center generation to break
 nexus-jenkins-plugin-3.9.20201203-120425.a87655e
 nexus-jenkins-plugin-3.9.20201203-135942.e9f4ebc
-
+nexus-jenkins-plugin-3.9.20201203-151437.f2f6b16

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -538,3 +538,8 @@ warnings
 
 # Suppress a release with regression that causes node's computer to be null
 spotinst-2.0.26
+
+# INFRA-2838 - no pom published, causes update center generation to break
+nexus-jenkins-plugin-3.9.20201203-120425.a87655e
+nexus-jenkins-plugin-3.9.20201203-135942.e9f4ebc
+

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -540,6 +540,6 @@ warnings
 spotinst-2.0.26
 
 # INFRA-2838 - no pom published, causes update center generation to break
-nexus-jenkins-plugin-3.9.20201203-120425.a87655e
 nexus-jenkins-plugin-3.9.20201203-135942.e9f4ebc
 nexus-jenkins-plugin-3.9.20201203-151437.f2f6b16
+nexus-jenkins-plugin-3.9.20201203-120425.a87655e # useless pom


### PR DESCRIPTION
https://issues.jenkins.io/browse/INFRA-2838

The last 2 releases of nexus-jenkins-plugin don't have a pom file which causes update-center2 generation to break.

The next release back [3.9.20201203-120425.a87655e](https://repo.jenkins-ci.org/releases/org/sonatype/nexus/ci/nexus-jenkins-plugin/3.9.20201203-120425.a87655e/) has a pom file but no jar or sources, not sure if that needs blocking too

cc @whyjustin

p.s. where are the sources of this plugin? I can't find them and they aren't linked on the plugin site