### PR TITLE
Restore distribution of tics plugin with fixed dependencies

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -498,7 +498,12 @@ kubernetes-ci
 zap-pipeline
 
 # Depublishing for having a dependency on itself, causing JENKINS-63877
-tics
+tics-1.0
+tics-2020.3.0.0
+tics-2020.3.0.1
+tics-2020.3.0.2
+tics-2020.3.0.4
+tics-2020.3.0.6
 
 # 2.1 existed before
 qualys-api-security-2.1.0


### PR DESCRIPTION
`tics` version 2020.3.0.7 has been fixed to no longer have a dependency on itself.

https://issues.jenkins.io/browse/HOSTING-1021 has some related discussion.
