### PR TITLE
Add support for snapshot versions

### DIFF
--- a/site/generate-htaccess.sh
+++ b/site/generate-htaccess.sh
@@ -44,14 +44,14 @@ for (( i = n-1 ; i >= 0 ; i-- )) ; do
     cat <<EOF
 
 # If major > ${major} or major = ${major} and minor > ${minor} or major = ${major} and minor = ${minor} and patch >= ${patch}, use this LTS update site
-RewriteCond %{QUERY_STRING} ^.*version=(\d)\.(\d+)\.(\d+)$ [NC]
+RewriteCond %{QUERY_STRING} ^.*version=(\d)\.(\d+)\.(\d+)(|[-].*)$ [NC]
 RewriteCond %1 >${major}
 RewriteRule ^(update\-center.*\.(json|html)+) /dynamic-stable-${major}\.${minor}\.${patch}%{REQUEST_URI}? [NC,L,R]
-RewriteCond %{QUERY_STRING} ^.*version=(\d)\.(\d+)\.(\d+)$ [NC]
+RewriteCond %{QUERY_STRING} ^.*version=(\d)\.(\d+)\.(\d+)(|[-].*)$ [NC]
 RewriteCond %1 =${major}
 RewriteCond %2 >${minor}
 RewriteRule ^(update\-center.*\.(json|html)+) /dynamic-stable-${major}\.${minor}\.${patch}%{REQUEST_URI}? [NC,L,R]
-RewriteCond %{QUERY_STRING} ^.*version=(\d)\.(\d+)\.(\d+)$ [NC]
+RewriteCond %{QUERY_STRING} ^.*version=(\d)\.(\d+)\.(\d+)(|[-].*)$ [NC]
 RewriteCond %1 =${major}
 RewriteCond %2 =${minor}
 RewriteCond %3 >=${patch}
@@ -66,10 +66,10 @@ EOF
     cat <<EOF
 
 # If major > ${major} or major = ${major} and minor >= ${minor}, use this weekly update site
-RewriteCond %{QUERY_STRING} ^.*version=(\d)\.(\d+)$ [NC]
+RewriteCond %{QUERY_STRING} ^.*version=(\d)\.(\d+)(|[-].*)$ [NC]
 RewriteCond %1 >${major}
 RewriteRule ^(update\-center.*\.(json|html)+) /dynamic-${major}\.${minor}%{REQUEST_URI}? [NC,L,R]
-RewriteCond %{QUERY_STRING} ^.*version=(\d)\.(\d+)$ [NC]
+RewriteCond %{QUERY_STRING} ^.*version=(\d)\.(\d+)(|[-].*)$ [NC]
 RewriteCond %1 =${major}
 RewriteCond %2 >=${minor}
 RewriteRule ^(update\-center.*\.(json|html)+) /dynamic-${major}\.${minor}%{REQUEST_URI}? [NC,L,R]
@@ -83,10 +83,10 @@ cat <<EOF
 
 # First LTS update site (stable-$oldestStable) gets all older LTS releases
 
-RewriteCond %{QUERY_STRING} ^.*version=\d\.(\d+)\.\d+$ [NC]
+RewriteCond %{QUERY_STRING} ^.*version=\d\.(\d+)\.\d+(|[-].*)$ [NC]
 RewriteRule ^(update\-center.*\.(json|html)+) /dynamic-stable-${oldestStable}%{REQUEST_URI}? [NC,L,R]
 
-RewriteCond %{QUERY_STRING} ^.*version=\d\.(\d+)+$ [NC]
+RewriteCond %{QUERY_STRING} ^.*version=\d\.(\d+)+(|[-].*)$ [NC]
 RewriteRule ^(update\-center.*\.(json|html)+) /dynamic-${oldestWeekly}%{REQUEST_URI}? [NC,L,R]
 
 EOF

--- a/site/test/test.sh
+++ b/site/test/test.sh
@@ -62,13 +62,21 @@ test_redirect "$TEST_BASE_URL/stable/update-center.json" "$TEST_BASE_URL/dynamic
 test_redirect "$TEST_BASE_URL/stable/latestCore.txt" "$TEST_BASE_URL/dynamic-stable-2.222.1/latestCore.txt"
 
 test_redirect "$TEST_BASE_URL/update-center.json?version=2.246" "$TEST_BASE_URL/dynamic-2.240/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.246-SNAPSHOT" "$TEST_BASE_URL/dynamic-2.240/update-center.json"
 test_redirect "$TEST_BASE_URL/update-center.json?version=2.240" "$TEST_BASE_URL/dynamic-2.240/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.240-SNAPSHOT" "$TEST_BASE_URL/dynamic-2.240/update-center.json"
 test_redirect "$TEST_BASE_URL/update-center.json?version=2.225" "$TEST_BASE_URL/dynamic-2.223/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.225-SNAPSHOT" "$TEST_BASE_URL/dynamic-2.223/update-center.json"
 test_redirect "$TEST_BASE_URL/update-center.json?version=2.223" "$TEST_BASE_URL/dynamic-2.223/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.223-SNAPSHOT" "$TEST_BASE_URL/dynamic-2.223/update-center.json"
 test_redirect "$TEST_BASE_URL/update-center.json?version=2.222" "$TEST_BASE_URL/dynamic-2.222/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.222-SNAPSHOT" "$TEST_BASE_URL/dynamic-2.222/update-center.json"
 test_redirect "$TEST_BASE_URL/update-center.json?version=2.222.1" "$TEST_BASE_URL/dynamic-stable-2.222.1/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.222.1-SNAPSHOT" "$TEST_BASE_URL/dynamic-stable-2.222.1/update-center.json"
 test_redirect "$TEST_BASE_URL/update-center.json?version=2.55" "$TEST_BASE_URL/dynamic-2.172/update-center.json"
 test_redirect "$TEST_BASE_URL/update-center.json?version=2.6" "$TEST_BASE_URL/dynamic-2.172/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.55-SNAPSHOT" "$TEST_BASE_URL/dynamic-2.172/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.6-SNAPSHOT" "$TEST_BASE_URL/dynamic-2.172/update-center.json"
 
 
 test_redirect "$TEST_BASE_URL/update-center.json?version=2.204.1" "$TEST_BASE_URL/dynamic-stable-2.204.1/update-center.json"
@@ -76,11 +84,16 @@ test_redirect "$TEST_BASE_URL/update-center.json?version=2.204.2" "$TEST_BASE_UR
 test_redirect "$TEST_BASE_URL/update-center.json?version=2.204.3" "$TEST_BASE_URL/dynamic-stable-2.204.2/update-center.json"
 test_redirect "$TEST_BASE_URL/update-center.json?version=2.204.4" "$TEST_BASE_URL/dynamic-stable-2.204.4/update-center.json"
 test_redirect "$TEST_BASE_URL/update-center.json?version=2.204.5" "$TEST_BASE_URL/dynamic-stable-2.204.4/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.204.5-SNAPSHOT" "$TEST_BASE_URL/dynamic-stable-2.204.4/update-center.json"
 test_redirect "$TEST_BASE_URL/update-center.json?version=2.204.6" "$TEST_BASE_URL/dynamic-stable-2.204.6/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.204.6-SNAPSHOT" "$TEST_BASE_URL/dynamic-stable-2.204.6/update-center.json"
 test_redirect "$TEST_BASE_URL/update-center.json?version=2.204.7" "$TEST_BASE_URL/dynamic-stable-2.204.6/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.204.7-SNAPSHOT" "$TEST_BASE_URL/dynamic-stable-2.204.6/update-center.json"
 
 test_redirect "$TEST_BASE_URL/update-center.actual.json?version=2.222" "$TEST_BASE_URL/dynamic-2.222/update-center.actual.json"
 test_redirect "$TEST_BASE_URL/update-center.actual.json?version=2.222.1" "$TEST_BASE_URL/dynamic-stable-2.222.1/update-center.actual.json"
+test_redirect "$TEST_BASE_URL/update-center.actual.json?version=2.222-SNAPSHOT" "$TEST_BASE_URL/dynamic-2.222/update-center.actual.json"
+test_redirect "$TEST_BASE_URL/update-center.actual.json?version=2.222.1-SNAPSHOT" "$TEST_BASE_URL/dynamic-stable-2.222.1/update-center.actual.json"
 
 # No more redirects to tiers
 test_redirect "$TEST_BASE_URL/plugin-documentation-urls.json?version=2.222.1" "$TEST_BASE_URL/current/plugin-documentation-urls.json"
@@ -88,9 +101,13 @@ test_redirect "$TEST_BASE_URL/latestCore.txt?version=2.222.1" "$TEST_BASE_URL/cu
 
 # Jenkins 1.x gets the oldest update sites
 test_redirect "$TEST_BASE_URL/update-center.json?version=1.650" "$TEST_BASE_URL/dynamic-2.172/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=1.650-SNAPSHOT" "$TEST_BASE_URL/dynamic-2.172/update-center.json"
 test_redirect "$TEST_BASE_URL/update-center.json?version=1.580" "$TEST_BASE_URL/dynamic-2.172/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=1.580-SNAPSHOT" "$TEST_BASE_URL/dynamic-2.172/update-center.json"
 test_redirect "$TEST_BASE_URL/update-center.json?version=1.580.1" "$TEST_BASE_URL/dynamic-stable-2.164.2/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=1.580.1-SNAPSHOT" "$TEST_BASE_URL/dynamic-stable-2.164.2/update-center.json"
 test_redirect "$TEST_BASE_URL/update-center.json?version=2.46.1" "$TEST_BASE_URL/dynamic-stable-2.164.2/update-center.json"
+test_redirect "$TEST_BASE_URL/update-center.json?version=2.46.1-SNAPSHOT" "$TEST_BASE_URL/dynamic-stable-2.164.2/update-center.json"
 
 # This would probably be ideal: Drop down if older than newest LTS baseline, this instance isn't getting updates weekly
 test_redirect "$TEST_BASE_URL/update-center.json?version=2.200" "$TEST_BASE_URL/dynamic-2.199/update-center.json"


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/pull/5106#issuecomment-743093376 points out that redirects don't work for snapshot versions (any more?).