### PR TITLE
Suspend distribution of github-api 1.222

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -548,3 +548,6 @@ spotinst-2.0.26
 nexus-jenkins-plugin-3.9.20201203-135942.e9f4ebc
 nexus-jenkins-plugin-3.9.20201203-151437.f2f6b16
 nexus-jenkins-plugin-3.9.20201203-120425.a87655e
+
+# Typo in version, should have been 1.122
+github-api-1.222


### PR DESCRIPTION
@bitwiseman 

We have no good way to inform users they have a bad release installed. The usual resolution is to publish a new version. Versions that have been used are burned afterwards. My general advice in such cases is to accept the mistake and move on with the new version numbers; it's simply unfortunate that the versioning scheme used here makes that awkward.

Unsure what the best way forward is; if it is to suspend 1.222, it should be done ASAP.