### PR TITLE
Remove unnecessary overrides

### DIFF
--- a/resources/wiki-overrides.properties
+++ b/resources/wiki-overrides.properties
@@ -80,6 +80,3 @@ handlebars=https://github.com/jenkinsci/js-libs/blob/master/handlebars/README.md
 jquery-detached=https://github.com/jenkinsci/js-libs/blob/master/jquery-detached/README.md
 momentjs=https://github.com/jenkinsci/js-libs/blob/master/momentjs/README.md
 numeraljs=https://github.com/jenkinsci/js-libs/blob/master/numeraljs/README.md
-
-# Required until a newer version than 1.0.0 is released
-synopsys-polaris=https://github.com/jenkinsci/synopsys-polaris-plugin

--- a/resources/wiki-overrides.properties
+++ b/resources/wiki-overrides.properties
@@ -4,9 +4,6 @@
 # Required until a newer version than 1.1 is released
 archived-artifact-url-viewer=https://wiki.jenkins-ci.org/display/JENKINS/Archived+Artifact+Url+Viewer+PlugIn
 
-# Required until a newer version than 0.3 is released
-plugin-usage-plugin=https://wiki.jenkins-ci.org/display/JENKINS/Plugin+Usage+Plugin+(Community)
-
 # Required until a newer version than 1.1.0 is released
 skype-notifier=http://wiki.jenkins-ci.org/display/JENKINS/Skype+Plugin
 
@@ -17,19 +14,16 @@ chef-tracking=https://wiki.jenkins-ci.org/display/JENKINS/Chef+Tracking+Plugin
 chosen-views-tabbar=https://wiki.jenkins-ci.org/display/JENKINS/Chosen+Views+Tab+Bar
 ## Source seems to *not* be under jenkinsci org: https://github.com/ThoughtsOnMobile/cocoapods-jenkins-integration
 cocoapods-integration=https://wiki.jenkins-ci.org/display/JENKINS/CocoaPods+Plugin
-cucumber-reports=https://wiki.jenkins-ci.org/display/JENKINS/Cucumber+Reports+Plugin
 custom-view-tabs=https://wiki.jenkins-ci.org/display/JENKINS/Custom+View+Tabs+Plugin
 ## Currently has the <url> tag, BUT with a typo https://wiki.jenkins-ci.org/display/JENKINS/Deploment+Notification+Plugin
 deployment-notification=https://wiki.jenkins-ci.org/display/JENKINS/Deployment+Notification+Plugin
 database-drizzle=https://wiki.jenkins-ci.org/display/JENKINS/Drizzle(+MySQL)%20Database%20Plugin
 diskcheck=https://wiki.jenkins-ci.org/display/JENKINS/DiskCheck+Plugin
-docker-build-publish=https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Docker+Build+and+Publish+plugin
 dynamicparameter=https://wiki.jenkins-ci.org/display/JENKINS/Dynamic+Parameter+Plug-in
 figlet-buildstep=https://wiki.jenkins-ci.org/display/JENKINS/Figlet+plugin
 groovyaxis=https://wiki.jenkins-ci.org/display/JENKINS/GroovyAxis
 hckrnews=https://wiki.jenkins-ci.org/display/JENKINS/Hckrnews+Plugin
 icon-shim=https://wiki.jenkins-ci.org/display/JENKINS/Icon+Shim+Plugin
-image-gallery=https://wiki.jenkins-ci.org/display/JENKINS/Image+Gallery+Plugin
 jenkins-testswarm-plugin=https://wiki.jenkins-ci.org/display/JENKINS/testswarm-plugin
 job-direct-mail=https://wiki.jenkins-ci.org/display/JENKINS/Job+Direct+Mail+Plugin
 jython=https://wiki.jenkins-ci.org/display/JENKINS/Jython+Plugin
@@ -47,9 +41,6 @@ prereq-buildstep=http://wiki.jenkins-ci.org/display/JENKINS/Prerequisite+build+s
 project-health-report=https://wiki.jenkins-ci.org/display/JENKINS/Project+Health+Report+Plugin
 puppet=https://wiki.jenkins-ci.org/display/JENKINS/Puppet+Plugin
 ruby-runtime=https://wiki.jenkins-ci.org/display/JENKINS/Ruby+Runtime+Plugin
-serenity=https://wiki.jenkins-ci.org/display/JENKINS/Serenity+Plugin
-## Currently has the <url> tag, BUT with a typo http://http://wiki.jenkins-ci.org/display/JENKINS/Skytap+Cloud+CI+Plugin
-skytap=https://wiki.jenkins-ci.org/display/JENKINS/Skytap+Cloud+CI+Plugin
 # Macro leads to 404, sources are actually located at https://github.com/SonarSource/jenkins-sonar-plugin
 sonar=https://wiki.jenkins-ci.org/display/JENKINS/SonarQube+plugin
 started-by-envvar=https://wiki.jenkins-ci.org/display/JENKINS/Started-By+Environment+Variable+Plugin
@@ -62,13 +53,9 @@ vaddy-plugin=https://wiki.jenkins-ci.org/display/JENKINS/VAddy+Plugin
 violations=https://wiki.jenkins-ci.org/display/JENKINS/Violations
 xpdev=https://wiki.jenkins-ci.org/display/JENKINS/XP-Dev+Plugin
 
-# Workaround for INFRA-922
-absint-astree=https://wiki.jenkins-ci.org/pages/viewpage.action?pageId=99910545
-
 github-scm-trait-notification-context=https://wiki.jenkins.io/display/JENKINS/Github+Custom+Notification+Context+SCM+Behaviour+Plugin
 ca-apm=https://wiki.jenkins.io/display/JENKINS/CA+APM+Plugin+1.x
 comments-remover=https://wiki.jenkins.io/display/JENKINS/XComment.io+-+Comments+Remover+Plugin
-qtest=https://github.com/jenkinsci/qtest-plugin
 pipeline-model-declarative-agent=https://github.com/jenkinsci/pipeline-model-definition-plugin/blob/master/pipeline-model-declarative-agent/README.md
 
 # Deprecated plugins (replaced by warnings-ng)


### PR DESCRIPTION
These plugins have meanwhile released a version with either the exact same URL or a better one (moving docs to GitHub).