### PR TITLE
Replace obsolete terminology

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -28,7 +28,7 @@ The generator pulls information from:
 * Jenkins usage statistics (see `Popularities.java`)
   - latest plugin installation numbers for `popularity` entries in update center JSON
 * link:resources/[Local resource files in this repository]
-  - GitHub topic whitelist (`resources/allowed-github-topics.properties`)
+  - GitHub topic allowlist (`resources/allowed-github-topics.properties`)
   - Artifact ignore list (`resources/artifact-ignores.properties`)
   - Deprecations (`resources/deprecations.properties`)
   - Label assignments (`resources/label-definitions.properties`)
@@ -53,7 +53,7 @@ Two ways can be used to define these labels:
 ==== GitHub
 
 Add https://help.github.com/en/github/administering-a-repository/classifying-your-repository-with-topics[topics] to your GitHub repository.
-For a list of supported topics, see the link:src/main/resources/allowed-github-topics.properties[whitelist file] that contains all topics that can be set on GitHub repositories that will be reflected in update sites.
+For a list of supported topics, see the link:src/main/resources/allowed-github-topics.properties[resource file] that contains all topics that can be set on GitHub repositories that will be reflected in update sites.
 Topics can be set with or without the prefix `jenkins-`. If a topics has that prefix, it is removed first:
 To add the label `matrix` for your plugin, you would add either `matrix` or `jenkins-matrix` on your repository. 
 

--- a/resources/allowed-github-topics.properties
+++ b/resources/allowed-github-topics.properties
@@ -1,4 +1,4 @@
-# This file lists all the labels that are whitelisted
+# This file lists all the labels that can be used via GitHub repository topics
 
 # Plugin governance labels. https://jenkins.io/doc/developer/plugin-governance/
 adopt-this-plugin

--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -121,7 +121,7 @@
     "id": "SECURITY-441",
     "type": "plugin",
     "name": "pipeline-maven",
-    "message": "Arbitrary files from Jenkins master available in Pipeline by using the withMaven step",
+    "message": "Arbitrary files from Jenkins controller available in Pipeline by using the withMaven step",
     "url": "https://jenkins.io/security/advisory/2017-03-09/",
     "versions": [
       {
@@ -434,7 +434,7 @@
     "id": "SECURITY-348",
     "type": "plugin",
     "name": "envinject",
-    "message": "Low privilege users are able to read parts of some files on master",
+    "message": "Low privilege users are able to read parts of some files on Jenkins controller",
     "url": "https://jenkins.io/security/advisory/2017-04-10/",
     "versions": [
       {
@@ -1035,7 +1035,7 @@
     "id": "SECURITY-538",
     "type": "plugin",
     "name": "script-security",
-    "message": "Unsafe entries in default whitelist",
+    "message": "Unsafe methods in the default list of approved signatures",
     "url": "https://jenkins.io/security/advisory/2017-07-10/",
     "versions": [
       {
@@ -1875,7 +1875,7 @@
     "id": "SECURITY-519",
     "type": "plugin",
     "name": "liquibase-runner",
-    "message": "Plugin allows users to load arbitrary Java code into master JVM",
+    "message": "Plugin allows users to load arbitrary Java code into Jenkins controller JVM",
     "url": "https://jenkins.io/security/advisory/2018-03-26/#SECURITY-519",
     "versions": [
       {
@@ -1900,7 +1900,7 @@
     "id": "SECURITY-545",
     "type": "plugin",
     "name": "copy-to-slave",
-    "message": "Plugin allows access to arbitrary files on the Jenkins master file system",
+    "message": "Plugin allows access to arbitrary files on the Jenkins controller file system",
     "url": "https://jenkins.io/security/advisory/2018-03-26/#SECURITY-545",
     "versions": [
       {
@@ -4941,7 +4941,7 @@
     "id": "SECURITY-921",
     "type": "plugin",
     "name": "workflow-remote-loader",
-    "message": "Unsafe Script Security whitelist entry",
+    "message": "Unsafe entry in Script Security list of approved signatures",
     "url": "https://jenkins.io/security/advisory/2019-05-31/#SECURITY-921",
     "versions": [
       {

--- a/site/LAYOUT.md
+++ b/site/LAYOUT.md
@@ -157,7 +157,7 @@ stable/
 This is a copy of/symlink to the LTS update site for the most recent LTS baseline.
 The top-level `.htaccess` file forwards requests to the latest `stable-x.xxx` update site.
 
-It exists for compatibility with older LTS masters that explicitly configure this URL as their update center and is also used by the jenkins-infra/jenkins.io build to determine the current LTS release (`latestCore.txt`).
+It exists for compatibility with older LTS controllers that explicitly configure this URL as their update center and is also used by the jenkins-infra/jenkins.io build to determine the current LTS release (`latestCore.txt`).
 
 
 ## Experimental update site

--- a/src/main/java/io/jenkins/update_center/Main.java
+++ b/src/main/java/io/jenkins/update_center/Main.java
@@ -41,7 +41,7 @@ import io.jenkins.update_center.json.UpdateCenterRoot;
 import io.jenkins.update_center.util.JavaSpecificationVersion;
 import io.jenkins.update_center.wrappers.FilteringRepository;
 import io.jenkins.update_center.wrappers.TruncatedMavenRepository;
-import io.jenkins.update_center.wrappers.WhitelistMavenRepository;
+import io.jenkins.update_center.wrappers.AllowedArtifactsListMavenRepository;
 import org.kohsuke.args4j.ClassParser;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
@@ -102,8 +102,8 @@ public class Main {
     @Option(name = "--max-plugins", usage = "For testing purposes: Limit the number of plugins included to the specified number.")
     @CheckForNull public Integer maxPlugins;
 
-    @Option(name = "--whitelist-file", usage = "For testing purposes: A Java properties file whose keys are artifactIds and values are space separated lists of versions to allow, or '*' to allow all")
-    @CheckForNull public File whitelistFile;
+    @Option(name = "--allowed-artifacts-file", usage = "For testing purposes: A Java properties file whose keys are artifactIds and values are space separated lists of versions to allow, or '*' to allow all")
+    @CheckForNull public File allowedArtifactsListFile;
 
 
     /* Configure what kinds of output to generate */
@@ -294,12 +294,12 @@ public class Main {
             return;
         }
         MavenRepository repo = DefaultMavenRepositoryBuilder.getInstance();
-        if (whitelistFile != null) {
+        if (allowedArtifactsListFile != null) {
             final Properties properties = new Properties();
-            try (FileInputStream fis = new FileInputStream(whitelistFile)) {
+            try (FileInputStream fis = new FileInputStream(allowedArtifactsListFile)) {
                 properties.load(fis);
             }
-            repo = new WhitelistMavenRepository(properties).withBaseRepository(repo);
+            repo = new AllowedArtifactsListMavenRepository(properties).withBaseRepository(repo);
         }
         if (maxPlugins != null) {
             repo = new TruncatedMavenRepository(maxPlugins).withBaseRepository(repo);
@@ -316,12 +316,12 @@ public class Main {
     private MavenRepository createRepository() throws Exception {
 
         MavenRepository repo = DefaultMavenRepositoryBuilder.getInstance();
-        if (whitelistFile != null) {
+        if (allowedArtifactsListFile != null) {
             final Properties properties = new Properties();
-            try (FileInputStream fis = new FileInputStream(whitelistFile)) {
+            try (FileInputStream fis = new FileInputStream(allowedArtifactsListFile)) {
                 properties.load(fis);
             }
-            repo = new WhitelistMavenRepository(properties).withBaseRepository(repo);
+            repo = new AllowedArtifactsListMavenRepository(properties).withBaseRepository(repo);
         }
         if (maxPlugins != null) {
             repo = new TruncatedMavenRepository(maxPlugins).withBaseRepository(repo);


### PR DESCRIPTION
* Renamed the "whitelist" related code (mostly development helper) to more precise "allowed artifacts list"
* Updated security warning titles, in many cases updating to match an earlier change to jenkins-infra/jenkins.io (a bunch of "master" occurrences, mostly)
* Call the GitHub topics list an allowlist

What's left:

* `master` branch is still used for now
* Offensive labels are still defined and allowed, that's being cleaned up in in #353
* Any references to plugins whose ID includes any of these terms will continue to exist until they've been renamed

FYI @MarkEWaite 