### PR TITLE
[SECURITY-261] Limit affected versions to those creating the problem

### DIFF
--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -1812,12 +1812,12 @@
     "id": "SECURITY-261",
     "type": "plugin",
     "name": "ghprb",
-    "message": "GitHub access tokens stored in in build.xml",
+    "message": "GitHub access tokens stored in build.xml",
     "url": "https://jenkins.io/security/advisory/2018-03-26/#SECURITY-261",
     "versions": [
       {
         "lastVersion": "1.40.0",
-        "pattern": "(Affected even if up to date|.*)"
+        "pattern": "(1[.]([0-9]|[1-3][0-9]|40))(|[-.].*)"
       }
     ]
   },


### PR DESCRIPTION
A current limitation of the warnings system is that we cannot check whether a previous version of the plugin has been installed before, and only warn then. This can matter if the problem is data previously written to disk. So we just warn for every release.

These warnings lose their usefulness over time: At some point, probably a few months later, we can assume everyone who would be affected has been informed about it, or will never be informed (e.g. third party update sites). At the same time, active warnings can be confusing people, as indicated by https://github.com/jenkinsci/ghprb-plugin/issues/805#issuecomment-778330826

Another option would be to phrase such warnings differently to make it clear it's about data stored in releases before …; but at least in this case it's been long enough ago that the warning simply doesn't matter anymore.