### PR TITLE
Suppress instance-identity plugin releases

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -411,6 +411,9 @@ kubesphere-extension-0.2.0
 sshd-1.0
 sshd-1.1
 sshd-1.2
+# pending https://github.com/jenkinsci/jenkins/pull/5304
+instance-identity-3.0
+instance-identity-3.0.1
 
 # released twice, with different groupIds
 selfie-trigger-plugin-1.0


### PR DESCRIPTION
Pending https://github.com/jenkinsci/jenkins/pull/5304 @timja. Basically it is necessary to fully test the core patch _before_ releasing the plugin for the first time, using Incrementals.