### PR TITLE
Ignore ca-mat-performance-benchmarking-by-broadcom-1.2

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -554,3 +554,6 @@ nexus-jenkins-plugin-3.9.20201203-120425.a87655e
 
 # Typo in version, should have been 1.122
 github-api-1.222
+
+# Messed up file, probably from manual upload
+ca-mat-performance-benchmarking-by-broadcom-1.2


### PR DESCRIPTION
https://updates.jenkins.io/download/plugins/ca-mat-performance-benchmarking-by-broadcom/1.2/ca-mat-performance-benchmarking-by-broadcom.hpi is not even close to a valid HPI file. Probably related to the release trouble mentioned in https://github.com/jenkins-infra/repository-permissions-updater/pull/1844.

While this isn't advertised to instances, it still shows in https://updates.jenkins.io/download/plugins/ca-mat-performance-benchmarking-by-broadcom/

FYI @pessoarthur