### PR TITLE
[INFRA-2928] Add issue tracker metadata

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -27,6 +27,7 @@ The generator pulls information from:
   - plugin labels from repositories topics
 * Jenkins usage statistics (see `Popularities.java`)
   - latest plugin installation numbers for `popularity` entries in update center JSON
+* Plugin issue tracker metadata JSON file on `reports.jenkins.io` (see `IssueTrackerSource.java`)
 * link:resources/[Local resource files in this repository]
   - GitHub topic allowlist (`resources/allowed-github-topics.properties`)
   - Artifact ignore list (`resources/artifact-ignores.properties`)

--- a/src/main/java/io/jenkins/update_center/IssueTrackerSource.java
+++ b/src/main/java/io/jenkins/update_center/IssueTrackerSource.java
@@ -7,7 +7,6 @@ import org.apache.commons.io.IOUtils;
 
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.logging.Level;
@@ -16,8 +15,7 @@ import java.util.logging.Logger;
 public class IssueTrackerSource {
     private static final Logger LOGGER = Logger.getLogger(IssueTrackerSource.class.getName());
 
-    // TODO FIXME cannot have a dependency from update-center2 to ci.jenkins.io due to security publication process, and this also would lose metadata while ci.jenkins.io is down.
-    private static final String DATA_URL = Environment.getString("ISSUE_TRACKER_JSON_URL", "https://ci.jenkins.io/job/Infra/job/repository-permissions-updater/job/master/lastSuccessfulBuild/artifact/json/issues.index.json");
+    private static final String DATA_URL = Environment.getString("ISSUE_TRACKER_JSON_URL", "https://reports.jenkins.io/issues.index.json");
 
     private HashMap<String, List<IssueTracker>> pluginToIssueTrackers;
 

--- a/src/main/java/io/jenkins/update_center/IssueTrackerSource.java
+++ b/src/main/java/io/jenkins/update_center/IssueTrackerSource.java
@@ -1,0 +1,52 @@
+package io.jenkins.update_center;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.TypeReference;
+import io.jenkins.update_center.util.Environment;
+import org.apache.commons.io.IOUtils;
+
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class IssueTrackerSource {
+    private static final Logger LOGGER = Logger.getLogger(IssueTrackerSource.class.getName());
+
+    // TODO FIXME cannot have a dependency from update-center2 to ci.jenkins.io due to security publication process, and this also would lose metadata while ci.jenkins.io is down.
+    private static final String DATA_URL = Environment.getString("ISSUE_TRACKER_JSON_URL", "https://ci.jenkins.io/job/Infra/job/repository-permissions-updater/job/master/lastSuccessfulBuild/artifact/json/issues.index.json");
+
+    private HashMap<String, List<IssueTracker>> pluginToIssueTrackers;
+
+    public static class IssueTracker {
+        public String type;
+        public String viewUrl;
+        public String reportUrl;
+    }
+
+    private static IssueTrackerSource instance;
+
+    public static IssueTrackerSource getInstance() {
+        if (instance == null) {
+            instance = new IssueTrackerSource();
+            instance.init();
+        }
+        return instance;
+    }
+
+    private void init() {
+        try {
+            final String jsonData = IOUtils.toString(new URL(DATA_URL), StandardCharsets.UTF_8);
+            pluginToIssueTrackers = JSON.parseObject(jsonData, new TypeReference<HashMap<String, List<IssueTracker>>>(){}.getType());
+        } catch (Exception ex) {
+            LOGGER.log(Level.WARNING, ex.getMessage());
+        }
+    }
+
+    public List<IssueTracker> getIssueTrackers(String plugin) {
+        return pluginToIssueTrackers.computeIfAbsent(plugin, p -> null); // Don't advertise empty lists of issue trackers if there are none.
+    }
+}

--- a/src/main/java/io/jenkins/update_center/PluginUpdateCenterEntry.java
+++ b/src/main/java/io/jenkins/update_center/PluginUpdateCenterEntry.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 /**
  * An entry of a plugin in the update center metadata.

--- a/src/main/java/io/jenkins/update_center/PluginUpdateCenterEntry.java
+++ b/src/main/java/io/jenkins/update_center/PluginUpdateCenterEntry.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 /**
  * An entry of a plugin in the update center metadata.
@@ -116,6 +117,10 @@ public class PluginUpdateCenterEntry {
 
     public String getScm() throws IOException {
         return latestOffered.getScmUrl();
+    }
+
+    public List<IssueTrackerSource.IssueTracker> getIssueTrackers() {
+        return IssueTrackerSource.getInstance().getIssueTrackers(artifactId);
     }
 
     public String getRequiredCore() throws IOException {


### PR DESCRIPTION
See [INFRA-2928](https://issues.jenkins.io/browse/INFRA-2928). Supersedes (mostly) https://github.com/jenkins-infra/update-center2/pull/461. Downstream from https://github.com/jenkins-infra/repository-permissions-updater/pull/1806.

This adds a new entry `issueTrackers` to plugin metadata that closely resembles the upstream output format described in https://github.com/jenkins-infra/repository-permissions-updater#consuming-issue-trackers, except this drops the `reference` entry. `type` is kept to allow for UI labels related to that.

CC @halkeye @timja 