### PR TITLE
[INFRA-2929] Expose default branch in GitHub

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -25,6 +25,7 @@ The generator pulls information from:
 * GitHub (see `GitHubSource.java`)
   - determine source code repository that actually exists (sometimes metadata is wrong)
   - plugin labels from repositories topics
+  - default branch name
 * Jenkins usage statistics (see `Popularities.java`)
   - latest plugin installation numbers for `popularity` entries in update center JSON
 * Plugin issue tracker metadata JSON file on `reports.jenkins.io` (see `IssueTrackerSource.java`)

--- a/src/main/java/io/jenkins/update_center/GitHubSource.java
+++ b/src/main/java/io/jenkins/update_center/GitHubSource.java
@@ -53,9 +53,9 @@ public class GitHubSource {
         return "https://api.github.com/graphql";
     }
 
-    protected Map<String, List<String>> initializeOrganizationData(String organization) throws IOException {
+    protected void initializeOrganizationData(String organization) throws IOException {
         if (this.topicNames != null) {
-            return this.topicNames;
+            return; // Already initialized
         }
         this.topicNames = new HashMap<>();
         this.defaultBranches = new HashMap<>();
@@ -169,7 +169,6 @@ public class GitHubSource {
             }
         }
         LOGGER.log(Level.INFO, "Retrieved GitHub repo data");
-        return this.topicNames;
     }
 
     public List<String> getRepositoryTopics(String org, String repo) throws IOException { // TODO get rid of throws

--- a/src/main/java/io/jenkins/update_center/GitHubSource.java
+++ b/src/main/java/io/jenkins/update_center/GitHubSource.java
@@ -10,6 +10,7 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
 
+import javax.annotation.CheckForNull;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -32,6 +33,7 @@ public class GitHubSource {
 
     private Set<String> repoNames;
     private Map<String, List<String>> topicNames;
+    private Map<String, String> defaultBranches;
 
 
     private void init() {
@@ -56,6 +58,7 @@ public class GitHubSource {
             return this.topicNames;
         }
         this.topicNames = new HashMap<>();
+        this.defaultBranches = new HashMap<>();
         this.repoNames = new TreeSet<>(String::compareToIgnoreCase);
 
         LOGGER.log(Level.INFO, "Retrieving GitHub repo data...");
@@ -87,6 +90,9 @@ public class GitHubSource {
                             "      edges {\n" +
                             "        node {\n" +
                             "          name\n" +
+                            "          defaultBranchRef {\n" +
+                            "            name\n" +
+                            "          }\n" +
                             "          repositoryTopics(first:100) {\n" +
                             "            edges {\n" +
                             "              node {\n" +
@@ -137,6 +143,17 @@ public class GitHubSource {
                 JSONObject node = ((JSONObject) repository).getJSONObject("node");
                 String name = node.getString("name");
                 this.repoNames.add("https://github.com/" + organization + "/" + name);
+
+                if (node.optJSONObject("defaultBranchRef") == null) {
+                    // empty repo, so ignore everything else
+                    LOGGER.log(Level.WARNING, "Unexpected empty GitHub repository: " + name);
+                    continue;
+                }
+                final String defaultBranchName = node.getJSONObject("defaultBranchRef").getString("name");
+                if (defaultBranchName != null) {
+                    this.defaultBranches.put(organization + "/" + name, defaultBranchName);
+                }
+
                 if (node.getJSONObject("repositoryTopics").getJSONArray("edges").size() == 0) {
                     continue;
                 }
@@ -157,6 +174,11 @@ public class GitHubSource {
 
     public List<String> getRepositoryTopics(String org, String repo) throws IOException { // TODO get rid of throws
         return this.topicNames == null ? Collections.emptyList() : this.topicNames.getOrDefault(org + "/" + repo, Collections.emptyList());
+    }
+
+    @CheckForNull
+    public String getDefaultBranch(String org, String repo) {
+        return this.defaultBranches.get(org + "/" + repo);
     }
 
     private static GitHubSource instance;

--- a/src/main/java/io/jenkins/update_center/PluginUpdateCenterEntry.java
+++ b/src/main/java/io/jenkins/update_center/PluginUpdateCenterEntry.java
@@ -143,6 +143,10 @@ public class PluginUpdateCenterEntry {
         return latestOffered.getLabels();
     }
 
+    public String getDefaultBranch() throws IOException {
+        return latestOffered.getDefaultBranch();
+    }
+
     public List<HPI.Dependency> getDependencies() throws IOException {
         return latestOffered.getDependencies();
     }

--- a/src/test/resources/github_graphql_Y3Vyc29yOnYyOpHOA0oRaA==.txt
+++ b/src/test/resources/github_graphql_Y3Vyc29yOnYyOpHOA0oRaA==.txt
@@ -1,1 +1,1551 @@
-{"data":{"organization":{"repositories":{"pageInfo":{"startCursor":"Y3Vyc29yOnYyOpHOA0oTyg==","hasNextPage":false,"endCursor":"Y3Vyc29yOnYyOpHOA9QbUQ=="},"edges":[{"node":{"name":"quality-gates-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"workflow-step-api-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"workflow-api-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"workflow-support-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"workflow-basic-steps-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"workflow-durable-task-step-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"workflow-scm-step-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"pipeline-build-step-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"pipeline-input-step-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"pipeline-stage-step-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"workflow-cps-plugin","repositoryTopics":{"edges":[{"node":{"topic":{"name":"pipeline"}}}]}}},{"node":{"name":"workflow-job-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"workflow-multibranch-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"workflow-cps-global-lib-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"workflow-aggregator-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"pipeline-milestone-step-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"hp-quality-center-plugin","repositoryTopics":{"edges":[{"node":{"topic":{"name":"jenkins"}}},{"node":{"topic":{"name":"jenkins-pipeline"}}},{"node":{"topic":{"name":"jenkins-plugin"}}},{"node":{"topic":{"name":"quality"}}},{"node":{"topic":{"name":"testing"}}},{"node":{"topic":{"name":"test-automation"}}}]}}},{"node":{"name":"file-operations-plugin","repositoryTopics":{"edges":[{"node":{"topic":{"name":"jenkins"}}},{"node":{"topic":{"name":"jenkins-plugin"}}},{"node":{"topic":{"name":"file-operations"}}}]}}},{"node":{"name":"sonarqube-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"google-deployment-manager-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"sinatra-chef-builder-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"prometheus-plugin","repositoryTopics":{"edges":[{"node":{"topic":{"name":"prometheus"}}},{"node":{"topic":{"name":"prometheus-metrics"}}},{"node":{"topic":{"name":"jenkins"}}},{"node":{"topic":{"name":"plugin"}}}]}}},{"node":{"name":"imagecomparison-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"vncviewer-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"vncrecorder-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"react-material-icons","repositoryTopics":{"edges":[]}}},{"node":{"name":"boot-clj-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"github-pr-coverage-status-plugin","repositoryTopics":{"edges":[{"node":{"topic":{"name":"jenkins-plugin"}}},{"node":{"topic":{"name":"pull-requests"}}},{"node":{"topic":{"name":"coverage"}}},{"node":{"topic":{"name":"badge"}}}]}}},{"node":{"name":"scm-sqs-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"nomad-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"bmc-rpd-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"mq-notifier-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"waptpro-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"ibm-security-appscansource-scanner-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"htmlresource-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"rpi-build-status-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"codecommit-url-helper-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"srcclr-installer-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"jenkins-design-language","repositoryTopics":{"edges":[]}}},{"node":{"name":"environment-manager-tools-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"consul-kv-builder-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"inedo-proget-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"node-sharing-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"external-workspace-manager-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"permissive-script-security-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"build-pipeline-extension-layout-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"gitlab-oauth-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"ec2-fleet-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"community-gsoc2016-info","repositoryTopics":{"edges":[]}}},{"node":{"name":"codescan-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"cisco-spark-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"url-auth-sso-plugin","repositoryTopics":{"edges":[{"node":{"topic":{"name":"jenkins-plugin"}}},{"node":{"topic":{"name":"sso"}}},{"node":{"topic":{"name":"authentication"}}}]}}},{"node":{"name":"pubsub-light-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"sse-gateway-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"mdt-deployment-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"vsts-cd-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"plumber-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"cucumber-annotation-indexer","repositoryTopics":{"edges":[]}}},{"node":{"name":"bouncycastle-api-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"office-365-connector-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"spotinst-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"deadmanssnitch-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"groovy-pipeline-model","repositoryTopics":{"edges":[]}}},{"node":{"name":"jenkins-test-harness-htmlunit","repositoryTopics":{"edges":[]}}},{"node":{"name":"ws-ws-replacement-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"openshift-sync-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"blueocean-acceptance-test","repositoryTopics":{"edges":[]}}},{"node":{"name":"codebeamer-xunit-importer-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"parasoft-findings-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"view-cloner-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"kubernetes-ci-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"kubernetes-pipeline-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"aqua-security-scanner-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"restricted-register-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"nvm-wrapper-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"capability-annotation","repositoryTopics":{"edges":[]}}},{"node":{"name":"browserstack-integration-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"sonarqube-slack-pusher-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"run-selector-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"protecode-sc-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"composer-trigger-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"oic-auth-plugin","repositoryTopics":{"edges":[{"node":{"topic":{"name":"jenkins-plugin"}}},{"node":{"topic":{"name":"openid-connect"}}}]}}},{"node":{"name":"codehealth-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"extensivetesting-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"contrast-continuous-application-security-plugin","repositoryTopics":{"edges":[{"node":{"topic":{"name":"jenkins-plugin"}}},{"node":{"topic":{"name":"jenkins"}}},{"node":{"topic":{"name":"security"}}},{"node":{"topic":{"name":"security-tools"}}},{"node":{"topic":{"name":"vulnerabilities"}}}]}}},{"node":{"name":"testodyssey-execution-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"last-changes-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"fabric-beta-publisher-plugin","repositoryTopics":{"edges":[{"node":{"topic":{"name":"fabric-beta"}}},{"node":{"topic":{"name":"jenkins-plugin"}}},{"node":{"topic":{"name":"android"}}},{"node":{"topic":{"name":"apk"}}},{"node":{"topic":{"name":"continuous-delivery"}}},{"node":{"topic":{"name":"continuous-integration"}}}]}}},{"node":{"name":"resource-disposer-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"pipeline-maven-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"hpe-network-virtualization-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"influxdb-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"open-stf-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"gogs-webhook-plugin","repositoryTopics":{"edges":[{"node":{"topic":{"name":"gogs"}}},{"node":{"topic":{"name":"webhook"}}},{"node":{"topic":{"name":"jenkins"}}},{"node":{"topic":{"name":"gogs-webhook-plugin"}}}]}}},{"node":{"name":"cucumber-trend-report-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"openshift-login-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"azure-batch-parallel-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"codefresh-plugin","repositoryTopics":{"edges":[{"node":{"topic":{"name":"docker"}}},{"node":{"topic":{"name":"ci-cd"}}},{"node":{"topic":{"name":"jenkins-plugin"}}}]}}},{"node":{"name":"console-badge-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"statistics-gatherer-plugin","repositoryTopics":{"edges":[]}}}]}}}}
+{
+  "data": {
+    "organization": {
+      "repositories": {
+        "pageInfo": {
+          "startCursor": "Y3Vyc29yOnYyOpHOA0oRaA==",
+          "hasNextPage": false,
+          "endCursor": "Y3Vyc29yOnYyOpHOABHA7A=="
+        },
+        "edges": [
+          {
+            "node": {
+              "name": "gmaven",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "core-js",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "jelly",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "jexl",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "json-lib",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "maven-hudson-dev-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "netx",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "svnkit",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "trilead-ssh2",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "winstone",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "jetty"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "jetty-server"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "winstone"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "servlet-container"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "xstream",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "htmlunit",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "dom4j",
+              "defaultBranchRef": {
+                "name": "patched"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "jenkins.rb",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "adopt-this-plugin"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "git-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "git"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "scm"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "jenkins-clone-workspace-scm-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "Hudson-Gerrit-Plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "throttle-concurrent-builds-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "jmdns",
+              "defaultBranchRef": {
+                "name": "incoming"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "gerrit-trigger-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "hudson-notifo-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "rake-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "rubymetrics-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "priority-sorter-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "adopt-this-plugin"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "hudson-clearcase-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "jenkins",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "continuous-integration"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "continuous-delivery"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "continuous-deployment"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "java"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "groovy"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "jenkins"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "pipelines-as-code"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "devops"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "cicd"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "hacktoberfest"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "robot-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "testbed-ant-sample",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "testbed-anttest-sample",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "labmanager-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "plugin-blekkoPanel",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "maven-hpi-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "jenkins"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "maven-plugin"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "subversion-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "scm"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "adopt-this-plugin"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "WebSVN2-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "analysis-suite-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "analysis-regression-checker-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "VMWareLabManager-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "audit-trail-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "administrative-monitor"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "logging"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "audit"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "analysis-test-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "android-emulator-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "BlameSubversion-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "URLSCM-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "analysis-collector-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "deprecated"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "analysis-pom-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "SCTMExecutor-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "bamboo-notifier-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "backlog-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "analysis-core-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "deprecated"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "blame-upstream-commiters-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "artifactory-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "accurev-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "java"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "jenkins-accurev-plugin"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "accurev"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "jenkins-plugin"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "scm"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "adopt-this-plugin"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "bruceschneier-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "adopt-this-plugin"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "bazaar-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "active-directory-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "bitkeeper-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "backup-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "adopt-this-plugin"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "buggame-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "bugzilla-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "bulk-builder-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "batch-task-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "cas1-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "campfire-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "caroline-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "ccm-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "build-timeout-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "adopt-this-plugin"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "cccc-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "changelog-history-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "buckminster-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "chucknorris-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "ui"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "jenkins-plugin"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "fun"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "chuck-norris"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "chuck-norris-jokes"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "chuck-norris-facts"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "cifs-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "build-publisher-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "adopt-this-plugin"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "clearcase-release-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "codeplex-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "claim-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "collapsing-console-sections-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "jenkins-plugin"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "console"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "console-visualization"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "adopt-this-plugin"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "cmvc-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "codescanner-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "clearcase-ucm-baseline-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "conditional-upstream-trigger-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "concordionpresenter-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "codeviation-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "cmakebuilder-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "cmake"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "jenkins-plugin"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "jenkins-builder"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "pipeline"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "copy-to-slave-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "adopt-this-plugin"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "compact-columns-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "copyarchiver-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "covcomplplot-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "clover-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "coverage-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "collabnet-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "cppncss-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "adopt-this-plugin"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "copyartifact-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "jenkins-plugin"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "jenkins-builder"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "artifact"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "culprit-report-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "cron_column-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "configurationslicing-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "cppcheck-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "crowd-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "cpptest-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "adopt-this-plugin"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "createjobadvanced-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "dbCharts-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "cygpath-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "windows"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "cygwin"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/test/resources/github_graphql_null.txt
+++ b/src/test/resources/github_graphql_null.txt
@@ -1,1 +1,1551 @@
-{"data":{"organization":{"repositories":{"pageInfo":{"startCursor":"Y3Vyc29yOnYyOpHOAAJ45A==","hasNextPage":true,"endCursor":"Y3Vyc29yOnYyOpHOABHA7A=="},"edges":[{"node":{"name":"gmaven","repositoryTopics":{"edges":[]}}},{"node":{"name":"core-js","repositoryTopics":{"edges":[]}}},{"node":{"name":"jelly","repositoryTopics":{"edges":[]}}},{"node":{"name":"jexl","repositoryTopics":{"edges":[]}}},{"node":{"name":"json-lib","repositoryTopics":{"edges":[]}}},{"node":{"name":"maven-hudson-dev-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"netx","repositoryTopics":{"edges":[]}}},{"node":{"name":"svnkit","repositoryTopics":{"edges":[]}}},{"node":{"name":"trilead-ssh2","repositoryTopics":{"edges":[]}}},{"node":{"name":"winstone","repositoryTopics":{"edges":[]}}},{"node":{"name":"xstream","repositoryTopics":{"edges":[]}}},{"node":{"name":"htmlunit","repositoryTopics":{"edges":[]}}},{"node":{"name":"dom4j","repositoryTopics":{"edges":[]}}},{"node":{"name":"jenkins.rb","repositoryTopics":{"edges":[]}}},{"node":{"name":"git-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"jenkins-clone-workspace-scm-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"Hudson-Gerrit-Plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"throttle-concurrent-builds-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"jmdns","repositoryTopics":{"edges":[]}}},{"node":{"name":"gerrit-trigger-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"hudson-notifo-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"rake-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"rubymetrics-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"priority-sorter-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"hudson-clearcase-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"jenkins","repositoryTopics":{"edges":[{"node":{"topic":{"name":"continuous-integration"}}},{"node":{"topic":{"name":"continuous-delivery"}}},{"node":{"topic":{"name":"continuous-deployment"}}},{"node":{"topic":{"name":"java"}}},{"node":{"topic":{"name":"groovy"}}},{"node":{"topic":{"name":"jenkins"}}},{"node":{"topic":{"name":"pipelines-as-code"}}},{"node":{"topic":{"name":"devops"}}},{"node":{"topic":{"name":"hacktoberfest"}}},{"node":{"topic":{"name":"cicd"}}}]}}},{"node":{"name":"robot-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"testbed-ant-sample","repositoryTopics":{"edges":[]}}},{"node":{"name":"testbed-anttest-sample","repositoryTopics":{"edges":[]}}},{"node":{"name":"labmanager-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"plugin-blekkoPanel","repositoryTopics":{"edges":[]}}},{"node":{"name":"maven-hpi-plugin","repositoryTopics":{"edges":[{"node":{"topic":{"name":"jenkins"}}},{"node":{"topic":{"name":"maven-plugin"}}}]}}},{"node":{"name":"subversion-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"WebSVN2-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"analysis-suite-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"analysis-regression-checker-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"VMWareLabManager-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"audit-trail-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"analysis-test-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"android-emulator-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"BlameSubversion-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"URLSCM-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"analysis-collector-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"analysis-pom-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"SCTMExecutor-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"bamboo-notifier-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"backlog-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"analysis-core-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"blame-upstream-commiters-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"artifactory-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"accurev-plugin","repositoryTopics":{"edges":[{"node":{"topic":{"name":"java"}}},{"node":{"topic":{"name":"jenkins-accurev-plugin"}}},{"node":{"topic":{"name":"accurev"}}},{"node":{"topic":{"name":"jenkins-plugin"}}},{"node":{"topic":{"name":"scm"}}}]}}},{"node":{"name":"bruceschneier-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"bazaar-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"active-directory-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"bitkeeper-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"backup-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"buggame-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"bugzilla-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"bulk-builder-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"batch-task-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"cas1-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"campfire-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"caroline-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"ccm-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"build-timeout-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"cccc-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"changelog-history-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"buckminster-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"chucknorris-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"cifs-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"build-publisher-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"clearcase-release-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"codeplex-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"claim-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"collapsing-console-sections-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"cmvc-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"codescanner-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"clearcase-ucm-baseline-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"conditional-upstream-trigger-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"concordionpresenter-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"codeviation-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"cmakebuilder-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"copy-to-slave-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"compact-columns-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"copyarchiver-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"covcomplplot-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"clover-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"coverage-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"collabnet-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"cppncss-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"copyartifact-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"culprit-report-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"cron_column-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"configurationslicing-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"cppcheck-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"crowd-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"cpptest-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"createjobadvanced-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"dbCharts-plugin","repositoryTopics":{"edges":[]}}},{"node":{"name":"cygpath-plugin","repositoryTopics":{"edges":[]}}}]}}}}
+{
+  "data": {
+    "organization": {
+      "repositories": {
+        "pageInfo": {
+          "startCursor": "Y3Vyc29yOnYyOpHOAAehJA==",
+          "hasNextPage": true,
+          "endCursor": "Y3Vyc29yOnYyOpHOA0oRaA=="
+        },
+        "edges": [
+          {
+            "node": {
+              "name": "core-js",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "jelly",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "jexl",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "json-lib",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "maven-hudson-dev-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "netx",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "svnkit",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "trilead-ssh2",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "winstone",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "jetty"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "jetty-server"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "winstone"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "servlet-container"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "xstream",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "htmlunit",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "dom4j",
+              "defaultBranchRef": {
+                "name": "patched"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "jenkins.rb",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "adopt-this-plugin"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "git-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "git"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "scm"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "jenkins-clone-workspace-scm-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "Hudson-Gerrit-Plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "throttle-concurrent-builds-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "jmdns",
+              "defaultBranchRef": {
+                "name": "incoming"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "gerrit-trigger-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "hudson-notifo-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "rake-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "rubymetrics-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "priority-sorter-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "adopt-this-plugin"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "hudson-clearcase-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "jenkins",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "continuous-integration"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "continuous-delivery"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "continuous-deployment"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "java"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "groovy"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "jenkins"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "pipelines-as-code"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "devops"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "cicd"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "hacktoberfest"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "robot-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "testbed-ant-sample",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "testbed-anttest-sample",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "labmanager-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "plugin-blekkoPanel",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "maven-hpi-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "jenkins"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "maven-plugin"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "subversion-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "scm"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "adopt-this-plugin"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "WebSVN2-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "analysis-suite-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "analysis-regression-checker-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "VMWareLabManager-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "audit-trail-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "administrative-monitor"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "logging"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "audit"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "analysis-test-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "android-emulator-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "BlameSubversion-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "URLSCM-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "analysis-collector-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "deprecated"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "analysis-pom-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "SCTMExecutor-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "bamboo-notifier-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "backlog-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "analysis-core-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "deprecated"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "blame-upstream-commiters-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "artifactory-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "accurev-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "java"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "jenkins-accurev-plugin"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "accurev"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "jenkins-plugin"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "scm"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "adopt-this-plugin"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "bruceschneier-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "adopt-this-plugin"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "bazaar-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "active-directory-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "bitkeeper-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "backup-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "adopt-this-plugin"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "buggame-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "bugzilla-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "bulk-builder-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "batch-task-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "cas1-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "campfire-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "caroline-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "ccm-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "build-timeout-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "adopt-this-plugin"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "cccc-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "changelog-history-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "buckminster-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "chucknorris-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "ui"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "jenkins-plugin"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "fun"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "chuck-norris"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "chuck-norris-jokes"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "chuck-norris-facts"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "cifs-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "build-publisher-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "adopt-this-plugin"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "clearcase-release-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "codeplex-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "claim-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "collapsing-console-sections-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "jenkins-plugin"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "console"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "console-visualization"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "adopt-this-plugin"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "cmvc-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "codescanner-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "clearcase-ucm-baseline-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "conditional-upstream-trigger-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "concordionpresenter-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "codeviation-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "cmakebuilder-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "cmake"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "jenkins-plugin"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "jenkins-builder"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "pipeline"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "copy-to-slave-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "adopt-this-plugin"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "compact-columns-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "copyarchiver-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "covcomplplot-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "clover-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "coverage-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "collabnet-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "cppncss-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "adopt-this-plugin"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "copyartifact-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "jenkins-plugin"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "jenkins-builder"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "artifact"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "culprit-report-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "cron_column-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "configurationslicing-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "cppcheck-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "crowd-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "cpptest-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "adopt-this-plugin"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "createjobadvanced-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "dbCharts-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "cygpath-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": [
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "windows"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "topic": {
+                        "name": "cygwin"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": {
+              "name": "deploy-websphere-plugin",
+              "defaultBranchRef": {
+                "name": "master"
+              },
+              "repositoryTopics": {
+                "edges": []
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
See [INFRA-2929](https://issues.jenkins.io/browse/INFRA-2929).

Implements the rest of https://github.com/jenkins-infra/update-center2/pull/461 after https://github.com/jenkins-infra/update-center2/pull/492 takes care of issue tracker metadata via a different approach.