### PR TITLE
[INFRA-1502] Reduce certificate validity duration to 2 weeks

### DIFF
--- a/site/generate.sh
+++ b/site/generate.sh
@@ -67,7 +67,8 @@ unzip -q "$MAIN_DIR"/tmp/generator-$version.zip -d "$MAIN_DIR"/tmp/generator/
 function execute {
   # To use a locally built snapshot, use the following line instead:
   # java -Dfile.encoding=UTF-8 -jar target/update-center2-*-bin/update-center2-*.jar "$@"
-  java -Dfile.encoding=UTF-8 -jar "$MAIN_DIR"/tmp/generator/update-center2-*.jar "$@"
+  java -DCERTIFICATE_MINIMUM_VALID_DAYS=14 -Dfile.encoding=UTF-8 -jar "$MAIN_DIR"/tmp/generator/update-center2-*.jar "$@"
+  # TODO once we have a new cert, no longer override the duration
 }
 
 execute --dynamic-tier-list-file tmp/tiers.json


### PR DESCRIPTION
We're getting a new root cert soon for [INFRA-1502](https://issues.jenkins.io/browse/INFRA-1502), see https://www.jenkins.io/blog/2021/03/15/update-center-certificate-rotation/

Meanwhile, we need to accept a shorter validity duration by basically reverting #471.