### PR TITLE
Allow overriding max age for recent releases

### DIFF
--- a/site/generate.sh
+++ b/site/generate.sh
@@ -67,6 +67,9 @@ unzip -q "$MAIN_DIR"/tmp/generator-$version.zip -d "$MAIN_DIR"/tmp/generator/
 function execute {
   # To use a locally built snapshot, use the following line instead:
   # java -Dfile.encoding=UTF-8 -jar target/update-center2-*-bin/update-center2-*.jar "$@"
+  # Commonly provided system properties:
+  # -DRECENT_RELEASES_MAX_AGE_HOURS=30 in case the build failed for a while
+  # -DCERTIFICATE_MINIMUM_VALID_DAYS=14 in case the cert is about to expire
   java -DCERTIFICATE_MINIMUM_VALID_DAYS=14 -Dfile.encoding=UTF-8 -jar "$MAIN_DIR"/tmp/generator/update-center2-*.jar "$@"
   # TODO once we have a new cert, no longer override the duration
 }

--- a/src/main/java/io/jenkins/update_center/json/RecentReleasesRoot.java
+++ b/src/main/java/io/jenkins/update_center/json/RecentReleasesRoot.java
@@ -4,6 +4,7 @@ import com.alibaba.fastjson.annotation.JSONField;
 import io.jenkins.update_center.HPI;
 import io.jenkins.update_center.MavenRepository;
 import io.jenkins.update_center.Plugin;
+import io.jenkins.update_center.util.Environment;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -27,5 +28,5 @@ public class RecentReleasesRoot extends WithoutSignature {
         }
     }
 
-    private static final Duration MAX_AGE = Duration.ofHours(3);
+    private static final Duration MAX_AGE = Duration.ofHours(Environment.getInteger("RECENT_RELEASES_MAX_AGE_HOURS", 3));
 }


### PR DESCRIPTION
This will more easily allow overriding how far back `recent-releases.json` looks for artifacts to include.

Useful in cases where the build failed for a while, like today, and `recent-releases.json` wouldn't cover everything. Previously, this would require patching the application and creating a new release.

----

Alternatively (and this is what I was doing today) we can patch the application locally and just run it with

```
--generate-recent-releases --skip-update-center  --www-dir ./recent
```

only generating a more comprehensive `recent-releases.json` file; which is barely more work than passing a system property.