### PR TITLE
[INFRA-2937] Add support for generating platform-plugins.json

### DIFF
--- a/resources/platform-plugins.json
+++ b/resources/platform-plugins.json
@@ -1,0 +1,110 @@
+[
+  {
+    "category":"Organization and Administration",
+    "plugins": [
+      { "name": "dashboard-view" },
+      { "name": "cloudbees-folder", "suggested": true },
+      { "name": "configuration-as-code" },
+      { "name": "antisamy-markup-formatter", "suggested": true }
+    ]
+  },
+  {
+    "category":"Build Features",
+    "description":"Add general purpose features to your jobs",
+    "plugins": [
+      { "name": "build-name-setter" },
+      { "name": "build-timeout", "suggested": true },
+      { "name": "config-file-provider" },
+      { "name": "credentials-binding", "suggested": true },
+      { "name": "embeddable-build-status" },
+      { "name": "rebuild" },
+      { "name": "ssh-agent" },
+      { "name": "throttle-concurrents" },
+      { "name": "timestamper", "suggested": true },
+      { "name": "ws-cleanup", "suggested": true }
+    ]
+  },
+  {
+    "category":"Build Tools",
+    "plugins": [
+      { "name": "ant", "suggested": true },
+      { "name": "gradle", "suggested": true },
+      { "name": "msbuild" },
+      { "name": "nodejs" }
+    ]
+  },
+  {
+    "category":"Build Analysis and Reporting",
+    "plugins": [
+      { "name": "cobertura" },
+      { "name": "htmlpublisher" },
+      { "name": "junit" },
+      { "name": "warnings-ng" },
+      { "name": "xunit" }
+    ]
+  },
+  {
+    "category":"Pipelines and Continuous Delivery",
+    "plugins": [
+      { "name": "workflow-aggregator", "suggested": true, "added": "2.0" },
+      { "name": "github-branch-source", "suggested": true, "added": "2.0" },
+      { "name": "pipeline-github-lib", "suggested": true, "added": "2.0" },
+      { "name": "pipeline-stage-view", "suggested": true, "added": "2.0" },
+      { "name": "conditional-buildstep" },
+      { "name": "jenkins-multijob-plugin" },
+      { "name": "parameterized-trigger" },
+      { "name": "copyartifact" }
+    ]
+  },
+  {
+    "category":"Source Code Management",
+    "plugins": [
+      { "name": "bitbucket" },
+      { "name": "clearcase" },
+      { "name": "cvs" },
+      { "name": "git", "suggested": true },
+      { "name": "git-parameter" },
+      { "name": "github" },
+      { "name": "gitlab-plugin" },
+      { "name": "p4" },
+      { "name": "repo" },
+      { "name": "subversion" }
+    ]
+  },
+  {
+    "category":"Distributed Builds",
+    "plugins": [
+      { "name": "matrix-project" },
+      { "name": "ssh-slaves", "suggested": true },
+      { "name": "windows-slaves" }
+    ]
+  },
+  {
+    "category":"User Management and Security",
+    "plugins": [
+      { "name": "matrix-auth", "suggested": true },
+      { "name": "pam-auth", "suggested": true },
+      { "name": "ldap", "suggested": true },
+      { "name": "role-strategy" },
+      { "name": "active-directory" },
+      { "name": "authorize-project" }
+    ]
+  },
+  {
+    "category":"Notifications and Publishing",
+    "plugins": [
+      { "name": "email-ext", "suggested": true },
+      { "name": "emailext-template" },
+      { "name": "mailer", "suggested": true },
+      { "name": "publish-over-ssh" },
+      { "name": "ssh" }
+    ]
+  },
+  {
+    "category":"Languages",
+    "plugins": [
+      { "name": "locale"},
+      { "name": "localization-zh-cn"}
+    ]
+  }
+]

--- a/src/main/java/io/jenkins/update_center/Main.java
+++ b/src/main/java/io/jenkins/update_center/Main.java
@@ -27,6 +27,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.util.VersionNumber;
 import io.jenkins.lib.support_log_formatter.SupportLogFormatter;
 import io.jenkins.update_center.args4j.LevelOptionHandler;
+import io.jenkins.update_center.json.PlatformPluginsRoot;
 import io.jenkins.update_center.json.RecentReleasesRoot;
 import io.jenkins.update_center.json.TieredUpdateSitesGenerator;
 import io.jenkins.update_center.json.PluginDocumentationUrlsRoot;
@@ -130,6 +131,9 @@ public class Main {
 
     @Option(name = "--generate-recent-releases", usage = "Generate recent releases file (as input to targeted rsync etc.)")
     public boolean generateRecentReleases;
+
+    @Option(name = "--generate-platform-plugins", usage = "Generate platform-plugins.json (to override wizard suggestions)")
+    public boolean generatePlatformPlugins;
 
 
     /* Configure options modifying output */
@@ -266,6 +270,10 @@ public class Main {
             new RecentReleasesRoot(repo).write(new File(www, RECENT_RELEASES_JSON_FILENAME), prettyPrint);
         }
 
+        if (generatePlatformPlugins) {
+            new PlatformPluginsRoot(new File(Main.resourcesDir, PLATFORM_PLUGINS_RESOURCE_FILENAME)).writeWithSignature(new File(www, PLATFORM_PLUGINS_JSON_FILENAME), signer, prettyPrint);
+        }
+
         directoryTreeBuilder.build(repo);
     }
 
@@ -354,6 +362,8 @@ public class Main {
     private static final String PLUGIN_VERSIONS_JSON_FILENAME = "plugin-versions.json";
     private static final String RELEASE_HISTORY_JSON_FILENAME = "release-history.json";
     private static final String RECENT_RELEASES_JSON_FILENAME = "recent-releases.json";
+    private static final String PLATFORM_PLUGINS_JSON_FILENAME = "platform-plugins.json";
+    private static final String PLATFORM_PLUGINS_RESOURCE_FILENAME = "platform-plugins.json";
     private static final String EOL = System.getProperty("line.separator");
 
     private static final Logger LOGGER = Logger.getLogger(Main.class.getName());

--- a/src/main/java/io/jenkins/update_center/json/PlatformCategory.java
+++ b/src/main/java/io/jenkins/update_center/json/PlatformCategory.java
@@ -1,0 +1,13 @@
+package io.jenkins.update_center.json;
+
+import com.alibaba.fastjson.annotation.JSONField;
+
+import java.util.List;
+
+public class PlatformCategory {
+    @JSONField
+    public String category;
+
+    @JSONField
+    public List<PlatformPlugin> plugins;
+}

--- a/src/main/java/io/jenkins/update_center/json/PlatformPlugin.java
+++ b/src/main/java/io/jenkins/update_center/json/PlatformPlugin.java
@@ -1,0 +1,25 @@
+package io.jenkins.update_center.json;
+
+import com.alibaba.fastjson.annotation.JSONField;
+
+public class PlatformPlugin {
+
+    /**
+     * The plugin ID.
+     */
+    @JSONField
+    public String name;
+
+    /**
+     * In which version of Jenkins was this suggestion added?
+     * Used for upgrade wizard / similar functionality.
+     */
+    @JSONField
+    public String added;
+
+    /**
+     * Whether this plugin should be installed by default.
+     */
+    @JSONField
+    public boolean suggested;
+}

--- a/src/main/java/io/jenkins/update_center/json/PlatformPluginsRoot.java
+++ b/src/main/java/io/jenkins/update_center/json/PlatformPluginsRoot.java
@@ -1,0 +1,25 @@
+package io.jenkins.update_center.json;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.annotation.JSONField;
+import com.google.common.io.Files;
+import org.apache.commons.io.IOUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+
+public class PlatformPluginsRoot extends WithSignature {
+
+    @JSONField
+    public List<PlatformCategory> categories;
+
+    public PlatformPluginsRoot(File referenceFile) throws IOException {
+        try (Reader r = Files.newReader(referenceFile, StandardCharsets.UTF_8)) {
+            categories = Arrays.asList(JSON.parseObject(IOUtils.toString(r), PlatformCategory[].class));
+        }
+    }
+}


### PR DESCRIPTION
This adds support for serving a statically defined `platform-plugins.json` with a new wrapper object that includes a signature to basically serve as a PoC for a corresponding core change.

This does _not_ add support for generating such files to the wrapper scripts or `.htaccess`, but both changes combined prepare for a future change that provides such `platform-plugins.json` via update sites (that could then also distinguish content by reported client version).