### PR TITLE
Use RPU permissions for 'developers' instead of Maven metadata

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -28,7 +28,10 @@ The generator pulls information from:
   - default branch name
 * Jenkins usage statistics (see `Popularities.java`)
   - latest plugin installation numbers for `popularity` entries in update center JSON
-* Plugin issue tracker metadata JSON file on `reports.jenkins.io` (see `IssueTrackerSource.java`)
+* Various metadata JSON files on `reports.jenkins.io`
+  - Plugin issue tracker metadata JSON file, see `IssueTrackerSource.java`
+  - Plugin maintainer mapping JSON file, see `MaintainersSource.java`
+  - Maintainer info JSON file, see `MaintainersSource.java`
 * link:resources/[Local resource files in this repository]
   - GitHub topic allowlist (`resources/allowed-github-topics.properties`)
   - Artifact ignore list (`resources/artifact-ignores.properties`)

--- a/src/main/java/io/jenkins/update_center/HPI.java
+++ b/src/main/java/io/jenkins/update_center/HPI.java
@@ -89,16 +89,6 @@ public class HPI extends MavenArtifact {
         return new URL(StringUtils.removeEnd(DOWNLOADS_ROOT_URL, "/") + "/plugins/" + artifact.artifactId + "/" + version + "/" + artifact.artifactId + ".hpi");
     }
 
-    /**
-     * Who built this release?
-     *
-     * @return a string describing who built the release
-     * @throws IOException when a problem occurs obtaining the information from metadata
-     */
-    public String getBuiltBy() throws IOException {
-        return getManifestAttributes().getValue("Built-By");
-    }
-
     public String getRequiredJenkinsVersion() throws IOException {
         String v = getManifestAttributes().getValue("Jenkins-Version");
         if (v!=null)        return v;
@@ -188,37 +178,6 @@ public class HPI extends MavenArtifact {
             return null;
         }
         return trim;
-    }
-
-    private List<Developer> developers;
-
-    public List<Developer> getDevelopers() throws IOException {
-        if (developers == null) {
-            String devs = getManifestAttributes().getValue("Plugin-Developers");
-            if (devs == null || devs.trim().length() == 0) {
-                developers = Collections.emptyList();
-            } else {
-
-                List<Developer> r = new ArrayList<>();
-                Matcher m = DEVELOPERS_PATTERN.matcher(devs);
-                int totalMatched = 0;
-                while (m.find()) {
-                    final String name = fixEmptyAndTrim(m.group(1));
-                    final String id = fixEmptyAndTrim(m.group(2));
-                    final String email = fixEmptyAndTrim(m.group(3));
-                    if (name != null || id != null || email != null) {
-                        r.add(new Developer(name, id, email));
-                    }
-                    totalMatched += m.end() - m.start();
-                }
-                if (totalMatched < devs.length()) {
-                    // ignore and move on
-                    LOGGER.log(Level.INFO, "Unparsable developer info: '" + devs.substring(totalMatched) + "' for" + artifact.getGav());
-                }
-                developers = r;
-            }
-        }
-        return developers;
     }
 
     private String description;

--- a/src/main/java/io/jenkins/update_center/MaintainersSource.java
+++ b/src/main/java/io/jenkins/update_center/MaintainersSource.java
@@ -1,0 +1,147 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2021, Daniel Beck
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.jenkins.update_center;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.TypeReference;
+import com.alibaba.fastjson.annotation.JSONField;
+import io.jenkins.update_center.util.Environment;
+import org.apache.commons.io.IOUtils;
+
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+public class MaintainersSource {
+    private static final Logger LOGGER = Logger.getLogger(MaintainersSource.class.getName());
+
+    private static final String PLUGIN_MAINTAINERS_DATA_URL = Environment.getString("PLUGIN_MAINTAINERS_DATA_URL", "https://reports.jenkins.io/maintainers.index.json");
+    private static final String MAINTAINERS_INFO_URL = Environment.getString("MAINTAINERS_INFO_URL", "https://reports.jenkins.io/maintainers-info-report.json");
+
+    private Map<String, List<String>> pluginToMaintainers;
+    private Map<String, Maintainer> maintainerInfo;
+
+    /**
+     * Utility class for parsing JSON from {@link #MAINTAINERS_INFO_URL}.
+     */
+    private static class JsonMaintainer {
+        @JSONField
+        public String displayName;
+
+        @JSONField
+        public String name;
+
+        private Maintainer toMaintainer() {
+            return new Maintainer(name, displayName);
+        }
+    }
+
+    public static class Maintainer {
+        private final String name;
+        private final String developerId;
+
+        public Maintainer(String id, String name) {
+            this.developerId = id;
+            this.name = name;
+        }
+
+        public String getDeveloperId() {
+            return developerId;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    private static MaintainersSource instance;
+
+    public static MaintainersSource getInstance() {
+        if (instance == null) {
+            instance = new MaintainersSource();
+            instance.init();
+        }
+        return instance;
+    }
+
+    private void init() {
+        // Obtain maintainer info
+        try {
+            final String jsonData = IOUtils.toString(new URL(MAINTAINERS_INFO_URL), StandardCharsets.UTF_8);
+            final List<JsonMaintainer> rawMaintainersInfo = JSON.parseObject(jsonData, new TypeReference<List<JsonMaintainer>>() {}.getType());
+            maintainerInfo = new HashMap<>(rawMaintainersInfo.stream().map(m -> new AbstractMap.SimpleEntry<>(m.name, m.toMaintainer())).collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue)));
+        } catch (Exception ex) {
+            LOGGER.log(Level.WARNING, "Failed to process " + MAINTAINERS_INFO_URL, ex);
+            maintainerInfo = new HashMap<>();
+        }
+
+        // Obtain plugin/maintainers mapping
+        try {
+            final String jsonData = IOUtils.toString(new URL(PLUGIN_MAINTAINERS_DATA_URL), StandardCharsets.UTF_8);
+            pluginToMaintainers = JSON.parseObject(jsonData, new TypeReference<HashMap<String, List<String>>>() {
+            }.getType());
+        } catch (Exception ex) {
+            pluginToMaintainers = new HashMap<>();
+            LOGGER.log(Level.WARNING, "Failed to process" + PLUGIN_MAINTAINERS_DATA_URL, ex);
+        }
+    }
+
+    private List<String> getMaintainerIDs(ArtifactCoordinates plugin) {
+        final String ga = plugin.groupId + ":" + plugin.artifactId;
+        if (pluginToMaintainers.containsKey(ga)) {
+            return pluginToMaintainers.get(ga);
+        }
+        final List<String> candidateGAs = pluginToMaintainers.keySet().stream().filter(s -> s.endsWith(":" + plugin.artifactId)).collect(Collectors.toList());
+        switch (candidateGAs.size()) {
+            case 1:
+                final String key = candidateGAs.get(0);
+                LOGGER.log(Level.INFO, "Apparent mismatch of group IDs between permissions assignment: " + key + " and latest available release of plugin: " + plugin);
+                return pluginToMaintainers.get(key);
+            case 0:
+                // No maintainer information found
+                LOGGER.log(Level.INFO, "No maintainer information found for plugin: " + plugin);
+                return new ArrayList<>();
+            default: // 2+ candidate artifacts but none match exactly
+                LOGGER.log(Level.WARNING, "Multiple artifact IDs match, but none exactly. Will not provide maintainer information for plugin: " + plugin);
+                return new ArrayList<>();
+        }
+    }
+
+    /**
+     * Return the list of maintainers for the specified plugin.
+     *
+     * @param plugin the plugin.
+     * @return list of maintainers
+     */
+    public List<Maintainer> getMaintainers(ArtifactCoordinates plugin) {
+        return getMaintainerIDs(plugin).stream().map((String key) -> maintainerInfo.getOrDefault(key, new Maintainer(key, null))).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/io/jenkins/update_center/PluginUpdateCenterEntry.java
+++ b/src/main/java/io/jenkins/update_center/PluginUpdateCenterEntry.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.text.SimpleDateFormat;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -174,13 +173,8 @@ public class PluginUpdateCenterEntry {
         return trim;
     }
 
-    public List<HPI.Developer> getDevelopers() throws IOException {
-        final List<HPI.Developer> developers = latestOffered.getDevelopers();
-        final String builtBy = fixEmptyAndTrim(latestOffered.getBuiltBy());
-        if (developers.isEmpty() && builtBy != null) {
-            return Collections.singletonList(new HPI.Developer(null, builtBy, null));
-        }
-        return developers;
+    public List<MaintainersSource.Maintainer> getDevelopers() {
+        return MaintainersSource.getInstance().getMaintainers(this.latestOffered.artifact);
     }
 
     public String getExcerpt() throws IOException {

--- a/src/test/java/io/jenkins/update_center/MaintainersSourceTest.java
+++ b/src/test/java/io/jenkins/update_center/MaintainersSourceTest.java
@@ -1,0 +1,17 @@
+package io.jenkins.update_center;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class MaintainersSourceTest {
+    @Test
+    public void testContent() {
+        final List<MaintainersSource.Maintainer> maintainers = MaintainersSource.getInstance().getMaintainers(new ArtifactCoordinates("org.jenkins-ci.plugins", "matrix-auth", "unused", "unused", "unused"));
+        Assert.assertEquals("matrix-auth has one maintainer", 1, maintainers.size());
+        final MaintainersSource.Maintainer maintainer = maintainers.get(0);
+        Assert.assertEquals("User ID expected", "danielbeck", maintainer.getDeveloperId());
+        Assert.assertEquals("Display name expected", "Daniel Beck", maintainer.getName());
+    }
+}


### PR DESCRIPTION
Downstream of https://github.com/jenkins-infra/repository-permissions-updater/pull/1880 and https://github.com/jenkins-infra/infra-reports/pull/27

PR currently fails because of infra not yet having the ID/display name maintainer mapping because trusted.ci is down, so a test assertion fails.