### PR TITLE
[INFRA-1502] Perform validation with new root certificate

### DIFF
--- a/site/generate.sh
+++ b/site/generate.sh
@@ -92,7 +92,7 @@ mkdir -p "$WWW_ROOT_DIR"
 echo "# one update site per line" > "$MAIN_DIR"/tmp/args.lst
 
 function generate {
-  echo "--key $SECRET/update-center.key --certificate $SECRET/update-center.cert --root-certificate $( dirname "$0" )/../resources/certificates/jenkins-update-center-root-ca.crt $EXTRA_ARGS $*" >> "$MAIN_DIR"/tmp/args.lst
+  echo "--key $SECRET/update-center.key --certificate $SECRET/update-center.cert --root-certificate $( dirname "$0" )/../resources/certificates/jenkins-update-center-root-ca-2.crt $EXTRA_ARGS $*" >> "$MAIN_DIR"/tmp/args.lst
 }
 
 function sanity-check {


### PR DESCRIPTION
https://issues.jenkins.io/browse/INFRA-1502

The infra team switched over to the new root cert on Monday as announced on https://www.jenkins.io/blog/2021/03/15/update-center-certificate-rotation/ and since then `update-center2` builds have shown signature validation failures because it tries to validate a new yearly cert against the old root certificate 🤦 

This fixes that.

Applied it from this origin branch, and it works 🎉 

Delete after merge (but don't forget to switch the job back).