### PR TITLE
Note fix of SECURITY-1510 in backlog plugin

### DIFF
--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -7332,7 +7332,7 @@
     "versions": [
       {
         "lastVersion": "2.4",
-        "pattern": ".*"
+        "pattern": "(1|2[.][0-4])(|[.-].+)"
       }
     ]
   },


### PR DESCRIPTION
Apparently this is fixed in version 2.5 of the plugin.

I'll confirm that and then merge this PR.