### PR TITLE
Switch to using wget with convert links to make sure index.html has absolute urls to the jenkins.io assets

### DIFF
--- a/site/generate.sh
+++ b/site/generate.sh
@@ -195,5 +195,5 @@ popd
 
 # copy other static resource files
 echo '{}' > "$WWW_ROOT_DIR/uctest.json"
-curl --location --fail https://www.jenkins.io/templates/updates/index.html > "$WWW_ROOT_DIR/index.html"
+wget -q --convert-links -O "$WWW_ROOT_DIR/index.html" --convert-links https://www.jenkins.io/templates/updates/index.html
 cp -av "tmp/tiers.json" "$WWW_ROOT_DIR/tiers.json"


### PR DESCRIPTION
Fixes the rendering of https://updates.jenkins.io so that it will look like the usual page rather than looking like this:

![screencapture-updates-jenkins-io-2021-04-15-12_50_08-edit](https://user-images.githubusercontent.com/156685/114923218-cb60ed80-9de9-11eb-8d7d-ccc36ba7d5f9.png)
