### PR TITLE
Add generation timestamp to metadata

### DIFF
--- a/src/main/java/io/jenkins/update_center/json/WithSignature.java
+++ b/src/main/java/io/jenkins/update_center/json/WithSignature.java
@@ -23,6 +23,7 @@ import java.time.format.DateTimeFormatter;
  */
 public abstract class WithSignature {
     private JsonSignature signature;
+    private final String generationTimestamp = DateTimeFormatter.ISO_DATE_TIME.format(Instant.now().atOffset(ZoneOffset.UTC).withNano(0));
 
     @JSONField
     public JsonSignature getSignature() {
@@ -36,11 +37,7 @@ public abstract class WithSignature {
      * @return a string with the current date and time in the format YYYY-MM-DD'T'HH:mm:ss'Z'
      */
     public String getGenerationTimestamp() {
-        /*
-         * This just gets called once during serialization.
-         * We don't have to worry about this returning the same value every time.
-         */
-        return DateTimeFormatter.ISO_DATE_TIME.format(Instant.now().atOffset(ZoneOffset.UTC).withNano(0));
+        return generationTimestamp;
     }
 
     /**

--- a/src/main/java/io/jenkins/update_center/json/WithSignature.java
+++ b/src/main/java/io/jenkins/update_center/json/WithSignature.java
@@ -29,12 +29,18 @@ public abstract class WithSignature {
         return signature;
     }
 
+    /**
+     * Returns a string with the current date and time in ISO-8601 format.
+     * It doesn't have fractional seconds and the timezone is always UTC ('Z').
+     *
+     * @return a string with the current date and time in the format YYYY-MM-DD'T'HH:mm:ss'Z'
+     */
     public String getGenerationTimestamp() {
         /*
          * This just gets called once during serialization.
          * We don't have to worry about this returning the same value every time.
          */
-        return DateTimeFormatter.ISO_DATE_TIME.format(Instant.now().atOffset(ZoneOffset.UTC));
+        return DateTimeFormatter.ISO_DATE_TIME.format(Instant.now().atOffset(ZoneOffset.UTC).withNano(0));
     }
 
     /**

--- a/src/main/java/io/jenkins/update_center/json/WithSignature.java
+++ b/src/main/java/io/jenkins/update_center/json/WithSignature.java
@@ -29,7 +29,11 @@ public abstract class WithSignature {
         return signature;
     }
 
-    public String getDate() {
+    public String getGenerationTimestamp() {
+        /*
+         * This just gets called once during serialization.
+         * We don't have to worry about this returning the same value every time.
+         */
         return DateTimeFormatter.ISO_DATE_TIME.format(Instant.now().atOffset(ZoneOffset.UTC));
     }
 

--- a/src/main/java/io/jenkins/update_center/json/WithSignature.java
+++ b/src/main/java/io/jenkins/update_center/json/WithSignature.java
@@ -14,6 +14,9 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.security.GeneralSecurityException;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 
 /**
  * Support generation of JSON output with included checksum + signatures block for the same JSON output.
@@ -24,6 +27,10 @@ public abstract class WithSignature {
     @JSONField
     public JsonSignature getSignature() {
         return signature;
+    }
+
+    public String getDate() {
+        return DateTimeFormatter.ISO_DATE_TIME.format(Instant.now().atOffset(ZoneOffset.UTC));
     }
 
     /**

--- a/src/test/java/io/jenkins/update_center/TimestampTest.java
+++ b/src/test/java/io/jenkins/update_center/TimestampTest.java
@@ -1,0 +1,25 @@
+package io.jenkins.update_center;
+
+import io.jenkins.update_center.json.WithSignature;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+public class TimestampTest {
+    @Test
+    public void checkTimestamp() throws Exception {
+        WithSignature w = new WithSignature() {
+        };
+
+        String timestamp = w.getGenerationTimestamp();
+
+        Assert.assertTrue("format as expected", timestamp.matches("^202[0-9][-][0-9]{2}[-][0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$"));
+
+        Instant parsed = Instant.parse(timestamp);
+
+        Assert.assertTrue("before now", parsed.isBefore(Instant.now()));
+        Assert.assertTrue("very recent", parsed.isAfter(Instant.now().minus(1, ChronoUnit.SECONDS)));
+    }
+}

--- a/src/test/java/io/jenkins/update_center/TimestampTest.java
+++ b/src/test/java/io/jenkins/update_center/TimestampTest.java
@@ -15,7 +15,7 @@ public class TimestampTest {
 
         String timestamp = w.getGenerationTimestamp();
 
-        Assert.assertTrue("format as expected", timestamp.matches("^202[0-9][-][0-9]{2}[-][0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$"));
+        Assert.assertTrue("format as expected", timestamp.matches("^202[0-9][-][0-9]{2}[-][0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"));
 
         Instant parsed = Instant.parse(timestamp);
 

--- a/src/test/java/io/jenkins/update_center/TimestampTest.java
+++ b/src/test/java/io/jenkins/update_center/TimestampTest.java
@@ -21,5 +21,9 @@ public class TimestampTest {
 
         Assert.assertTrue("before now", parsed.isBefore(Instant.now()));
         Assert.assertTrue("very recent", parsed.isAfter(Instant.now().minus(1, ChronoUnit.SECONDS)));
+
+        String timestamp2 = w.getGenerationTimestamp();
+        Assert.assertEquals("Doesn't change over time", timestamp, timestamp2);
+
     }
 }


### PR DESCRIPTION
This will allow consumers to figure out if they get outdated data. We could even use it for an infra probe given recent trusted.ci stability problems 😓

Output (excerpt):

```
{
  "connectionCheckUrl": "http://www.google.com/",
  "core": {
    "buildDate": "Apr 20, 2021",
    "name": "core",
    "sha1": "4CUREvEyDp+w5LnceNb5v4Z25ak=",
    "sha256": "nBz97VAlE/o1eAcLDEynxGE6eKvxhI1Ug7DvAsE0J8g=",
    "url": "https://updates.jenkins.io/download/war/2.289/jenkins.war",
    "version": "2.289"
  },
  "deprecations": {
    ...
  },
  "generationTimestamp": "2021-04-26T19:08:45.177Z",
```