### PR TITLE
Note SECURITY-832 being fixed in snsnotify 2.0

### DIFF
--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -4225,7 +4225,7 @@
     "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-832",
     "versions": [
       {
-        "pattern": ".*"
+        "pattern": "1(|[.-].+)"
       }
     ]
   },


### PR DESCRIPTION
The maintainer filed [SECURITY-2354](https://issues.jenkins.io/browse/SECURITY-2354) and informed us there that this was fixed.