### PR TITLE
Suspend blitz.io plugin (service discontinued)

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -15,6 +15,7 @@ binary-deployer                  # removal requested by alecharp: this plugin wa
 blackduck-installer              # "This plugin is no longer supported and should not be used." -- https://wiki.jenkins-ci.org/display/JENKINS/Black+Duck+Vulnerability+Installer+Plugin
 blackduck-hub                    # End of life.  Replaced with Detect. 
 blitz.io-jenkins                 # renamed to blitz_io-jenkins
+blitz_io-jenkins                 # service discontinued: https://en.wikipedia.org/wiki/Blitz_(software)
 build-node-column                # superseded by Extra Columns Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Build+Node+Column+Plugin
 buildcoin-plugin                 # service discontinued: https://github.com/github/github-services/pull/538 -- https://wiki.jenkins-ci.org/display/JENKINS/Buildcoin+Plugin
 buildheroes                      # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Buildheroes

--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -19,6 +19,8 @@ blackduck-hub = https://git.io/JfaQa
 # https://wiki.jenkins.io/display/JENKINS/Black+Duck+Vulnerability+Installer+Plugin
 blackduck-installer = https://wiki.jenkins.io/x/nYHHB
 blueocean-executor-info = https://issues.jenkins.io/browse/JENKINS-56773
+# https://github.com/jenkins-infra/update-center2/pull/521
+blitz_io-jenkins = https://git.io/J3d1Y
 # https://github.com/jenkinsci/brakeman-plugin/issues/23
 brakeman = https://git.io/JT2XI
 build-flow-extensions-plugin = https://groups.google.com/d/msg/jenkinsci-dev/YKfydxnpvyE/mMN7LNBoBgAJ

--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -18,9 +18,9 @@ azure-iot-edge = https://git.io/JtOjd
 blackduck-hub = https://git.io/JfaQa
 # https://wiki.jenkins.io/display/JENKINS/Black+Duck+Vulnerability+Installer+Plugin
 blackduck-installer = https://wiki.jenkins.io/x/nYHHB
-blueocean-executor-info = https://issues.jenkins.io/browse/JENKINS-56773
 # https://github.com/jenkins-infra/update-center2/pull/521
 blitz_io-jenkins = https://git.io/J3d1Y
+blueocean-executor-info = https://issues.jenkins.io/browse/JENKINS-56773
 # https://github.com/jenkinsci/brakeman-plugin/issues/23
 brakeman = https://git.io/JT2XI
 build-flow-extensions-plugin = https://groups.google.com/d/msg/jenkinsci-dev/YKfydxnpvyE/mMN7LNBoBgAJ


### PR DESCRIPTION
The service was shut down in 2018, making the plugin redundant.