### PR TITLE
Add deprecation links for suspended plugins

### DIFF
--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -59,6 +59,7 @@ codescan = https://git.io/JfaQb
 configuration-as-code-support = https://git.io/JfaHz
 # https://wiki.jenkins.io/display/JENKINS/CopyArchiver+Plugin
 copyarchiver = https://wiki.jenkins.io/x/ywJAAg
+copy-to-slave = https://jenkins.io/security/advisory/2018-03-26/
 cpptest = https://issues.jenkins.io/browse/INFRA-2487
 # https://wiki.jenkins.io/display/JENKINS/CppUnit+Plugin
 cppunit = https://wiki.jenkins.io/x/6oE5Ag
@@ -66,6 +67,7 @@ cppunit = https://wiki.jenkins.io/x/6oE5Ag
 dockerhub = https://git.io/JfaQF
 DotCi-Plugins-Starter-Pack = https://issues.jenkins.io/browse/INFRA-2487
 dry = https://issues.jenkins.io/browse/INFRA-2487
+dynamicparameter = https://jenkins.io/security/advisory/2017-04-10/
 # https://wiki.jenkins.io/display/JENKINS/Emotional+Hudson+Plugin
 emotional-hudson = https://wiki.jenkins.io/x/C4DX
 # https://github.com/jenkins-infra/update-center2/pull/257
@@ -84,6 +86,7 @@ gitorious = https://wiki.jenkins.io/x/ngDiAw
 google-desktop-gadget = https://wiki.jenkins.io/x/E4A3AQ
 # https://wiki.jenkins.io/display/JENKINS/Google+Code+Plugin
 googlecode = https://wiki.jenkins.io/x/DQC7
+grails = https://jenkins.io/security/advisory/2017-04-10/
 # https://wiki.jenkins.io/display/JENKINS/Hall+Plugin
 hall-jenkins = https://wiki.jenkins.io/x/qQghB
 # https://wiki.jenkins.io/display/JENKINS/HockeyApp+Plugin
@@ -101,8 +104,14 @@ jenkow-activiti-designer = https://wiki.jenkins.io/x/ngnqAw
 jenkow-activiti-explorer = https://wiki.jenkins.io/x/yQH8Aw
 # https://wiki.jenkins.io/display/JENKINS/Jenkow+Plugin
 jenkow-plugin = https://wiki.jenkins.io/x/WIuhAw
+# https://github.com/jenkins-infra/update-center2/pull/21
+jshint-checkstyle = https://git.io/JsmW2
 # https://github.com/jenkins-infra/update-center2/pull/94
 kanboard-publisher = https://git.io/JfaQH
+kubernetes-ci = https://jenkins.io/security/advisory/2020-07-02
+kubernetes-pipeline-arquillian-steps = https://jenkins.io/security/advisory/2019-09-25/
+kubernetes-pipeline-aggregator = https://jenkins.io/security/advisory/2019-09-25/
+kubernetes-pipeline-steps = https://jenkins.io/security/advisory/2019-09-25/
 # https://wiki.jenkins.io/display/JENKINS/M2+Extra+Steps+Plugin
 m2-extra-steps = https://wiki.jenkins.io/x/FIc5Ag
 # https://wiki.jenkins.io/display/JENKINS/CloudBees+Cloud+Connector+Plugin
@@ -125,7 +134,12 @@ origo-issue-notifier = https://wiki.jenkins.io/x/qgabAg
 paranoia = https://git.io/JfaQS
 # https://plugins.jenkins.io/perfectomobile/
 perfectomobile = https://developers.perfectomobile.com/display/PD/Legacy+%7C+Jenkins+plugin
+perforce = https://jenkins.io/security/advisory/2018-03-26/
+persona = https://jenkins.io/security/advisory/2020-10-08
 php = https://issues.jenkins.io/browse/INFRA-2487
+# https://github.com/jenkins-infra/update-center2/pull/384
+play-autotest-plugin = https://git.io/JsmWA
+pipeline-classpath = https://jenkins.io/security/advisory/2017-03-20
 # https://github.com/jenkinsci/pipeline-editor-plugin
 pipeline-editor = https://git.io/JfaQy
 pmd = https://issues.jenkins.io/browse/INFRA-2487
@@ -144,6 +158,7 @@ scis-ad = https://git.io/JfaQX
 scm-branch-pr-filter = https://issues.jenkins.io/browse/INFRA-1358
 # https://github.com/jenkins-infra/update-center2/pull/324
 SCTMExecutor = https://git.io/JfaQP
+scripttrigger = https://jenkins.io/security/advisory/2017-04-10/
 # https://wiki.jenkins.io/display/JENKINS/Build+Secret+Plugin
 secret = https://wiki.jenkins.io/x/9ghSAg
 # https://wiki.jenkins.io/display/JENKINS/Setenv+Plugin
@@ -152,9 +167,11 @@ setenv = https://wiki.jenkins.io/x/YAtSAg
 sonargraph-plugin = https://git.io/JJ5h1
 # https://wiki.jenkins.io/pages/viewpage.action?pageId=63930505
 sonatype-ci = https://wiki.jenkins.io/x/iYDPAw
+svn-tag = https://jenkins.io/security/advisory/2017-04-10/
 swamp = https://issues.jenkins.io/browse/INFRA-2487
 tasks = https://issues.jenkins.io/browse/INFRA-2487
 # https://wiki.jenkins.io/display/JENKINS/TEPCO+Plugin
+tfs = https://issues.jenkins.io/browse/INFRA-2751
 tepco = https://wiki.jenkins.io/x/zoBoAw
 # https://wiki.jenkins.io/display/JENKINS/TEPCO+Electric+Power+Usage+Widget
 tepco-epuw = https://wiki.jenkins.io/x/vohoAw
@@ -168,5 +185,7 @@ vessel = https://groups.google.com/d/msg/jenkinsci-dev/L34eAMMWA5o/-AxtRdGsAAAJ
 warnings = https://issues.jenkins.io/browse/INFRA-2487
 # https://github.com/jenkinsci/xltestview-plugin/commit/ea034f9929b520e63b9ce15aed9bdb62354146cf
 xltest-plugin = https://git.io/JfaQK
+xtrigger = https://jenkins.io/security/advisory/2017-04-10/
+zap-pipeline = https://www.jenkins.io/security/advisory/2020-07-02
 # https://wiki.jenkins.io/display/JENKINS/ZAProxy+Plugin
 zaproxy = https://wiki.jenkins.io/x/JgCsB

--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -23,9 +23,10 @@ blitz_io-jenkins = https://git.io/J3d1Y
 blueocean-executor-info = https://issues.jenkins.io/browse/JENKINS-56773
 # https://github.com/jenkinsci/brakeman-plugin/issues/23
 brakeman = https://git.io/JT2XI
-build-flow-extensions-plugin = https://groups.google.com/d/msg/jenkinsci-dev/YKfydxnpvyE/mMN7LNBoBgAJ
-build-flow-test-aggregator = https://groups.google.com/d/msg/jenkinsci-dev/YKfydxnpvyE/mMN7LNBoBgAJ
-build-flow-toolbox-plugin = https://groups.google.com/d/msg/jenkinsci-dev/YKfydxnpvyE/mMN7LNBoBgAJ
+build-flow-extensions-plugin = https://www.jenkins.io/security/plugins/#suspensions
+build-flow-test-aggregator = https://www.jenkins.io/security/plugins/#suspensions
+build-flow-toolbox-plugin = https://www.jenkins.io/security/plugins/#suspensions
+build-flow-plugin = https://www.jenkins.io/security/plugins/#suspensions
 # https://wiki.jenkins.io/display/JENKINS/Build+Node+Column+Plugin
 build-node-column = https://wiki.jenkins.io/x/1QiMAw
 # https://wiki.jenkins.io/display/JENKINS/Buildcoin+Plugin
@@ -59,7 +60,7 @@ codescan = https://git.io/JfaQb
 configuration-as-code-support = https://git.io/JfaHz
 # https://wiki.jenkins.io/display/JENKINS/CopyArchiver+Plugin
 copyarchiver = https://wiki.jenkins.io/x/ywJAAg
-copy-to-slave = https://jenkins.io/security/advisory/2018-03-26/
+copy-to-slave = https://www.jenkins.io/security/plugins/#suspensions
 cpptest = https://issues.jenkins.io/browse/INFRA-2487
 # https://wiki.jenkins.io/display/JENKINS/CppUnit+Plugin
 cppunit = https://wiki.jenkins.io/x/6oE5Ag
@@ -67,7 +68,7 @@ cppunit = https://wiki.jenkins.io/x/6oE5Ag
 dockerhub = https://git.io/JfaQF
 DotCi-Plugins-Starter-Pack = https://issues.jenkins.io/browse/INFRA-2487
 dry = https://issues.jenkins.io/browse/INFRA-2487
-dynamicparameter = https://jenkins.io/blog/2017/04/10/security-advisory/#distributing-vulnerable-plugins
+dynamicparameter = https://www.jenkins.io/security/plugins/#suspensions
 # https://wiki.jenkins.io/display/JENKINS/Emotional+Hudson+Plugin
 emotional-hudson = https://wiki.jenkins.io/x/C4DX
 # https://github.com/jenkins-infra/update-center2/pull/257
@@ -86,7 +87,7 @@ gitorious = https://wiki.jenkins.io/x/ngDiAw
 google-desktop-gadget = https://wiki.jenkins.io/x/E4A3AQ
 # https://wiki.jenkins.io/display/JENKINS/Google+Code+Plugin
 googlecode = https://wiki.jenkins.io/x/DQC7
-grails = https://jenkins.io/blog/2017/04/10/security-advisory/#distributing-vulnerable-plugins
+grails = https://www.jenkins.io/security/plugins/#suspensions
 # https://wiki.jenkins.io/display/JENKINS/Hall+Plugin
 hall-jenkins = https://wiki.jenkins.io/x/qQghB
 # https://wiki.jenkins.io/display/JENKINS/HockeyApp+Plugin
@@ -108,10 +109,10 @@ jenkow-plugin = https://wiki.jenkins.io/x/WIuhAw
 jshint-checkstyle = https://git.io/JsmW2
 # https://github.com/jenkins-infra/update-center2/pull/94
 kanboard-publisher = https://git.io/JfaQH
-kubernetes-ci = https://jenkins.io/security/advisory/2020-07-02
-kubernetes-pipeline-arquillian-steps = https://jenkins.io/security/advisory/2019-09-25/
-kubernetes-pipeline-aggregator = https://jenkins.io/security/advisory/2019-09-25/
-kubernetes-pipeline-steps = https://jenkins.io/security/advisory/2019-09-25/
+kubernetes-ci = https://www.jenkins.io/security/plugins/#suspensions
+kubernetes-pipeline-arquillian-steps = https://www.jenkins.io/security/plugins/#suspensions
+kubernetes-pipeline-aggregator = https://www.jenkins.io/security/plugins/#suspensions
+kubernetes-pipeline-steps = https://www.jenkins.io/security/plugins/#suspensions
 # https://wiki.jenkins.io/display/JENKINS/M2+Extra+Steps+Plugin
 m2-extra-steps = https://wiki.jenkins.io/x/FIc5Ag
 # https://wiki.jenkins.io/display/JENKINS/CloudBees+Cloud+Connector+Plugin
@@ -135,7 +136,7 @@ paranoia = https://git.io/JfaQS
 # https://plugins.jenkins.io/perfectomobile/
 perfectomobile = https://developers.perfectomobile.com/display/PD/Legacy+%7C+Jenkins+plugin
 perforce = https://jenkins.io/security/advisory/2018-03-26/
-persona = https://jenkins.io/security/advisory/2020-10-08
+persona = https://www.jenkins.io/security/plugins/#suspensions
 php = https://issues.jenkins.io/browse/INFRA-2487
 # https://github.com/jenkins-infra/update-center2/pull/384
 play-autotest-plugin = https://git.io/JsmWA
@@ -158,7 +159,7 @@ scis-ad = https://git.io/JfaQX
 scm-branch-pr-filter = https://issues.jenkins.io/browse/INFRA-1358
 # https://github.com/jenkins-infra/update-center2/pull/324
 SCTMExecutor = https://git.io/JfaQP
-scripttrigger = https://jenkins.io/blog/2017/04/10/security-advisory/#distributing-vulnerable-plugins
+scripttrigger = https://www.jenkins.io/security/plugins/#suspensions
 # https://wiki.jenkins.io/display/JENKINS/Build+Secret+Plugin
 secret = https://wiki.jenkins.io/x/9ghSAg
 # https://wiki.jenkins.io/display/JENKINS/Setenv+Plugin
@@ -167,7 +168,7 @@ setenv = https://wiki.jenkins.io/x/YAtSAg
 sonargraph-plugin = https://git.io/JJ5h1
 # https://wiki.jenkins.io/pages/viewpage.action?pageId=63930505
 sonatype-ci = https://wiki.jenkins.io/x/iYDPAw
-svn-tag = https://jenkins.io/blog/2017/04/10/security-advisory/#distributing-vulnerable-plugins
+svn-tag = https://www.jenkins.io/security/plugins/#suspensions
 swamp = https://issues.jenkins.io/browse/INFRA-2487
 tasks = https://issues.jenkins.io/browse/INFRA-2487
 # https://wiki.jenkins.io/display/JENKINS/TEPCO+Plugin
@@ -185,7 +186,7 @@ vessel = https://groups.google.com/d/msg/jenkinsci-dev/L34eAMMWA5o/-AxtRdGsAAAJ
 warnings = https://issues.jenkins.io/browse/INFRA-2487
 # https://github.com/jenkinsci/xltestview-plugin/commit/ea034f9929b520e63b9ce15aed9bdb62354146cf
 xltest-plugin = https://git.io/JfaQK
-xtrigger = https://jenkins.io/blog/2017/04/10/security-advisory/#distributing-vulnerable-plugins
-zap-pipeline = https://www.jenkins.io/security/advisory/2020-07-02
+xtrigger = https://www.jenkins.io/security/plugins/#suspensions
+zap-pipeline = https://www.jenkins.io/security/plugins/#suspensions
 # https://wiki.jenkins.io/display/JENKINS/ZAProxy+Plugin
 zaproxy = https://wiki.jenkins.io/x/JgCsB

--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -135,12 +135,12 @@ origo-issue-notifier = https://wiki.jenkins.io/x/qgabAg
 paranoia = https://git.io/JfaQS
 # https://plugins.jenkins.io/perfectomobile/
 perfectomobile = https://developers.perfectomobile.com/display/PD/Legacy+%7C+Jenkins+plugin
-perforce = https://jenkins.io/security/advisory/2018-03-26/
+perforce = https://www.jenkins.io/security/advisory/2018-03-26/#SECURITY-373
 persona = https://www.jenkins.io/security/plugins/#suspensions
 php = https://issues.jenkins.io/browse/INFRA-2487
 # https://github.com/jenkins-infra/update-center2/pull/384
 play-autotest-plugin = https://git.io/JsmWA
-pipeline-classpath = https://jenkins.io/security/advisory/2017-03-20
+pipeline-classpath = https://www.jenkins.io/security/plugins/#suspensions
 # https://github.com/jenkinsci/pipeline-editor-plugin
 pipeline-editor = https://git.io/JfaQy
 pmd = https://issues.jenkins.io/browse/INFRA-2487

--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -67,7 +67,7 @@ cppunit = https://wiki.jenkins.io/x/6oE5Ag
 dockerhub = https://git.io/JfaQF
 DotCi-Plugins-Starter-Pack = https://issues.jenkins.io/browse/INFRA-2487
 dry = https://issues.jenkins.io/browse/INFRA-2487
-dynamicparameter = https://jenkins.io/security/advisory/2017-04-10/
+dynamicparameter = https://jenkins.io/blog/2017/04/10/security-advisory/#distributing-vulnerable-plugins
 # https://wiki.jenkins.io/display/JENKINS/Emotional+Hudson+Plugin
 emotional-hudson = https://wiki.jenkins.io/x/C4DX
 # https://github.com/jenkins-infra/update-center2/pull/257
@@ -86,7 +86,7 @@ gitorious = https://wiki.jenkins.io/x/ngDiAw
 google-desktop-gadget = https://wiki.jenkins.io/x/E4A3AQ
 # https://wiki.jenkins.io/display/JENKINS/Google+Code+Plugin
 googlecode = https://wiki.jenkins.io/x/DQC7
-grails = https://jenkins.io/security/advisory/2017-04-10/
+grails = https://jenkins.io/blog/2017/04/10/security-advisory/#distributing-vulnerable-plugins
 # https://wiki.jenkins.io/display/JENKINS/Hall+Plugin
 hall-jenkins = https://wiki.jenkins.io/x/qQghB
 # https://wiki.jenkins.io/display/JENKINS/HockeyApp+Plugin
@@ -158,7 +158,7 @@ scis-ad = https://git.io/JfaQX
 scm-branch-pr-filter = https://issues.jenkins.io/browse/INFRA-1358
 # https://github.com/jenkins-infra/update-center2/pull/324
 SCTMExecutor = https://git.io/JfaQP
-scripttrigger = https://jenkins.io/security/advisory/2017-04-10/
+scripttrigger = https://jenkins.io/blog/2017/04/10/security-advisory/#distributing-vulnerable-plugins
 # https://wiki.jenkins.io/display/JENKINS/Build+Secret+Plugin
 secret = https://wiki.jenkins.io/x/9ghSAg
 # https://wiki.jenkins.io/display/JENKINS/Setenv+Plugin
@@ -167,7 +167,7 @@ setenv = https://wiki.jenkins.io/x/YAtSAg
 sonargraph-plugin = https://git.io/JJ5h1
 # https://wiki.jenkins.io/pages/viewpage.action?pageId=63930505
 sonatype-ci = https://wiki.jenkins.io/x/iYDPAw
-svn-tag = https://jenkins.io/security/advisory/2017-04-10/
+svn-tag = https://jenkins.io/blog/2017/04/10/security-advisory/#distributing-vulnerable-plugins
 swamp = https://issues.jenkins.io/browse/INFRA-2487
 tasks = https://issues.jenkins.io/browse/INFRA-2487
 # https://wiki.jenkins.io/display/JENKINS/TEPCO+Plugin
@@ -185,7 +185,7 @@ vessel = https://groups.google.com/d/msg/jenkinsci-dev/L34eAMMWA5o/-AxtRdGsAAAJ
 warnings = https://issues.jenkins.io/browse/INFRA-2487
 # https://github.com/jenkinsci/xltestview-plugin/commit/ea034f9929b520e63b9ce15aed9bdb62354146cf
 xltest-plugin = https://git.io/JfaQK
-xtrigger = https://jenkins.io/security/advisory/2017-04-10/
+xtrigger = https://jenkins.io/blog/2017/04/10/security-advisory/#distributing-vulnerable-plugins
 zap-pipeline = https://www.jenkins.io/security/advisory/2020-07-02
 # https://wiki.jenkins.io/display/JENKINS/ZAProxy+Plugin
 zaproxy = https://wiki.jenkins.io/x/JgCsB


### PR DESCRIPTION
This should cover all suspended plugins with >200 (0.07%) known installs.