### PR TITLE
remove ci-with-toad-edge from list of suspended plugin and suspend specific plugin versions

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -493,7 +493,9 @@ testfairy-2.2.5-beta
 lambdatest-automation-1.16
 
 # Non OSI license: These plugins use a custom license (3 clause BSD + 4th clause about trademark use)
-ci-with-toad-edge
+ci-with-toad-edge-1.0
+ci-with-toad-edge-1.2
+ci-with-toad-edge-2.0
 ci-with-toad-devops-toolkit
 
 # Depublished as agreed with maintainer after SECURITY-1879 in 2020-06-03 security advisory


### PR DESCRIPTION
We have updated the license to OSI approved for ci-with-toad-edge plugin.
https://github.com/jenkinsci/ci-with-toad-edge-plugin/blob/master/LICENSE

With ci-with-toad-edge-2.2, we have fixed the license issue.

Please merge this PR.




