### PR TITLE
Formally deprecating plugins left behind in recent core PRs

### DIFF
--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -159,7 +159,6 @@ poll-mailbox-trigger = https://git.io/JfaQM
 pretest-commit = https://wiki.jenkins.io/x/5gB-B
 # https://wiki.jenkins.io/display/JENKINS/pucm+plugin
 PUCM = https://wiki.jenkins.io/x/fIBVAw
-rad-builder = https://groups.google.com/g/jenkinsci-dev/c/9M2B6ZTKjI0/m/BChinuUVBAAJ
 # https://github.com/jenkins-infra/update-center2/pull/13
 rtc = https://git.io/JfaQ1
 # https://wiki.jenkins.io/display/JENKINS/Retry+Failed+Builds+Plugin

--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -18,7 +18,7 @@ azure-iot-edge = https://git.io/JtOjd
 blackduck-hub = https://git.io/JfaQa
 # https://wiki.jenkins.io/display/JENKINS/Black+Duck+Vulnerability+Installer+Plugin
 blackduck-installer = https://wiki.jenkins.io/x/nYHHB
-BlameSubversion = https://groups.google.com/g/jenkinsci-dev/c/9M2B6ZTKjI0/m/BChinuUVBAAJ
+BlameSubversion = https://github.com/jenkinsci/jenkins/pull/5320
 # https://github.com/jenkins-infra/update-center2/pull/521
 blitz_io-jenkins = https://git.io/J3d1Y
 blueocean-executor-info = https://issues.jenkins.io/browse/JENKINS-56773
@@ -53,13 +53,13 @@ cloudbees-disk-usage-simple-plugin = https://git.io/JfaQN
 cloudbees-enterprise-plugins = https://wiki.jenkins.io/x/3gX8Aw
 # https://wiki.jenkins.io/display/JENKINS/CloudBees+Registration+Plugin
 cloudbees-registration = https://wiki.jenkins.io/x/z4FLB
-cloverphp = https://groups.google.com/g/jenkinsci-dev/c/9M2B6ZTKjI0/m/BChinuUVBAAJ
-cmvc = https://groups.google.com/g/jenkinsci-dev/c/9M2B6ZTKjI0/m/BChinuUVBAAJ
+cloverphp = https://github.com/jenkinsci/jenkins/pull/5320
+cmvc = https://github.com/jenkinsci/jenkins/pull/5320
 codeclimate-plugin = https://issues.jenkins.io/browse/INFRA-2487
 # https://github.com/jenkins-infra/update-center2/pull/299
 codescanner = https://issues.jenkins.io/browse/INFRA-2487
 codescan = https://git.io/JfaQb
-config-rotator = https://groups.google.com/g/jenkinsci-dev/c/9M2B6ZTKjI0/m/BChinuUVBAAJ
+config-rotator = https://github.com/jenkinsci/jenkins/pull/5320
 # https://github.com/jenkinsci/configuration-as-code-plugin/releases/tag/configuration-as-code-1.18
 configuration-as-code-support = https://git.io/JfaHz
 # https://wiki.jenkins.io/display/JENKINS/CopyArchiver+Plugin
@@ -73,7 +73,7 @@ dockerhub = https://git.io/JfaQF
 DotCi-Plugins-Starter-Pack = https://issues.jenkins.io/browse/INFRA-2487
 dry = https://issues.jenkins.io/browse/INFRA-2487
 dynamicparameter = https://www.jenkins.io/security/plugins/#suspensions
-emma = https://groups.google.com/g/jenkinsci-dev/c/9M2B6ZTKjI0/m/BChinuUVBAAJ
+emma = https://github.com/jenkinsci/jenkins/pull/5320
 # https://wiki.jenkins.io/display/JENKINS/Emotional+Hudson+Plugin
 emotional-hudson = https://wiki.jenkins.io/x/C4DX
 # https://github.com/jenkins-infra/update-center2/pull/257
@@ -82,7 +82,7 @@ externalresource-dispatcher = https://groups.google.com/d/msg/jenkinsci-dev/YKfy
 findbugs = https://issues.jenkins.io/browse/INFRA-2487
 # https://github.com/jenkinsci/fortify-cloudscan-plugin#deprecation-notice
 fortify-cloudscan-jenkins-plugin = https://git.io/JfhPD
-genexus = https://groups.google.com/g/jenkinsci-dev/c/9M2B6ZTKjI0/m/BChinuUVBAAJ
+genexus = https://github.com/jenkinsci/jenkins/pull/5320
 # https://wiki.jenkins.io/display/JENKINS/Gerrit+Plugin
 gerrit = https://wiki.jenkins.io/x/9ICVAg
 # https://wiki.jenkins.io/display/JENKINS/Girls+Plugin
@@ -96,7 +96,7 @@ googlecode = https://wiki.jenkins.io/x/DQC7
 grails = https://www.jenkins.io/security/plugins/#suspensions
 # https://wiki.jenkins.io/display/JENKINS/Hall+Plugin
 hall-jenkins = https://wiki.jenkins.io/x/qQghB
-harvest = https://groups.google.com/g/jenkinsci-dev/c/9M2B6ZTKjI0/m/BChinuUVBAAJ
+harvest = https://github.com/jenkinsci/jenkins/pull/5320
 # https://wiki.jenkins.io/display/JENKINS/HockeyApp+Plugin
 hockeyapp = https://wiki.jenkins.io/x/7oPPAw
 # https://wiki.jenkins.io/display/JENKINS/iON+Deployer+Plugin
@@ -105,7 +105,7 @@ ion-deployer-plugin = https://wiki.jenkins.io/x/FhOMAw
 javanet = https://wiki.jenkins.io/x/AgDL
 # https://wiki.jenkins.io/display/JENKINS/java.net+uploader+Plugin
 javanet-uploader = https://wiki.jenkins.io/x/ZoAL
-javatest-report = https://groups.google.com/g/jenkinsci-dev/c/9M2B6ZTKjI0/m/BChinuUVBAAJ
+javatest-report = https://github.com/jenkinsci/jenkins/pull/5320
 jenkins-tracker = https://issues.jenkins.io/browse/INFRA-1531
 # https://wiki.jenkins.io/display/JENKINS/Jenkow+Activiti+Designer
 jenkow-activiti-designer = https://wiki.jenkins.io/x/ngnqAw
@@ -133,7 +133,7 @@ mypeople = https://wiki.jenkins.io/x/xQRCB
 nabaztag = https://wiki.jenkins.io/x/dIEuAg
 # https://wiki.jenkins.io/display/JENKINS/Netio-Plugin
 netio-plugin = https://wiki.jenkins.io/x/7gMHB
-nis-notification-lamp = https://groups.google.com/g/jenkinsci-dev/c/9M2B6ZTKjI0/m/BChinuUVBAAJ
+nis-notification-lamp = https://github.com/jenkinsci/jenkins/pull/5521
 # https://wiki.jenkins.io/display/JENKINS/Node+Offline+Notification+Plugin
 nodeofflinenotification = https://wiki.jenkins.io/x/0IKhAw
 # https://wiki.jenkins.io/display/JENKINS/Notifo+Plugin
@@ -179,7 +179,7 @@ sonargraph-plugin = https://git.io/JJ5h1
 sonatype-ci = https://wiki.jenkins.io/x/iYDPAw
 svn-tag = https://www.jenkins.io/security/plugins/#suspensions
 swamp = https://issues.jenkins.io/browse/INFRA-2487
-synergy = https://groups.google.com/g/jenkinsci-dev/c/9M2B6ZTKjI0/m/BChinuUVBAAJ
+synergy = https://github.com/jenkinsci/jenkins/pull/5320
 tasks = https://issues.jenkins.io/browse/INFRA-2487
 # https://wiki.jenkins.io/display/JENKINS/TEPCO+Plugin
 tfs = https://issues.jenkins.io/browse/INFRA-2751
@@ -193,8 +193,8 @@ url-change-trigger = https://wiki.jenkins.io/x/BQBJ
 # https://github.com/jenkins-infra/update-center2/pull/302
 veracode-scanner = https://git.io/JfaQ6
 vessel = https://groups.google.com/d/msg/jenkinsci-dev/L34eAMMWA5o/-AxtRdGsAAAJ
-vs-code-metrics = https://groups.google.com/g/jenkinsci-dev/c/9M2B6ZTKjI0/m/BChinuUVBAAJ
-vss = https://groups.google.com/g/jenkinsci-dev/c/9M2B6ZTKjI0/m/BChinuUVBAAJ
+vs-code-metrics = https://github.com/jenkinsci/jenkins/pull/5320
+vss = https://github.com/jenkinsci/jenkins/pull/5320
 warnings = https://issues.jenkins.io/browse/INFRA-2487
 # https://github.com/jenkinsci/xltestview-plugin/commit/ea034f9929b520e63b9ce15aed9bdb62354146cf
 xltest-plugin = https://git.io/JfaQK

--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -173,6 +173,7 @@ scripttrigger = https://www.jenkins.io/security/plugins/#suspensions
 secret = https://wiki.jenkins.io/x/9ghSAg
 # https://wiki.jenkins.io/display/JENKINS/Setenv+Plugin
 setenv = https://wiki.jenkins.io/x/YAtSAg
+slave-prerequisites = https://github.com/jenkinsci/jenkins/pull/5526
 # https://github.com/jenkins-infra/update-center2/pull/405#issue-455150640
 sonargraph-plugin = https://git.io/JJ5h1
 # https://wiki.jenkins.io/pages/viewpage.action?pageId=63930505
@@ -192,6 +193,7 @@ testflight = https://wiki.jenkins.io/x/pwZ1Aw
 url-change-trigger = https://wiki.jenkins.io/x/BQBJ
 # https://github.com/jenkins-infra/update-center2/pull/302
 veracode-scanner = https://git.io/JfaQ6
+vertx = https://github.com/jenkinsci/jenkins/pull/5526
 vessel = https://groups.google.com/d/msg/jenkinsci-dev/L34eAMMWA5o/-AxtRdGsAAAJ
 vs-code-metrics = https://github.com/jenkinsci/jenkins/pull/5320
 vss = https://github.com/jenkinsci/jenkins/pull/5320

--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -18,7 +18,8 @@ azure-iot-edge = https://git.io/JtOjd
 blackduck-hub = https://git.io/JfaQa
 # https://wiki.jenkins.io/display/JENKINS/Black+Duck+Vulnerability+Installer+Plugin
 blackduck-installer = https://wiki.jenkins.io/x/nYHHB
-BlameSubversion = https://github.com/jenkinsci/jenkins/pull/5320
+# https://github.com/jenkinsci/jenkins/pull/5320
+BlameSubversion = https://git.io/Jn6Co
 # https://github.com/jenkins-infra/update-center2/pull/521
 blitz_io-jenkins = https://git.io/J3d1Y
 blueocean-executor-info = https://issues.jenkins.io/browse/JENKINS-56773
@@ -53,13 +54,16 @@ cloudbees-disk-usage-simple-plugin = https://git.io/JfaQN
 cloudbees-enterprise-plugins = https://wiki.jenkins.io/x/3gX8Aw
 # https://wiki.jenkins.io/display/JENKINS/CloudBees+Registration+Plugin
 cloudbees-registration = https://wiki.jenkins.io/x/z4FLB
-cloverphp = https://github.com/jenkinsci/jenkins/pull/5320
-cmvc = https://github.com/jenkinsci/jenkins/pull/5320
+# https://github.com/jenkinsci/jenkins/pull/5320
+cloverphp = https://git.io/Jn6Co
+# https://github.com/jenkinsci/jenkins/pull/5320
+cmvc = https://git.io/Jn6Co
 codeclimate-plugin = https://issues.jenkins.io/browse/INFRA-2487
 # https://github.com/jenkins-infra/update-center2/pull/299
 codescanner = https://issues.jenkins.io/browse/INFRA-2487
 codescan = https://git.io/JfaQb
-config-rotator = https://github.com/jenkinsci/jenkins/pull/5320
+# https://github.com/jenkinsci/jenkins/pull/5320
+config-rotator = https://git.io/Jn6Co
 # https://github.com/jenkinsci/configuration-as-code-plugin/releases/tag/configuration-as-code-1.18
 configuration-as-code-support = https://git.io/JfaHz
 # https://wiki.jenkins.io/display/JENKINS/CopyArchiver+Plugin
@@ -73,7 +77,8 @@ dockerhub = https://git.io/JfaQF
 DotCi-Plugins-Starter-Pack = https://issues.jenkins.io/browse/INFRA-2487
 dry = https://issues.jenkins.io/browse/INFRA-2487
 dynamicparameter = https://www.jenkins.io/security/plugins/#suspensions
-emma = https://github.com/jenkinsci/jenkins/pull/5320
+# https://github.com/jenkinsci/jenkins/pull/5320
+emma = https://git.io/Jn6Co
 # https://wiki.jenkins.io/display/JENKINS/Emotional+Hudson+Plugin
 emotional-hudson = https://wiki.jenkins.io/x/C4DX
 # https://github.com/jenkins-infra/update-center2/pull/257
@@ -82,7 +87,8 @@ externalresource-dispatcher = https://groups.google.com/d/msg/jenkinsci-dev/YKfy
 findbugs = https://issues.jenkins.io/browse/INFRA-2487
 # https://github.com/jenkinsci/fortify-cloudscan-plugin#deprecation-notice
 fortify-cloudscan-jenkins-plugin = https://git.io/JfhPD
-genexus = https://github.com/jenkinsci/jenkins/pull/5320
+# https://github.com/jenkinsci/jenkins/pull/5320
+genexus = https://git.io/Jn6Co
 # https://wiki.jenkins.io/display/JENKINS/Gerrit+Plugin
 gerrit = https://wiki.jenkins.io/x/9ICVAg
 # https://wiki.jenkins.io/display/JENKINS/Girls+Plugin
@@ -96,7 +102,8 @@ googlecode = https://wiki.jenkins.io/x/DQC7
 grails = https://www.jenkins.io/security/plugins/#suspensions
 # https://wiki.jenkins.io/display/JENKINS/Hall+Plugin
 hall-jenkins = https://wiki.jenkins.io/x/qQghB
-harvest = https://github.com/jenkinsci/jenkins/pull/5320
+# https://github.com/jenkinsci/jenkins/pull/5320
+harvest = https://git.io/Jn6Co
 # https://wiki.jenkins.io/display/JENKINS/HockeyApp+Plugin
 hockeyapp = https://wiki.jenkins.io/x/7oPPAw
 # https://wiki.jenkins.io/display/JENKINS/iON+Deployer+Plugin
@@ -105,7 +112,8 @@ ion-deployer-plugin = https://wiki.jenkins.io/x/FhOMAw
 javanet = https://wiki.jenkins.io/x/AgDL
 # https://wiki.jenkins.io/display/JENKINS/java.net+uploader+Plugin
 javanet-uploader = https://wiki.jenkins.io/x/ZoAL
-javatest-report = https://github.com/jenkinsci/jenkins/pull/5320
+# https://github.com/jenkinsci/jenkins/pull/5320
+javatest-report = https://git.io/Jn6Co
 jenkins-tracker = https://issues.jenkins.io/browse/INFRA-1531
 # https://wiki.jenkins.io/display/JENKINS/Jenkow+Activiti+Designer
 jenkow-activiti-designer = https://wiki.jenkins.io/x/ngnqAw
@@ -133,7 +141,8 @@ mypeople = https://wiki.jenkins.io/x/xQRCB
 nabaztag = https://wiki.jenkins.io/x/dIEuAg
 # https://wiki.jenkins.io/display/JENKINS/Netio-Plugin
 netio-plugin = https://wiki.jenkins.io/x/7gMHB
-nis-notification-lamp = https://github.com/jenkinsci/jenkins/pull/5521
+# https://github.com/jenkinsci/jenkins/pull/5521
+nis-notification-lamp = https://git.io/Jn6Wf
 # https://wiki.jenkins.io/display/JENKINS/Node+Offline+Notification+Plugin
 nodeofflinenotification = https://wiki.jenkins.io/x/0IKhAw
 # https://wiki.jenkins.io/display/JENKINS/Notifo+Plugin
@@ -173,14 +182,16 @@ scripttrigger = https://www.jenkins.io/security/plugins/#suspensions
 secret = https://wiki.jenkins.io/x/9ghSAg
 # https://wiki.jenkins.io/display/JENKINS/Setenv+Plugin
 setenv = https://wiki.jenkins.io/x/YAtSAg
-slave-prerequisites = https://github.com/jenkinsci/jenkins/pull/5526
+# https://github.com/jenkinsci/jenkins/pull/5526
+slave-prerequisites = https://git.io/Jn6WI
 # https://github.com/jenkins-infra/update-center2/pull/405#issue-455150640
 sonargraph-plugin = https://git.io/JJ5h1
 # https://wiki.jenkins.io/pages/viewpage.action?pageId=63930505
 sonatype-ci = https://wiki.jenkins.io/x/iYDPAw
 svn-tag = https://www.jenkins.io/security/plugins/#suspensions
 swamp = https://issues.jenkins.io/browse/INFRA-2487
-synergy = https://github.com/jenkinsci/jenkins/pull/5320
+# https://github.com/jenkinsci/jenkins/pull/5320
+synergy = https://git.io/Jn6Co
 tasks = https://issues.jenkins.io/browse/INFRA-2487
 # https://wiki.jenkins.io/display/JENKINS/TEPCO+Plugin
 tfs = https://issues.jenkins.io/browse/INFRA-2751
@@ -193,10 +204,13 @@ testflight = https://wiki.jenkins.io/x/pwZ1Aw
 url-change-trigger = https://wiki.jenkins.io/x/BQBJ
 # https://github.com/jenkins-infra/update-center2/pull/302
 veracode-scanner = https://git.io/JfaQ6
-vertx = https://github.com/jenkinsci/jenkins/pull/5526
+# https://github.com/jenkinsci/jenkins/pull/5526
+vertx = https://git.io/Jn6WI
 vessel = https://groups.google.com/d/msg/jenkinsci-dev/L34eAMMWA5o/-AxtRdGsAAAJ
-vs-code-metrics = https://github.com/jenkinsci/jenkins/pull/5320
-vss = https://github.com/jenkinsci/jenkins/pull/5320
+# https://github.com/jenkinsci/jenkins/pull/5320
+vs-code-metrics = https://git.io/Jn6Co
+# https://github.com/jenkinsci/jenkins/pull/5320
+vss = https://git.io/Jn6Co
 warnings = https://issues.jenkins.io/browse/INFRA-2487
 # https://github.com/jenkinsci/xltestview-plugin/commit/ea034f9929b520e63b9ce15aed9bdb62354146cf
 xltest-plugin = https://git.io/JfaQK

--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -18,6 +18,7 @@ azure-iot-edge = https://git.io/JtOjd
 blackduck-hub = https://git.io/JfaQa
 # https://wiki.jenkins.io/display/JENKINS/Black+Duck+Vulnerability+Installer+Plugin
 blackduck-installer = https://wiki.jenkins.io/x/nYHHB
+BlameSubversion = https://groups.google.com/g/jenkinsci-dev/c/9M2B6ZTKjI0/m/BChinuUVBAAJ
 # https://github.com/jenkins-infra/update-center2/pull/521
 blitz_io-jenkins = https://git.io/J3d1Y
 blueocean-executor-info = https://issues.jenkins.io/browse/JENKINS-56773
@@ -52,10 +53,13 @@ cloudbees-disk-usage-simple-plugin = https://git.io/JfaQN
 cloudbees-enterprise-plugins = https://wiki.jenkins.io/x/3gX8Aw
 # https://wiki.jenkins.io/display/JENKINS/CloudBees+Registration+Plugin
 cloudbees-registration = https://wiki.jenkins.io/x/z4FLB
+cloverphp = https://groups.google.com/g/jenkinsci-dev/c/9M2B6ZTKjI0/m/BChinuUVBAAJ
+cmvc = https://groups.google.com/g/jenkinsci-dev/c/9M2B6ZTKjI0/m/BChinuUVBAAJ
 codeclimate-plugin = https://issues.jenkins.io/browse/INFRA-2487
 # https://github.com/jenkins-infra/update-center2/pull/299
 codescanner = https://issues.jenkins.io/browse/INFRA-2487
 codescan = https://git.io/JfaQb
+config-rotator = https://groups.google.com/g/jenkinsci-dev/c/9M2B6ZTKjI0/m/BChinuUVBAAJ
 # https://github.com/jenkinsci/configuration-as-code-plugin/releases/tag/configuration-as-code-1.18
 configuration-as-code-support = https://git.io/JfaHz
 # https://wiki.jenkins.io/display/JENKINS/CopyArchiver+Plugin
@@ -69,6 +73,7 @@ dockerhub = https://git.io/JfaQF
 DotCi-Plugins-Starter-Pack = https://issues.jenkins.io/browse/INFRA-2487
 dry = https://issues.jenkins.io/browse/INFRA-2487
 dynamicparameter = https://www.jenkins.io/security/plugins/#suspensions
+emma = https://groups.google.com/g/jenkinsci-dev/c/9M2B6ZTKjI0/m/BChinuUVBAAJ
 # https://wiki.jenkins.io/display/JENKINS/Emotional+Hudson+Plugin
 emotional-hudson = https://wiki.jenkins.io/x/C4DX
 # https://github.com/jenkins-infra/update-center2/pull/257
@@ -77,6 +82,7 @@ externalresource-dispatcher = https://groups.google.com/d/msg/jenkinsci-dev/YKfy
 findbugs = https://issues.jenkins.io/browse/INFRA-2487
 # https://github.com/jenkinsci/fortify-cloudscan-plugin#deprecation-notice
 fortify-cloudscan-jenkins-plugin = https://git.io/JfhPD
+genexus = https://groups.google.com/g/jenkinsci-dev/c/9M2B6ZTKjI0/m/BChinuUVBAAJ
 # https://wiki.jenkins.io/display/JENKINS/Gerrit+Plugin
 gerrit = https://wiki.jenkins.io/x/9ICVAg
 # https://wiki.jenkins.io/display/JENKINS/Girls+Plugin
@@ -90,6 +96,7 @@ googlecode = https://wiki.jenkins.io/x/DQC7
 grails = https://www.jenkins.io/security/plugins/#suspensions
 # https://wiki.jenkins.io/display/JENKINS/Hall+Plugin
 hall-jenkins = https://wiki.jenkins.io/x/qQghB
+harvest = https://groups.google.com/g/jenkinsci-dev/c/9M2B6ZTKjI0/m/BChinuUVBAAJ
 # https://wiki.jenkins.io/display/JENKINS/HockeyApp+Plugin
 hockeyapp = https://wiki.jenkins.io/x/7oPPAw
 # https://wiki.jenkins.io/display/JENKINS/iON+Deployer+Plugin
@@ -98,6 +105,7 @@ ion-deployer-plugin = https://wiki.jenkins.io/x/FhOMAw
 javanet = https://wiki.jenkins.io/x/AgDL
 # https://wiki.jenkins.io/display/JENKINS/java.net+uploader+Plugin
 javanet-uploader = https://wiki.jenkins.io/x/ZoAL
+javatest-report = https://groups.google.com/g/jenkinsci-dev/c/9M2B6ZTKjI0/m/BChinuUVBAAJ
 jenkins-tracker = https://issues.jenkins.io/browse/INFRA-1531
 # https://wiki.jenkins.io/display/JENKINS/Jenkow+Activiti+Designer
 jenkow-activiti-designer = https://wiki.jenkins.io/x/ngnqAw
@@ -125,6 +133,7 @@ mypeople = https://wiki.jenkins.io/x/xQRCB
 nabaztag = https://wiki.jenkins.io/x/dIEuAg
 # https://wiki.jenkins.io/display/JENKINS/Netio-Plugin
 netio-plugin = https://wiki.jenkins.io/x/7gMHB
+nis-notification-lamp = https://groups.google.com/g/jenkinsci-dev/c/9M2B6ZTKjI0/m/BChinuUVBAAJ
 # https://wiki.jenkins.io/display/JENKINS/Node+Offline+Notification+Plugin
 nodeofflinenotification = https://wiki.jenkins.io/x/0IKhAw
 # https://wiki.jenkins.io/display/JENKINS/Notifo+Plugin
@@ -150,6 +159,7 @@ poll-mailbox-trigger = https://git.io/JfaQM
 pretest-commit = https://wiki.jenkins.io/x/5gB-B
 # https://wiki.jenkins.io/display/JENKINS/pucm+plugin
 PUCM = https://wiki.jenkins.io/x/fIBVAw
+rad-builder = https://groups.google.com/g/jenkinsci-dev/c/9M2B6ZTKjI0/m/BChinuUVBAAJ
 # https://github.com/jenkins-infra/update-center2/pull/13
 rtc = https://git.io/JfaQ1
 # https://wiki.jenkins.io/display/JENKINS/Retry+Failed+Builds+Plugin
@@ -170,6 +180,7 @@ sonargraph-plugin = https://git.io/JJ5h1
 sonatype-ci = https://wiki.jenkins.io/x/iYDPAw
 svn-tag = https://www.jenkins.io/security/plugins/#suspensions
 swamp = https://issues.jenkins.io/browse/INFRA-2487
+synergy = https://groups.google.com/g/jenkinsci-dev/c/9M2B6ZTKjI0/m/BChinuUVBAAJ
 tasks = https://issues.jenkins.io/browse/INFRA-2487
 # https://wiki.jenkins.io/display/JENKINS/TEPCO+Plugin
 tfs = https://issues.jenkins.io/browse/INFRA-2751
@@ -183,6 +194,8 @@ url-change-trigger = https://wiki.jenkins.io/x/BQBJ
 # https://github.com/jenkins-infra/update-center2/pull/302
 veracode-scanner = https://git.io/JfaQ6
 vessel = https://groups.google.com/d/msg/jenkinsci-dev/L34eAMMWA5o/-AxtRdGsAAAJ
+vs-code-metrics = https://groups.google.com/g/jenkinsci-dev/c/9M2B6ZTKjI0/m/BChinuUVBAAJ
+vss = https://groups.google.com/g/jenkinsci-dev/c/9M2B6ZTKjI0/m/BChinuUVBAAJ
 warnings = https://issues.jenkins.io/browse/INFRA-2487
 # https://github.com/jenkinsci/xltestview-plugin/commit/ea034f9929b520e63b9ce15aed9bdb62354146cf
 xltest-plugin = https://git.io/JfaQK


### PR DESCRIPTION
In recent core PRs jenkinsci/jenkins#5320, jenkinsci/jenkins#5338, jenkinsci/jenkins#5521, and jenkinsci/jenkins#5526, we are intentionally leaving behind 15 plugins. These plugins are unmaintained, and they have not seen commits or releases in years. Even when we opened PRs against them, these PRs went unacknowledged. We have judged that the benefit of supporting these plugins is not worth the cost to ongoing maintenance.

We do our users a disservice by not explicitly marking these plugins as deprecated. These plugins are, de facto, unsupported. It may not be ideal, but this is the status quo and the reality. Users should be warned when installing these plugins for the first time, and users who have them already installed should be warned that these plugins may cause problems.

I am linking to a response from a Jenkins board member on an email thread I started about this topic. This is the most concise and official statement of our policy that I can find. If an improved statement materializes on jenkins.io, we can always update the link in the future. But for the sake of our users, we should deprecate these plugins now.