### PR TITLE
GeneXus plugin is not deprecated

### DIFF
--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -87,8 +87,6 @@ externalresource-dispatcher = https://groups.google.com/d/msg/jenkinsci-dev/YKfy
 findbugs = https://issues.jenkins.io/browse/INFRA-2487
 # https://github.com/jenkinsci/fortify-cloudscan-plugin#deprecation-notice
 fortify-cloudscan-jenkins-plugin = https://git.io/JfhPD
-# https://github.com/jenkinsci/jenkins/pull/5320
-genexus = https://git.io/Jn6Co
 # https://wiki.jenkins.io/display/JENKINS/Gerrit+Plugin
 gerrit = https://wiki.jenkins.io/x/9ICVAg
 # https://wiki.jenkins.io/display/JENKINS/Girls+Plugin


### PR DESCRIPTION
Although included in the primary list of candidates for deprecation due to jenkinsci/jenkins#5320, the plugin was fixed on its 1.10 release on June 3, and removed from the list (see https://github.com/bitwiseman/jep/tree/00c184f97f40c5f79f8f83074c78dd4fb1e1ac43/jep/231)

The plugin does have mantainers and is not deprecated.