### PR TITLE
Handle duplicate maintainer entries

### DIFF
--- a/src/main/java/io/jenkins/update_center/HPI.java
+++ b/src/main/java/io/jenkins/update_center/HPI.java
@@ -48,6 +48,8 @@ import javax.annotation.CheckForNull;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -60,8 +62,6 @@ import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.net.URL;
-import java.net.MalformedURLException;
 
 /**
  * A particular version of a plugin and its metadata.
@@ -214,25 +214,6 @@ public class HPI extends MavenArtifact {
         }
 
         private static final String OPTIONAL_RESOLUTION = ";resolution:=optional";
-    }
-
-    public static class Developer {
-        @JSONField
-        public final String name;
-        @JSONField
-        public final String developerId;
-        @JSONField
-        public final String email;
-
-        public Developer(String name, String developerId, String email) {
-            this.name = has(name) ? name : null;
-            this.developerId = has(developerId) ? developerId : null;
-            this.email = has(email) ? email : null;
-        }
-
-        private boolean has(String s) {
-            return s!=null && s.length()>0;
-        }
     }
 
     private String name;

--- a/src/main/java/io/jenkins/update_center/MaintainersSource.java
+++ b/src/main/java/io/jenkins/update_center/MaintainersSource.java
@@ -99,7 +99,13 @@ public class MaintainersSource {
         try {
             final String jsonData = IOUtils.toString(new URL(MAINTAINERS_INFO_URL), StandardCharsets.UTF_8);
             final List<JsonMaintainer> rawMaintainersInfo = JSON.parseObject(jsonData, new TypeReferenceForListOfJsonMaintainer().getType());
-            maintainerInfo = new HashMap<>(rawMaintainersInfo.stream().map(m -> new AbstractMap.SimpleEntry<>(m.name, m.toMaintainer())).collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue)));
+            maintainerInfo = new HashMap<>();
+            rawMaintainersInfo.forEach(m -> {
+                if (maintainerInfo.containsKey(m.name)) {
+                    LOGGER.warning("Duplicate entry for " + m.name + " in " + MAINTAINERS_INFO_URL);
+                }
+                maintainerInfo.put(m.name, m.toMaintainer());
+            });
         } catch (RuntimeException | IOException ex) {
             LOGGER.log(Level.WARNING, "Failed to process " + MAINTAINERS_INFO_URL, ex);
             maintainerInfo = new HashMap<>();


### PR DESCRIPTION
Currently https://reports.jenkins.io/maintainers-info-report.json contains

```
  {
    "name": "thycotic_dsv",
    "displayName": "Thycotic Dev"
  },
  {
    "name": "thycotic_dsv",
    "displayName": "Thycotic Dev"
  },
  ```
  which breaks getting display names for all maintainers (all are null in https://updates.jenkins.io/current/update-center.actual.json )
  
  This makes parsing of the display names more robust, duplicates will only be reported in the log and not fail the whole parsing process.
  
  Also removes unused `Developer` since it was replaced by `Maintainer`.

CC @daniel-beck 