### PR TITLE
Disable all tuleap

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -560,4 +560,6 @@ github-api-1.222
 ca-mat-performance-benchmarking-by-broadcom-1.2
 
 # INFRA-3023
-tuleap-api-2.3.0
+tuleap-api
+tuleap-git-branch-source
+tuleap-oauth


### PR DESCRIPTION
The job keeps failing with 
`Caused by: java.io.IOException: Failed to retrieve content of https://repo.jenkins-ci.org/releases/io/jenkins/plugins/tuleap-api/2.3.0/tuleap-api-2.3.0.pom `