### PR TITLE
Added the superceded plugin: thycotic-vault-plugin to be ignored.

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -141,6 +141,7 @@ TestExecuter                     # renamed to selected-tests-executor
 testflight                       # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Testflight+Plugin
 TestResultsAnalyzer              # renamed to test-results-analyzer
 tusarnotifier                    # superseded by DTKit Plugin with automatic migration -- https://wiki.jenkins-ci.org/display/JENKINS/TusarNotifier
+thycotic-vault-plugin            # superseded by https://github.com/jenkinsci/thycotic-secret-server-plugin and https://github.com/jenkinsci/thycotic-devops-secrets-vault-plugin
 uithemes                         # removal requested by tfennelly
 upload-artifacts-to-nexus        # renamed, see https://issues.jenkins-ci.org/browse/HOSTING-41?focusedCommentId=250383&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-250383
 url-change-trigger               # Superseded by URLTrigger Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/URL+Change+Trigger


### PR DESCRIPTION
The `thycotic-vault-plugin` has been superseded by two new plugins from Thycotic, which are now available in the Jenkins plugin repository.  