### PR TITLE
Determine stable/ directory based on last dynamic LTS

### DIFF
--- a/site/generate.sh
+++ b/site/generate.sh
@@ -101,6 +101,8 @@ function sanity-check {
   if [[ 1500000 -ge $( wc -c < "$file" ) ]] ; then
     echo "Sanity check: $file looks too small" >&2
     exit 1
+  else
+    echo "Sanity check: $file looks OK" >&2
   fi
 }
 
@@ -164,9 +166,6 @@ for ltsv in "${RELEASES[@]}" ; do
   sanity-check "$WWW_ROOT_DIR/stable-$v"
   ln -sf ../updates "$WWW_ROOT_DIR/$v/updates"
   ln -sf ../updates "$WWW_ROOT_DIR/stable-$v/updates"
-
-  # needed for the stable/ directory (below)
-  lastLTS=$v
 done
 
 for version in "${WEEKLY_RELEASES[@]}" ; do
@@ -177,6 +176,9 @@ done
 for version in "${STABLE_RELEASES[@]}" ; do
   sanity-check "$WWW_ROOT_DIR/dynamic-stable-$version"
   ln -sf ../updates "$WWW_ROOT_DIR/dynamic-stable-$version/updates"
+
+  # needed for the stable/ directory (below)
+  lastLTS=dynamic-stable-$version
 done
 
 sanity-check "$WWW_ROOT_DIR/experimental"
@@ -187,7 +189,7 @@ ln -sf ../updates "$WWW_ROOT_DIR/current/updates"
 
 # generate symlinks to retain compatibility with past layout and make Apache index useful
 pushd "$WWW_ROOT_DIR"
-  ln -s "stable-$lastLTS" stable
+  ln -s "$lastLTS" stable
   for f in latest latestCore.txt plugin-documentation-urls.json release-history.json plugin-versions.json update-center.json update-center.actual.json update-center.json.html ; do
     ln -s "current/$f" .
   done


### PR DESCRIPTION
`.htaccess` rules redirect requests to files in `/stable/` to the latest `dynamic-stable-2.xyz.w`, but the actual directory is built on a really old branch, so the contents of https://updates.jenkins.io/stable/ don't look like https://updates.jenkins.io/dynamic-stable-2.289.1/ (see file sizes).

This PR aims to change that.