### PR TITLE
Remove duplication between deprecations and ignores

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -113,10 +113,8 @@ There are various reasons to need to do this, such as:
 * A plugin integrates with a service that has been shut down.
 
 Both use cases (entire plugins, or specific versions) are controlled via the file `resources/artifact-ignores.properties`.
+That file may also define URL of a deprecation notice that is shown to users who already installed the plugin.
 See that file for usage examples.
-
-Such plugins typically should get a corresponding deprecation entry in `resources/deprecations.properties`.
-
 
 === Security warnings
 

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -1,9 +1,9 @@
 # This file lists artifacts and specific versions of artifacts to hide in update center.
 # Possible syntaxes:
-# `artifactId` removes all versions of an artifact from distribution
-# `artifactId-version` removes specific version of an artifact from distribution
-# `artifactId = url` removes all versions of an artifact from distribution, provides deprecation message url
-# See comment in deprecations.properties for details about deprecation messages.
+# - `artifactId` removes all versions of an artifact from distribution
+# - `artifactId-version` removes specific version of an artifact from distribution
+# - `artifactId = url` removes all versions of an artifact from distribution, provides deprecation message URL
+#   See the header of deprecations.properties for details about deprecation messages.
 
 AntepediaReporter-CI-plugin      # closed-souce plugin; removal confirmed with owner, Guillaume Rousseau
 # service discontinued. Alternative: https://plugins.jenkins.io/appetize/ -- https://github.com/jenkins-infra/update-center2/pull/465

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -1,85 +1,132 @@
-# This file lists artifactId or artifactId-version values to hide in update center.
+# This file lists artifacts and specific versions of artifacts to hide in update center.
+# Possible syntaxes:
+# `artifactId` removes all versions of an artifact from distribution
+# `artifactId-version` removes specific version of an artifact from distribution
+# `artifactId = url` removes all versions of an artifact from distribution, provides deprecation message url
+# See comment in deprecations.properties for details about deprecation messages.
 
 AntepediaReporter-CI-plugin      # closed-souce plugin; removal confirmed with owner, Guillaume Rousseau
-appio                            # service discontinued. Alternative: https://plugins.jenkins.io/appetize/
-appthwack                        # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/AppThwack+Plugin
-assembla-oauth                   # renamed to assembla-auth https://groups.google.com/d/msg/jenkinsci-dev/TVz-D5etsUM/Knx9zXtEnSwJ
+# service discontinued. Alternative: https://plugins.jenkins.io/appetize/ -- https://github.com/jenkins-infra/update-center2/pull/465
+appio = https://git.io/JT9ZT
+# service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/AppThwack+Plugin
+appthwack = https://wiki.jenkins.io/x/cwchB
+# renamed to assembla-auth
+assembla-oauth = https://groups.google.com/d/msg/jenkinsci-dev/TVz-D5etsUM/Knx9zXtEnSwJ
 assembla-jenkins                 # Renamed to assembla
 associated-files-plugin          # renamed to associated-files
 aws-lambda-jenkins-plugin        # renamed to aws-lambda
 aws-lambda-plugin                # renamed to aws-lambda
 aws-yum-paramater                # renamed to package-parameter
-azure-iot-edge                   # deprecated
+# deprecated -- https://github.com/jenkinsci/azure-iot-edge-plugin/blob/master/Readme.md
+azure-iot-edge = https://git.io/JtOjd
 bees-sdk-plugin                  # removal requested by ndeloof: RUN@cloud service no longer exists
 binary-deployer                  # removal requested by alecharp: this plugin was never meant to be deployed. POC project.
-blackduck-installer              # "This plugin is no longer supported and should not be used." -- https://wiki.jenkins-ci.org/display/JENKINS/Black+Duck+Vulnerability+Installer+Plugin
-blackduck-hub                    # End of life.  Replaced with Detect. 
+# "This plugin is no longer supported and should not be used." -- https://wiki.jenkins-ci.org/display/JENKINS/Black+Duck+Vulnerability+Installer+Plugin
+blackduck-installer = https://wiki.jenkins.io/x/nYHHB
+# End of life.  Replaced with Detect. -- https://github.com/jenkins-infra/update-center2/pull/261
+blackduck-hub = https://git.io/JfaQa
 blitz.io-jenkins                 # renamed to blitz_io-jenkins
-blitz_io-jenkins                 # service discontinued: https://en.wikipedia.org/wiki/Blitz_(software)
-build-node-column                # superseded by Extra Columns Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Build+Node+Column+Plugin
-buildcoin-plugin                 # service discontinued: https://github.com/github/github-services/pull/538 -- https://wiki.jenkins-ci.org/display/JENKINS/Buildcoin+Plugin
-buildheroes                      # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Buildheroes
-codescan                         # service discontinued -- see https://www.codescan.io for alternative ways of running
-caroline                         # service shut down -- https://wiki.jenkins-ci.org/display/JENKINS/Caroline+Plugin
-ChatRoom                         # junk plugin; developer has been banned
-chrome-frame-plugin              # service discontinued https://www.chromium.org/developers/how-tos/chrome-frame-getting-started 
-cifs                             # Superseded by Publish Over CIFS Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/CIFS-Publisher+Plugin
-clang-scanbuild-plugin           # renamed to clang-scanbuild in https://github.com/jenkinsci/clang-scanbuild-plugin/commit/a6d57b67f6fbd0a9893ecf6436c54ecb670d5829
-cloudbees-deployer-plugin        # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Cloudbees+Deployer+Plugin
-cloudbees-enterprise-plugins     # Unsupported and retracted by service provider -- https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Jenkins+Enterprise
-cloudbees-registration           # "This feature is no longer relevant." -- https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Registration+Plugin
-cloudbees-disk-usage-simple-plugin # renamed to cloudbees-disk-usage-simple several years ago
-ColumnPack-plugin                # renamed to ColumnsPlugin
-ConfigurationSlicing             # renamed into configurationslicing, and this double causes a check out problem on Windows
-configuration-as-code-support    # deprecated
-convert-to-declarative           # renamed to declarative-pipeline-migration-assistant-plugin
+# service discontinued: https://en.wikipedia.org/wiki/Blitz_(software) -- https://github.com/jenkins-infra/update-center2/pull/521
+blitz_io-jenkins = https://git.io/J3d1Y
+# superseded by Extra Columns Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Build+Node+Column+Plugin
+build-node-column = https://wiki.jenkins.io/x/1QiMAw
+# service discontinued: https://github.com/github/github-services/pull/538 -- https://wiki.jenkins-ci.org/display/JENKINS/Buildcoin+Plugin
+buildcoin-plugin = https://wiki.jenkins.io/x/KoyhAw
+# service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Buildheroes
+buildheroes = https://wiki.jenkins.io/x/_AD8Aw
+# service discontinued -- see https://www.codescan.io for alternative ways of running -- https://github.com/jenkins-infra/update-center2/pull/299
+codescan = https://git.io/JfaQb
+# service shut down -- https://wiki.jenkins-ci.org/display/JENKINS/Caroline+Plugin
+caroline = https://wiki.jenkins.io/x/AwOMAw
+ChatRoom                          # junk plugin; developer has been banned
+# service discontinued https://www.chromium.org/developers/how-tos/chrome-frame-getting-started
+chrome-frame-plugin = https://www.chromium.org/developers/how-tos/chrome-frame-getting-started
+# Superseded by Publish Over CIFS Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/CIFS-Publisher+Plugin
+cifs = https://wiki.jenkins.io/x/lwC2Ag
+# renamed to clang-scanbuild in https://github.com/jenkinsci/clang-scanbuild-plugin/commit/a6d57b67f6fbd0a9893ecf6436c54ecb670d5829
+clang-scanbuild-plugin = https://git.io/JfaQr
+# service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Cloudbees+Deployer+Plugin
+cloudbees-deployer-plugin = https://wiki.jenkins.io/x/24RoAw
+# Unsupported and retracted by service provider -- https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Jenkins+Enterprise
+cloudbees-enterprise-plugins = https://wiki.jenkins.io/x/3gX8Aw
+# "This feature is no longer relevant." -- https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Registration+Plugin
+cloudbees-registration = https://wiki.jenkins.io/x/z4FLB
+# renamed to cloudbees-disk-usage-simple several years ago -- https://github.com/jenkins-infra/update-center2/pull/179
+cloudbees-disk-usage-simple-plugin = https://git.io/JfaQN
+ColumnPack-plugin                 # renamed to ColumnsPlugin
+ConfigurationSlicing              # renamed into configurationslicing, and this double causes a check out problem on Windows
+# deprecated -- https://github.com/jenkinsci/configuration-as-code-plugin/releases/tag/configuration-as-code-1.18
+configuration-as-code-support = https://git.io/JfaHz
+convert-to-declarative            # renamed to declarative-pipeline-migration-assistant-plugin
 convert-to-declarative-api       # renamed to declarative-pipeline-migration-assistant-plugin
-copyarchiver                     # superseded by ArtifactDeployer Plugin  -- https://wiki.jenkins-ci.org/display/JENKINS/CopyArchiver+Plugin
-cppunit                          # Incompatible with Hudson 1.355+ and superseded by xUnit Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/CppUnit+Plugin
+# superseded by ArtifactDeployer Plugin  -- https://wiki.jenkins-ci.org/display/JENKINS/CopyArchiver+Plugin
+copyarchiver = https://wiki.jenkins.io/x/ywJAAg
+# Incompatible with Hudson 1.355+ and superseded by xUnit Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/CppUnit+Plugin
+cppunit = https://wiki.jenkins.io/x/6oE5Ag
 create-fingerprint-plugin        # renamed to create-fingerprint
 datadog-build-reporter           # renamed to datadog
 delphix-plugin                   # renamed to delphix
 description-column               # renamed to description-column-plugin
-dockerhub                        # removal requested by teilo, superceded by dockerhub-notification
+# removal requested by teilo, superceded by dockerhub-notification -- https://github.com/jenkins-infra/update-center2/commit/e5a138873113d0e2d6af59d5699215a1835c15b7
+dockerhub = https://git.io/JfaQF
 drools                           # deprecated
-emotional-hudson                 # Superseded by Emotional Jenkins -- https://wiki.jenkins-ci.org/display/JENKINS/Emotional+Hudson+Plugin
+# Superseded by Emotional Jenkins -- https://wiki.jenkins-ci.org/display/JENKINS/Emotional+Hudson+Plugin
+emotional-hudson = https://wiki.jenkins.io/x/C4DX
 essentials                       # replaced by evergreen
 evergreen                        # not supposed to be installed manually. We use Incrementals http://repo.jenkins-ci.org/incrementals/io/jenkins/plugins/evergreen
-external-scheduler               # deprecated
+# deprecated -- https://github.com/jenkins-infra/update-center2/pull/257
+external-scheduler = https://git.io/JfaQ5
 first-plugin                     # INFRA-1108: Unintended release as part of a plugin tutorial workshop
 foofoo                           # junk: contains only the HelloWorldBuilder sample
 foreman-node-sharing             # Reimplemented as https://github.com/jenkinsci/node-sharing-plugin/
-gerrit                           # superseded by Gerrit Trigger Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Gerrit+Plugin
-girls                            # no... just... no -- https://wiki.jenkins-ci.org/display/JENKINS/Girls+Plugin
-gitorious                        # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Gitorious+Plugin
-google-desktop-gadget            # Google Desktop has been discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Hudson+Google+Desktop+Gadget
-googlecode                       # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Google+Code+Plugin
+# superseded by Gerrit Trigger Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Gerrit+Plugin
+gerrit = https://wiki.jenkins.io/x/9ICVAg
+# no... just... no -- https://wiki.jenkins-ci.org/display/JENKINS/Girls+Plugin
+girls = https://wiki.jenkins.io/x/OAWbAg
+# service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Gitorious+Plugin
+gitorious = https://wiki.jenkins.io/x/ngDiAw
+# Google Desktop has been discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Hudson+Google+Desktop+Gadget
+google-desktop-gadget = https://wiki.jenkins.io/x/E4A3AQ
+# service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Google+Code+Plugin
+googlecode = https://wiki.jenkins.io/x/DQC7
 groovy-events-listener-plugin-master # unintentional fork of groovy-events-listener-plugin
-hall-jenkins                     # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Hall+Plugin
+# service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Hall+Plugin
+hall-jenkins = https://wiki.jenkins.io/x/qQghB
 hello-world                      # people shouldn't actually *publish* the sample project!
 HiddenParameter                  # renamed to hidden-parameter
 hipchat-plugin                   # renamed to hipchat
-hockeyapp                        # service discontinued -- https://wiki.jenkins.io/display/JENKINS/HockeyApp+Plugin
+# service discontinued -- https://wiki.jenkins.io/display/JENKINS/HockeyApp+Plugin
+hockeyapp = https://wiki.jenkins.io/x/7oPPAw
 hudson-logaction-plugin          # renamed to logaction-plugin
 hudson-startup-trigger           # renamed to startup-trigger-plugin
 icon-shim-plugin                 # renamed to icon-shim
 integrity                        # renamed to integrity-plugin
-ion-deployer-plugin              # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/iON+Deployer+Plugin
+# service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/iON+Deployer+Plugin
+ion-deployer-plugin = https://wiki.jenkins.io/x/FhOMAw
 ivy2                             # subsumed into the ivy plugin
-javanet                          # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Java.net+Plugin
-javanet-uploader                 # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/java.net+uploader+Plugin
+# service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Java.net+Plugin
+javanet = https://wiki.jenkins.io/x/AgDL
+# service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/java.net+uploader+Plugin
+javanet-uploader = https://wiki.jenkins.io/x/ZoAL
 jbehave-hudson-plugin            # renamed to jbehave-jenkins-plugin
 jenkins-leiningen                # renamed to leiningen-plugin :'(
-jenkins-tracker                  # deleted by maintainers, https://issues.jenkins-ci.org/browse/INFRA-1531
+# deleted by maintainers
+jenkins-tracker = https://issues.jenkins.io/browse/INFRA-1531
 jenkinswalldisplay-pom           # renamed to jenkinswalldisplay
-jenkow-activiti-designer         # unmaintained -- https://wiki.jenkins-ci.org/display/JENKINS/Jenkow+Activiti+Designer
-jenkow-activiti-explorer         # unmaintained -- https://wiki.jenkins-ci.org/display/JENKINS/Jenkow+Activiti+Explorer
-jenkow-plugin                    # unmaintained -- https://wiki.jenkins-ci.org/display/JENKINS/Jenkow+Plugin
+# unmaintained -- https://wiki.jenkins-ci.org/display/JENKINS/Jenkow+Activiti+Designer
+jenkow-activiti-designer = https://wiki.jenkins.io/x/ngnqAw
+# unmaintained -- https://wiki.jenkins-ci.org/display/JENKINS/Jenkow+Activiti+Explorer
+jenkow-activiti-explorer = https://wiki.jenkins.io/x/yQH8Aw
+# unmaintained -- https://wiki.jenkins-ci.org/display/JENKINS/Jenkow+Plugin
+jenkow-plugin = https://wiki.jenkins.io/x/WIuhAw
 jgiven-plugin                    # renamed to jgiven
 jmeter                           # renamed to performance
-jshint-checkstyle                # deprecated
+# deprecated -- https://github.com/jenkins-infra/update-center2/pull/21
+jshint-checkstyle = https://git.io/JsmW2
 jslint-checkstyle                # renamed to jshint-checkstyle
-kanboard-publisher               # renamed to kanboard, see https://issues.jenkins-ci.org/browse/HOSTING-241?focusedCommentId=280720&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-280720
+# renamed to kanboard, see https://issues.jenkins-ci.org/browse/HOSTING-241?focusedCommentId=280720&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-280720
+# https://github.com/jenkins-infra/update-center2/pull/94
+kanboard-publisher = https://git.io/JfaQH
 karotz                           # service discontinued: https://twitter.com/Karotz/status/527852693960658944 -- https://wiki.jenkins-ci.org/display/JENKINS/Karotz+Plugin
 kato                             # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Kato+Plugin
 koji-plugin                      # renamed to koji
@@ -87,69 +134,101 @@ kundo                            # service discontinued -- https://wiki.jenkins-
 lechat                           # renamed to Kata which was discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/LeChat+Plugin
 loadrunner                       # closed-source plugin, removal requested by plugin author
 liverebel-deploy                 # only worked with obsolete releases -- https://wiki.jenkins-ci.org/display/JENKINS/LiveRebel+Plugin
-m2-extra-steps                   # part of core functionality since 1.433 -- https://wiki.jenkins-ci.org/display/JENKINS/M2+Extra+Steps+Plugin
-mansion-cloud                    # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Cloud+Connector+Plugin
+# part of core functionality since 1.433 -- https://wiki.jenkins-ci.org/display/JENKINS/M2+Extra+Steps+Plugin
+m2-extra-steps = https://wiki.jenkins.io/x/FIc5Ag
+# service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Cloud+Connector+Plugin
+mansion-cloud = https://wiki.jenkins.io/x/YwdRB
 mber                             # service discontinued -- https://wiki.jenkins.io/display/JENKINS/Mber+Plugin
-mcap-eas-plugin                  # superseded by Relution Publisher (see https://github.com/mwaylabs/jenkins-mcap-eas-plugin)
+# superseded by Relution Publisher (see https://github.com/mwaylabs/jenkins-mcap-eas-plugin)
+mcap-eas-plugin = https://git.io/JfaQ9
 mogotest                         # deprecated: mogotest service no longer exists
-mypeople                         # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/MyPeople+Plugin
-nabaztag                         # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Nabaztag+Plugin
-netio-plugin                     # product discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Netio-Plugin
-nodeofflinenotification          # superseded by Mail Watcher Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Node+Offline+Notification+Plugin
-notifo                           # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Notifo+Plugin
+# service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/MyPeople+Plugin
+mypeople = https://wiki.jenkins.io/x/xQRCB
+# service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Nabaztag+Plugin
+nabaztag = https://wiki.jenkins.io/x/dIEuAg
+# product discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Netio-Plugin
+netio-plugin = https://wiki.jenkins.io/x/7gMHB
+# superseded by Mail Watcher Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Node+Offline+Notification+Plugin
+nodeofflinenotification = https://wiki.jenkins.io/x/0IKhAw
+# service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Notifo+Plugin
+notifo = https://wiki.jenkins.io/x/0ADDAg
 octoperf-jenkins-plugin          # released from wrong repository; will be renamed
 openstack-plugin                 # renamed to openstack-cloud
-origo-issue-notifier             # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Origo+Issue+Notifier
+# service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Origo+Issue+Notifier
+origo-issue-notifier = https://wiki.jenkins.io/x/qgabAg
 otabuilder                       # latest sources at https://github.com/jeslyvarghese/otabuilder-plugin but discontinued due to tool chain discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Over-the-Air+Ad+Hoc+Deployment+Plugin+For+iOS
 paaslane                         # renamed to paaslane-estimate
-paranoia                         # renamed to extended-security-settings
+# renamed to extended-security-settings -- https://github.com/jenkins-infra/update-center2/pull/291
+paranoia = https://git.io/JfaQS
 pathignore-plugin                # renamed to pathignore
-perfectomobile                   # plugin obsolete, replaced by https://plugins.jenkins.io/perfecto/
+# plugin obsolete, replaced by https://plugins.jenkins.io/perfecto/
+perfectomobile = https://developers.perfectomobile.com/display/PD/Legacy+%7C+Jenkins+plugin
 perfectomobile-jenkins           # renamed to perfectomobile
 PerfPublisher                    # latest releases use "perfpublisher"
-pipeline-classpath               # https://jenkins.io/security/advisory/2017-03-20
-pipeline-editor                  # Unclear, but probably removed by author -- TODO ask Michael Neale -- https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Editor+Plugin
-poll-mailbox-trigger             # renamed to poll-mailbox-trigger-plugin :(
-pretest-commit                   # discontinued PoC, use Pretested Integration Plugin instead -- https://wiki.jenkins-ci.org/display/JENKINS/Pretest+Commit+Plugin
-PUCM                             # superseded by ClearCase UCM Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/pucm+plugin
+# https://jenkins.io/security/advisory/2017-03-20
+pipeline-classpath = https://www.jenkins.io/security/plugins/#suspensions
+# Removed by author -- https://github.com/jenkinsci/pipeline-editor-plugin
+pipeline-editor = https://git.io/JfaQy
+# renamed to poll-mailbox-trigger-plugin :( -- https://github.com/jenkins-infra/update-center2/pull/42
+poll-mailbox-trigger = https://git.io/JfaQM
+# discontinued PoC, use Pretested Integration Plugin instead -- https://wiki.jenkins-ci.org/display/JENKINS/Pretest+Commit+Plugin
+pretest-commit = https://wiki.jenkins.io/x/5gB-B
+# superseded by ClearCase UCM Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/pucm+plugin
+PUCM = https://wiki.jenkins.io/x/fIBVAw
 rally-bookkeeper                 # removal requested by Mike Rogers: will be Rally plugin 2.0
 rally-update-plugin-1            # renamed to rally-plugin(!)
 release-multi-test               # junk: contains only the HelloWorldBuilder sample
 release-test                     # junk: contains only the HelloWorldBuilder sample
 Relution                         # renamed to relution-publisher
-rtc                              # superseded by Team Concert Plugin
+# superseded by Team Concert Plugin -- https://github.com/jenkins-infra/update-center2/pull/13
+rtc = https://git.io/JfaQ1
 sahagin-jenkins-plugin           # renamed to sahagin-plugin
 sample                           # junk plugin; developer has been banned
 schedule-build-plugin            # renamed to schedule-build
-schedule-failed-builds           # superseded by Naginator Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Retry+Failed+Builds+Plugin
-scis-ad                          # deprecated
-scm-branch-pr-filter             # renamed shortly after publication for https://github.com/jenkins-infra/repository-permissions-updater/pull/459#issuecomment-334702817
+# superseded by Naginator Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Retry+Failed+Builds+Plugin
+schedule-failed-builds = https://wiki.jenkins.io/x/roM5Ag
+# deprecated -- https://github.com/jenkins-infra/update-center2/commit/5f3f5ae66ea0e819c27d6d1fed9fdb00781f636c
+scis-ad = https://git.io/JfaQX
+# renamed shortly after publication for https://github.com/jenkins-infra/repository-permissions-updater/pull/459#issuecomment-334702817
+scm-branch-pr-filter = https://issues.jenkins.io/browse/INFRA-1358
 script-realm-extended            # fork of a plugin and has since been subsumed -- https://wiki.jenkins-ci.org/display/JENKINS/Script+Security+Realm+Extended
-SCTMExecutor                     # plugin obsolete, replaced by Gradle-based invocation; depublishing as requested by 'silk' in SECURITY-1521
-secret                           # superseded by Credentials Binding Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Build+Secret+Plugin
+# plugin obsolete, replaced by Gradle-based invocation; depublishing as requested by 'silk' in SECURITY-1521, see https://github.com/jenkins-infra/update-center2/pull/324
+SCTMExecutor = https://git.io/JfaQP
+# superseded by Credentials Binding Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Build+Secret+Plugin
+secret = https://wiki.jenkins.io/x/9ghSAg
 security-no-captcha              # Functionality integrated in Jenkins 1.416 -- https://wiki.jenkins-ci.org/display/JENKINS/Security+No+CAPTCHA
 serenitec                        # gbossert asked to remove this plugin
-setenv                           # superseded by envinject -- https://wiki.jenkins-ci.org/display/JENKINS/Setenv+Plugin
+# superseded by envinject -- https://wiki.jenkins-ci.org/display/JENKINS/Setenv+Plugin
+setenv = https://wiki.jenkins.io/x/YAtSAg
 skytap-cloud-plugin              # renamed to skytap
 sms-notification                 # renamed to sms
-sonargraph-plugin                # superseded by sonargraph-integration
-sonatype-ci                      # deprecated (see Sonatype CLM: https://wiki.jenkins-ci.org/x/iYDPAw)
+# superseded by sonargraph-integration -- https://github.com/jenkins-infra/update-center2/pull/405
+sonargraph-plugin = https://git.io/JJ5h1
+# deprecated (see Sonatype CLM: https://wiki.jenkins-ci.org/x/iYDPAw)
+sonatype-ci = https://wiki.jenkins.io/x/iYDPAw
 ssh2easy-plugin                  # removal requested by plugin author, accidental rename
-tepco                            # unused? -- https://wiki.jenkins-ci.org/display/JENKINS/TEPCO+Plugin
-tepco-epuw                       # unused? -- https://wiki.jenkins-ci.org/display/JENKINS/TEPCO+Electric+Power+Usage+Widget
+# unused? -- https://wiki.jenkins-ci.org/display/JENKINS/TEPCO+Plugin
+tepco = https://wiki.jenkins.io/x/zoBoAw
+# unused? -- https://wiki.jenkins-ci.org/display/JENKINS/TEPCO+Electric+Power+Usage+Widget
+tepco-epuw = https://wiki.jenkins.io/x/vohoAw
 TestExecuter                     # renamed to selected-tests-executor
-testflight                       # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Testflight+Plugin
+# service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Testflight+Plugin
+testflight = https://wiki.jenkins.io/x/pwZ1Aw
 TestResultsAnalyzer              # renamed to test-results-analyzer
 tusarnotifier                    # superseded by DTKit Plugin with automatic migration -- https://wiki.jenkins-ci.org/display/JENKINS/TusarNotifier
 uithemes                         # removal requested by tfennelly
 upload-artifacts-to-nexus        # renamed, see https://issues.jenkins-ci.org/browse/HOSTING-41?focusedCommentId=250383&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-250383
-url-change-trigger               # Superseded by URLTrigger Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/URL+Change+Trigger
-vagrant-plugin                   # renamed to vagrant, herpderp
-vessel                           # service discontinued --- https://wiki.jenkins-ci.org/display/JENKINS/Vessel+plugin https://groups.google.com/d/msg/jenkinsci-dev/L34eAMMWA5o/-AxtRdGsAAAJ
+# Superseded by URLTrigger Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/URL+Change+Trigger
+url-change-trigger = https://wiki.jenkins.io/x/BQBJ
+vagrant-plugin                    # renamed to vagrant, herpderp
+# service discontinued --- https://wiki.jenkins-ci.org/display/JENKINS/Vessel+plugin https://groups.google.com/d/msg/jenkinsci-dev/L34eAMMWA5o/-AxtRdGsAAAJ
+vessel = https://groups.google.com/d/msg/jenkinsci-dev/L34eAMMWA5o/-AxtRdGsAAAJ
 weibo4jenkins                    # renamed to weibo
 wsnotifier                       # renamed to websocket
-xltest-plugin                    # renamed to xltestview-plugin in https://github.com/jenkinsci/xltestview-plugin/commit/ea034f9929b520e63b9ce15aed9bdb62354146cf
-zaproxy                          # superseded by zap -- https://wiki.jenkins-ci.org/display/JENKINS/ZAProxy+Plugin
+# renamed to xltestview-plugin in https://github.com/jenkinsci/xltestview-plugin/commit/ea034f9929b520e63b9ce15aed9bdb62354146cf
+xltest-plugin = https://git.io/JfaQK
+# superseded by zap -- https://wiki.jenkins-ci.org/display/JENKINS/ZAProxy+Plugin
+zaproxy = https://wiki.jenkins.io/x/JgCsB
 zaproxy-jenkins                  # renamed to zaproxy
 zubhium                          # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Zubhium+Plugin
 
@@ -234,11 +313,14 @@ delivery-pipeline-plugin-1.0.4
 
 # https://jenkins.io/security/advisory/2017-04-10/
 AdaptivePlugin                # SECURITY-457
-build-flow-plugin             # SECURITY-293
+# SECURITY-293
+build-flow-plugin = https://www.jenkins.io/security/plugins/#suspensions
 cas1                          # SECURITY-491
 cvs-tag                       # SECURITY-459
-dynamicparameter              # SECURITY-462
-grails                        # SECURITY-458
+# SECURITY-462
+dynamicparameter = https://www.jenkins.io/security/plugins/#suspensions
+# SECURITY-458
+grails = https://www.jenkins.io/security/plugins/#suspensions
 groovyaxis                    # SECURITY-460
 reactor-plugin                # SECURITY-487
 script-scm                    # SECURITY-461
@@ -261,15 +343,21 @@ scriptler-2.6                 # SECURITY-367 etc.
 scriptler-2.6.1               # SECURITY-367 etc.
 scriptler-2.7                 # SECURITY-367 etc.
 scriptler-2.9                 # SECURITY-367 etc.
-scripttrigger                 # SECURITY-456
-svn-tag                       # SECURITY-298
+# SECURITY-456
+scripttrigger = https://www.jenkins.io/security/plugins/#suspensions
+# SECURITY-298
+svn-tag = https://www.jenkins.io/security/plugins/#suspensions
 tcl                           # SECURITY-379
 
 # These plugins depend on one or more plugins suspended due to the 2017-04-10 advisory
-build-flow-extensions-plugin  # depends on build-flow-plugin, buildgraph-view
-build-flow-test-aggregator    # depends on build-flow-plugin
-build-flow-toolbox-plugin     # depends on build-flow-plugin
-externalresource-dispatcher   # depends on build-flow-plugin
+# depends on build-flow-plugin, buildgraph-view
+build-flow-extensions-plugin = https://www.jenkins.io/security/plugins/#suspensions
+# depends on build-flow-plugin
+build-flow-test-aggregator = https://www.jenkins.io/security/plugins/#suspensions
+# depends on build-flow-plugin
+build-flow-toolbox-plugin = https://www.jenkins.io/security/plugins/#suspensions
+# depends on build-flow-plugin
+externalresource-dispatcher = https://groups.google.com/d/msg/jenkinsci-dev/YKfydxnpvyE/mMN7LNBoBgAJ
 uno-choice-1.0                # While we serve pre-2.7 update sites; depends on scriptler
 uno-choice-1.1                # While we serve pre-2.7 update sites; depends on scriptler
 uno-choice-1.2                # While we serve pre-2.7 update sites; depends on scriptler
@@ -280,7 +368,8 @@ uno-choice-1.4                # While we serve pre-2.7 update sites; depends on 
 uno-choice-1.5.1              # While we serve pre-2.7 update sites; depends on scriptler
 uno-choice-1.5.2              # While we serve pre-2.7 update sites; depends on scriptler
 uno-choice-1.5.3              # While we serve pre-2.7 update sites; depends on scriptler
-xtrigger                      # depends on scripttrigger
+# depends on scripttrigger
+xtrigger = https://www.jenkins.io/security/plugins/#suspensions
 
 
 # These plugins implement Groovy scripting in an unsafe way, but are currently unreleased -- so suspend preemptively
@@ -316,8 +405,8 @@ jenkins-war-2.247
 azure-slave-plugin
 
 # Plugins not fixed in https://jenkins.io/security/advisory/2018-03-26/
-copy-to-slave
-perforce
+copy-to-slave = https://www.jenkins.io/security/plugins/#suspensions
+perforce = https://www.jenkins.io/security/advisory/2018-03-26/#SECURITY-373
 build-configurator  # depends on copy-to-slave
 lsf-cloud           # depends on copy-to-slave
 sge-cloud-plugin    # depends on copy-to-slave
@@ -357,7 +446,8 @@ git-client-3.0.0-rc
 
 # Replaced by the official fortify plugin https://wiki.jenkins.io/display/JENKINS/Fortify+Plugin
 fortify360
-fortify-cloudscan-jenkins-plugin
+# https://github.com/jenkinsci/fortify-cloudscan-plugin#deprecation-notice
+fortify-cloudscan-jenkins-plugin = https://git.io/JfhPD
 
 # Failed shading Snakeyaml, 1.9 has both shaded and direct dependency inside
 configuration-as-code-1.9
@@ -374,14 +464,17 @@ xltestview-plugin # apparently the service no longer exists anyway
 upload-pgyer-1.32
 
 # https://jenkins.io/security/advisory/2019-09-25/
-kubernetes-pipeline-arquillian-steps
-kubernetes-pipeline-steps
-kubernetes-pipeline-aggregator # mandatory dependency to the two plugins above
+kubernetes-pipeline-arquillian-steps = https://www.jenkins.io/security/plugins/#suspensions
+kubernetes-pipeline-steps = https://www.jenkins.io/security/plugins/#suspensions
+# mandatory dependency to the two plugins above
+kubernetes-pipeline-aggregator = https://www.jenkins.io/security/plugins/#suspensions
 
 # https://jenkins.io/security/advisory/2019-10-16/
 puppet-enterprise-pipeline
 
-veracode-scanner # not actively maintained (https://wiki.jenkins.io/display/JENKINS/Veracode+Scanner+Plugin), replaced by official Veracode plugin https://help.veracode.com/reader/PgbNZUD7j8aY7iG~hQZWxQ/yQtYXnlbLA6wsWodLn5zdw
+# not actively maintained (https://wiki.jenkins.io/display/JENKINS/Veracode+Scanner+Plugin), replaced by official Veracode plugin https://help.veracode.com/reader/PgbNZUD7j8aY7iG~hQZWxQ/yQtYXnlbLA6wsWodLn5zdw
+# https://github.com/jenkins-infra/update-center2/pull/302
+veracode-scanner = https://git.io/JfaQ6
 
 # https://issues.jenkins-ci.org/browse/JENKINS-59903 and https://issues.jenkins-ci.org/browse/JENKINS-59907
 durable-task-1.31
@@ -498,11 +591,11 @@ ci-with-toad-edge-1.2
 ci-with-toad-edge-2.0
 ci-with-toad-devops-toolkit
 
-# Depublished as agreed with maintainer after SECURITY-1879 in 2020-06-03 security advisory
-play-autotest-plugin
+# Depublished as agreed with maintainer after SECURITY-1879 in 2020-06-03 security advisory -- https://github.com/jenkins-infra/update-center2/pull/384
+play-autotest-plugin = https://git.io/JsmWA
 
 # Depublishing for RCE vulnerability, see https://www.jenkins.io/security/advisory/2020-07-02/#SECURITY-1738
-kubernetes-ci
+kubernetes-ci = https://www.jenkins.io/security/plugins/#suspensions
 
 # Depublishing for having a dependency on itself, causing JENKINS-63877
 tics-1.0
@@ -519,31 +612,32 @@ jsgames
 nerrvana
 
 # Arbitrary file read vulnerability while bringing no real benefits, see https://www.jenkins.io/security/advisory/2020-10-08/#SECURITY-2046
-persona
+persona = https://www.jenkins.io/security/plugins/#suspensions
 
 # Non-open dependency, see INFRA-2751
-tfs
+tfs = https://issues.jenkins.io/browse/INFRA-2751
 
 # INFRA-2487 -- suspend analysis-core and all plugins with a non-optional dependency on it
-analysis-collector
-analysis-core
-android-lint
-brakeman
-ccm
-CFLint
-checkstyle
-ci-game
-codeclimate-plugin
-codescanner
-cpptest
-DotCi-Plugins-Starter-Pack
-dry
-findbugs
-php
-pmd
-swamp
-tasks
-warnings
+analysis-collector = https://issues.jenkins.io/browse/INFRA-2487
+analysis-core = https://issues.jenkins.io/browse/INFRA-2487
+android-lint = https://issues.jenkins.io/browse/INFRA-2487
+ccm = https://issues.jenkins.io/browse/INFRA-2487
+CFLint = https://issues.jenkins.io/browse/INFRA-2487
+checkstyle = https://issues.jenkins.io/browse/INFRA-2487
+ci-game = https://issues.jenkins.io/browse/INFRA-2487
+codeclimate-plugin = https://issues.jenkins.io/browse/INFRA-2487
+codescanner = https://issues.jenkins.io/browse/INFRA-2487
+cpptest = https://issues.jenkins.io/browse/INFRA-2487
+DotCi-Plugins-Starter-Pack = https://issues.jenkins.io/browse/INFRA-2487
+dry = https://issues.jenkins.io/browse/INFRA-2487
+findbugs = https://issues.jenkins.io/browse/INFRA-2487
+php = https://issues.jenkins.io/browse/INFRA-2487
+pmd = https://issues.jenkins.io/browse/INFRA-2487
+swamp = https://issues.jenkins.io/browse/INFRA-2487
+tasks = https://issues.jenkins.io/browse/INFRA-2487
+warnings = https://issues.jenkins.io/browse/INFRA-2487
+# Functionality merged into warnings-ng to support INFRA-2487 -- https://github.com/jenkinsci/brakeman-plugin/issues/23
+brakeman = https://git.io/JT2XI
 
 # Suppress a release with regression that causes node's computer to be null
 spotinst-2.0.26

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -407,10 +407,14 @@ azure-slave-plugin
 # Plugins not fixed in https://jenkins.io/security/advisory/2018-03-26/
 copy-to-slave = https://www.jenkins.io/security/plugins/#suspensions
 perforce = https://www.jenkins.io/security/advisory/2018-03-26/#SECURITY-373
-build-configurator  # depends on copy-to-slave
-lsf-cloud           # depends on copy-to-slave
-sge-cloud-plugin    # depends on copy-to-slave
-reviewboard         # depends on perforce
+# depends on copy-to-slave
+build-configurator = https://www.jenkins.io/security/plugins/#suspensions
+# depends on copy-to-slave
+lsf-cloud = https://www.jenkins.io/security/plugins/#suspensions
+# depends on copy-to-slave
+sge-cloud-plugin = https://www.jenkins.io/security/plugins/#suspensions
+# depends on perforce
+reviewboard = https://www.jenkins.io/security/plugins/#suspensions
 
 # Licensing issue, see INFRA-2622
 liquibase-runner-1.0.0

--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -1,6 +1,7 @@
-# This file contains deprecated plugins (keys) and the URL the deprecation notice on plugins.jenkins.io and in Jenkins should link to (value).
+# This file contains deprecated plugins (keys) and the URL the deprecation notice on plugins.jenkins.io and in Jenkins
+# should link to (value). Use this file to mark a plugin as deprecated while continuing to distribute it. If a plugin
+# should be removed from distribution entirely, instead set a deprecation notice URL in artifact-ignores.properties.
 # Shorten URLs if and only if the URLs are to github.com (git.io) or wiki.jenkins.io. Record the real URL in a comment.
-# If a plugin is removed from distribution entirely, instead set a deprecation notice URL in artifact-ignores.properties.
 
 # https://github.com/jenkinsci/jenkins/pull/5320
 BlameSubversion = https://git.io/Jn6Co

--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -1,8 +1,6 @@
-# This file contains deprecated plugins (keys) and the URL the deprecation notice should link to (value).
-# While plugins can be deprecated through labels, that requires that the plugins continue being published.
-# Additionally, this file allows referencing deprecation notices outside of (obsolete or non-existing) plugin documentation.
+# This file contains deprecated plugins (keys) and the URL the deprecation notice on plugins.jenkins.io and in Jenkins should link to (value).
 # Shorten URLs if and only if the URLs are to github.com (git.io) or wiki.jenkins.io. Record the real URL in a comment.
-# If a plugin is removed from distribution, it should define deprecation notice URL in artifact-ignores.properties.
+# If a plugin is removed from distribution entirely, instead set a deprecation notice URL in artifact-ignores.properties.
 
 # https://github.com/jenkinsci/jenkins/pull/5320
 BlameSubversion = https://git.io/Jn6Co

--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -1,217 +1,34 @@
 # This file contains deprecated plugins (keys) and the URL the deprecation notice should link to (value).
 # While plugins can be deprecated through labels, that requires that the plugins continue being published.
-# This file allows marking plugins as deprecated while not publishing them otherwise.
 # Additionally, this file allows referencing deprecation notices outside of (obsolete or non-existing) plugin documentation.
 # Shorten URLs if and only if the URLs are to github.com (git.io) or wiki.jenkins.io. Record the real URL in a comment.
+# If a plugin is removed from distribution, it should define deprecation notice URL in artifact-ignores.properties.
 
-analysis-collector = https://issues.jenkins.io/browse/INFRA-2487
-analysis-core = https://issues.jenkins.io/browse/INFRA-2487
-android-lint = https://issues.jenkins.io/browse/INFRA-2487
-# https://github.com/jenkins-infra/update-center2/pull/465
-appio = https://git.io/JT9ZT
-# https://wiki.jenkins.io/display/JENKINS/AppThwack+Plugin
-appthwack = https://wiki.jenkins.io/x/cwchB
-assembla-oauth = https://groups.google.com/d/msg/jenkinsci-dev/TVz-D5etsUM/Knx9zXtEnSwJ
-# https://github.com/jenkinsci/azure-iot-edge-plugin/blob/master/Readme.md
-azure-iot-edge = https://git.io/JtOjd
-# https://github.com/jenkins-infra/update-center2/pull/261
-blackduck-hub = https://git.io/JfaQa
-# https://wiki.jenkins.io/display/JENKINS/Black+Duck+Vulnerability+Installer+Plugin
-blackduck-installer = https://wiki.jenkins.io/x/nYHHB
 # https://github.com/jenkinsci/jenkins/pull/5320
 BlameSubversion = https://git.io/Jn6Co
 # https://github.com/jenkins-infra/update-center2/pull/521
-blitz_io-jenkins = https://git.io/J3d1Y
 blueocean-executor-info = https://issues.jenkins.io/browse/JENKINS-56773
-# https://github.com/jenkinsci/brakeman-plugin/issues/23
-brakeman = https://git.io/JT2XI
-build-flow-extensions-plugin = https://www.jenkins.io/security/plugins/#suspensions
-build-flow-test-aggregator = https://www.jenkins.io/security/plugins/#suspensions
-build-flow-toolbox-plugin = https://www.jenkins.io/security/plugins/#suspensions
-build-flow-plugin = https://www.jenkins.io/security/plugins/#suspensions
-# https://wiki.jenkins.io/display/JENKINS/Build+Node+Column+Plugin
-build-node-column = https://wiki.jenkins.io/x/1QiMAw
-# https://wiki.jenkins.io/display/JENKINS/Buildcoin+Plugin
-buildcoin-plugin = https://wiki.jenkins.io/x/KoyhAw
-# https://wiki.jenkins.io/display/JENKINS/Buildheroes
-buildheroes = https://wiki.jenkins.io/x/_AD8Aw
-# https://wiki.jenkins.io/display/JENKINS/Caroline+Plugin
-caroline = https://wiki.jenkins.io/x/AwOMAw
-ccm = https://issues.jenkins.io/browse/INFRA-2487
-CFLint = https://issues.jenkins.io/browse/INFRA-2487
-checkstyle = https://issues.jenkins.io/browse/INFRA-2487
-chrome-frame-plugin = https://www.chromium.org/developers/how-tos/chrome-frame-getting-started
-# https://wiki.jenkins.io/display/JENKINS/CIFS-Publisher+Plugin
-ci-game = https://issues.jenkins.io/browse/INFRA-2487
-cifs = https://wiki.jenkins.io/x/lwC2Ag
-# https://github.com/jenkinsci/clang-scanbuild-plugin/commit/a6d57b67f6fbd0a9893ecf6436c54ecb670d5829
-clang-scanbuild-plugin = https://git.io/JfaQr
-# https://wiki.jenkins.io/display/JENKINS/Cloudbees+Deployer+Plugin
-cloudbees-deployer-plugin = https://wiki.jenkins.io/x/24RoAw
-# https://github.com/jenkins-infra/update-center2/pull/179
-cloudbees-disk-usage-simple-plugin = https://git.io/JfaQN
-# https://wiki.jenkins.io/display/JENKINS/CloudBees+Jenkins+Enterprise
-cloudbees-enterprise-plugins = https://wiki.jenkins.io/x/3gX8Aw
-# https://wiki.jenkins.io/display/JENKINS/CloudBees+Registration+Plugin
-cloudbees-registration = https://wiki.jenkins.io/x/z4FLB
 # https://github.com/jenkinsci/jenkins/pull/5320
 cloverphp = https://git.io/Jn6Co
 # https://github.com/jenkinsci/jenkins/pull/5320
 cmvc = https://git.io/Jn6Co
-codeclimate-plugin = https://issues.jenkins.io/browse/INFRA-2487
-# https://github.com/jenkins-infra/update-center2/pull/299
-codescanner = https://issues.jenkins.io/browse/INFRA-2487
-codescan = https://git.io/JfaQb
 # https://github.com/jenkinsci/jenkins/pull/5320
 config-rotator = https://git.io/Jn6Co
-# https://github.com/jenkinsci/configuration-as-code-plugin/releases/tag/configuration-as-code-1.18
-configuration-as-code-support = https://git.io/JfaHz
-# https://wiki.jenkins.io/display/JENKINS/CopyArchiver+Plugin
-copyarchiver = https://wiki.jenkins.io/x/ywJAAg
-copy-to-slave = https://www.jenkins.io/security/plugins/#suspensions
-cpptest = https://issues.jenkins.io/browse/INFRA-2487
-# https://wiki.jenkins.io/display/JENKINS/CppUnit+Plugin
-cppunit = https://wiki.jenkins.io/x/6oE5Ag
-# https://github.com/jenkins-infra/update-center2/commit/e5a138873113d0e2d6af59d5699215a1835c15b7
-dockerhub = https://git.io/JfaQF
-DotCi-Plugins-Starter-Pack = https://issues.jenkins.io/browse/INFRA-2487
-dry = https://issues.jenkins.io/browse/INFRA-2487
-dynamicparameter = https://www.jenkins.io/security/plugins/#suspensions
 # https://github.com/jenkinsci/jenkins/pull/5320
 emma = https://git.io/Jn6Co
-# https://wiki.jenkins.io/display/JENKINS/Emotional+Hudson+Plugin
-emotional-hudson = https://wiki.jenkins.io/x/C4DX
-# https://github.com/jenkins-infra/update-center2/pull/257
-external-scheduler = https://git.io/JfaQ5
-externalresource-dispatcher = https://groups.google.com/d/msg/jenkinsci-dev/YKfydxnpvyE/mMN7LNBoBgAJ
-findbugs = https://issues.jenkins.io/browse/INFRA-2487
-# https://github.com/jenkinsci/fortify-cloudscan-plugin#deprecation-notice
-fortify-cloudscan-jenkins-plugin = https://git.io/JfhPD
-# https://wiki.jenkins.io/display/JENKINS/Gerrit+Plugin
-gerrit = https://wiki.jenkins.io/x/9ICVAg
-# https://wiki.jenkins.io/display/JENKINS/Girls+Plugin
-girls = https://wiki.jenkins.io/x/OAWbAg
-# https://wiki.jenkins.io/display/JENKINS/Gitorious+Plugin
-gitorious = https://wiki.jenkins.io/x/ngDiAw
-# https://wiki.jenkins.io/display/JENKINS/Hudson+Google+Desktop+Gadget
-google-desktop-gadget = https://wiki.jenkins.io/x/E4A3AQ
-# https://wiki.jenkins.io/display/JENKINS/Google+Code+Plugin
-googlecode = https://wiki.jenkins.io/x/DQC7
-grails = https://www.jenkins.io/security/plugins/#suspensions
-# https://wiki.jenkins.io/display/JENKINS/Hall+Plugin
-hall-jenkins = https://wiki.jenkins.io/x/qQghB
 # https://github.com/jenkinsci/jenkins/pull/5320
 harvest = https://git.io/Jn6Co
-# https://wiki.jenkins.io/display/JENKINS/HockeyApp+Plugin
-hockeyapp = https://wiki.jenkins.io/x/7oPPAw
-# https://wiki.jenkins.io/display/JENKINS/iON+Deployer+Plugin
-ion-deployer-plugin = https://wiki.jenkins.io/x/FhOMAw
-# https://wiki.jenkins.io/display/JENKINS/Java.net+Plugin
-javanet = https://wiki.jenkins.io/x/AgDL
-# https://wiki.jenkins.io/display/JENKINS/java.net+uploader+Plugin
-javanet-uploader = https://wiki.jenkins.io/x/ZoAL
 # https://github.com/jenkinsci/jenkins/pull/5320
 javatest-report = https://git.io/Jn6Co
-jenkins-tracker = https://issues.jenkins.io/browse/INFRA-1531
-# https://wiki.jenkins.io/display/JENKINS/Jenkow+Activiti+Designer
-jenkow-activiti-designer = https://wiki.jenkins.io/x/ngnqAw
-# https://wiki.jenkins.io/display/JENKINS/Jenkow+Activiti+Explorer
-jenkow-activiti-explorer = https://wiki.jenkins.io/x/yQH8Aw
-# https://wiki.jenkins.io/display/JENKINS/Jenkow+Plugin
-jenkow-plugin = https://wiki.jenkins.io/x/WIuhAw
-# https://github.com/jenkins-infra/update-center2/pull/21
-jshint-checkstyle = https://git.io/JsmW2
-# https://github.com/jenkins-infra/update-center2/pull/94
-kanboard-publisher = https://git.io/JfaQH
-kubernetes-ci = https://www.jenkins.io/security/plugins/#suspensions
-kubernetes-pipeline-arquillian-steps = https://www.jenkins.io/security/plugins/#suspensions
-kubernetes-pipeline-aggregator = https://www.jenkins.io/security/plugins/#suspensions
-kubernetes-pipeline-steps = https://www.jenkins.io/security/plugins/#suspensions
-# https://wiki.jenkins.io/display/JENKINS/M2+Extra+Steps+Plugin
-m2-extra-steps = https://wiki.jenkins.io/x/FIc5Ag
-# https://wiki.jenkins.io/display/JENKINS/CloudBees+Cloud+Connector+Plugin
-mansion-cloud = https://wiki.jenkins.io/x/YwdRB
-# https://github.com/mwaylabs/jenkins-mcap-eas-plugin#jenkins-mcap-eas-plugin
-mcap-eas-plugin = https://git.io/JfaQ9
-# https://wiki.jenkins.io/display/JENKINS/MyPeople+Plugin
-mypeople = https://wiki.jenkins.io/x/xQRCB
-# https://wiki.jenkins.io/display/JENKINS/Nabaztag+Plugin
-nabaztag = https://wiki.jenkins.io/x/dIEuAg
-# https://wiki.jenkins.io/display/JENKINS/Netio-Plugin
-netio-plugin = https://wiki.jenkins.io/x/7gMHB
 # https://github.com/jenkinsci/jenkins/pull/5521
 nis-notification-lamp = https://git.io/Jn6Wf
-# https://wiki.jenkins.io/display/JENKINS/Node+Offline+Notification+Plugin
-nodeofflinenotification = https://wiki.jenkins.io/x/0IKhAw
-# https://wiki.jenkins.io/display/JENKINS/Notifo+Plugin
-notifo = https://wiki.jenkins.io/x/0ADDAg
-# https://wiki.jenkins.io/display/JENKINS/Origo+Issue+Notifier
-origo-issue-notifier = https://wiki.jenkins.io/x/qgabAg
-# https://github.com/jenkins-infra/update-center2/pull/291
-paranoia = https://git.io/JfaQS
-# https://plugins.jenkins.io/perfectomobile/
-perfectomobile = https://developers.perfectomobile.com/display/PD/Legacy+%7C+Jenkins+plugin
-perforce = https://www.jenkins.io/security/advisory/2018-03-26/#SECURITY-373
-persona = https://www.jenkins.io/security/plugins/#suspensions
-php = https://issues.jenkins.io/browse/INFRA-2487
-# https://github.com/jenkins-infra/update-center2/pull/384
-play-autotest-plugin = https://git.io/JsmWA
-pipeline-classpath = https://www.jenkins.io/security/plugins/#suspensions
-# https://github.com/jenkinsci/pipeline-editor-plugin
-pipeline-editor = https://git.io/JfaQy
-pmd = https://issues.jenkins.io/browse/INFRA-2487
-# https://github.com/jenkins-infra/update-center2/pull/42
-poll-mailbox-trigger = https://git.io/JfaQM
-# https://wiki.jenkins.io/display/JENKINS/Pretest+Commit+Plugin
-pretest-commit = https://wiki.jenkins.io/x/5gB-B
-# https://wiki.jenkins.io/display/JENKINS/pucm+plugin
-PUCM = https://wiki.jenkins.io/x/fIBVAw
-# https://github.com/jenkins-infra/update-center2/pull/13
-rtc = https://git.io/JfaQ1
-# https://wiki.jenkins.io/display/JENKINS/Retry+Failed+Builds+Plugin
-schedule-failed-builds = https://wiki.jenkins.io/x/roM5Ag
-# https://github.com/jenkins-infra/update-center2/commit/5f3f5ae66ea0e819c27d6d1fed9fdb00781f636c
-scis-ad = https://git.io/JfaQX
-scm-branch-pr-filter = https://issues.jenkins.io/browse/INFRA-1358
-# https://github.com/jenkins-infra/update-center2/pull/324
-SCTMExecutor = https://git.io/JfaQP
-scripttrigger = https://www.jenkins.io/security/plugins/#suspensions
-# https://wiki.jenkins.io/display/JENKINS/Build+Secret+Plugin
-secret = https://wiki.jenkins.io/x/9ghSAg
-# https://wiki.jenkins.io/display/JENKINS/Setenv+Plugin
-setenv = https://wiki.jenkins.io/x/YAtSAg
 # https://github.com/jenkinsci/jenkins/pull/5526
 slave-prerequisites = https://git.io/Jn6WI
-# https://github.com/jenkins-infra/update-center2/pull/405#issue-455150640
-sonargraph-plugin = https://git.io/JJ5h1
-# https://wiki.jenkins.io/pages/viewpage.action?pageId=63930505
-sonatype-ci = https://wiki.jenkins.io/x/iYDPAw
-svn-tag = https://www.jenkins.io/security/plugins/#suspensions
-swamp = https://issues.jenkins.io/browse/INFRA-2487
 # https://github.com/jenkinsci/jenkins/pull/5320
 synergy = https://git.io/Jn6Co
-tasks = https://issues.jenkins.io/browse/INFRA-2487
-# https://wiki.jenkins.io/display/JENKINS/TEPCO+Plugin
-tfs = https://issues.jenkins.io/browse/INFRA-2751
-tepco = https://wiki.jenkins.io/x/zoBoAw
-# https://wiki.jenkins.io/display/JENKINS/TEPCO+Electric+Power+Usage+Widget
-tepco-epuw = https://wiki.jenkins.io/x/vohoAw
-# https://wiki.jenkins.io/display/JENKINS/Testflight+Plugin
-testflight = https://wiki.jenkins.io/x/pwZ1Aw
-# https://wiki.jenkins.io/display/JENKINS/URL+Change+Trigger
-url-change-trigger = https://wiki.jenkins.io/x/BQBJ
-# https://github.com/jenkins-infra/update-center2/pull/302
-veracode-scanner = https://git.io/JfaQ6
 # https://github.com/jenkinsci/jenkins/pull/5526
 vertx = https://git.io/Jn6WI
-vessel = https://groups.google.com/d/msg/jenkinsci-dev/L34eAMMWA5o/-AxtRdGsAAAJ
 # https://github.com/jenkinsci/jenkins/pull/5320
 vs-code-metrics = https://git.io/Jn6Co
 # https://github.com/jenkinsci/jenkins/pull/5320
 vss = https://git.io/Jn6Co
-warnings = https://issues.jenkins.io/browse/INFRA-2487
-# https://github.com/jenkinsci/xltestview-plugin/commit/ea034f9929b520e63b9ce15aed9bdb62354146cf
-xltest-plugin = https://git.io/JfaQK
-xtrigger = https://www.jenkins.io/security/plugins/#suspensions
-# https://wiki.jenkins.io/display/JENKINS/ZAProxy+Plugin
-zaproxy = https://wiki.jenkins.io/x/JgCsB

--- a/src/main/java/io/jenkins/update_center/BaseMavenRepository.java
+++ b/src/main/java/io/jenkins/update_center/BaseMavenRepository.java
@@ -1,6 +1,7 @@
 package io.jenkins.update_center;
 
 import hudson.util.VersionNumber;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -13,6 +14,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.logging.Level;
+import java.util.stream.Stream;
 
 /**
  * A collection of artifacts from which we build index.
@@ -23,12 +25,25 @@ public abstract class BaseMavenRepository implements MavenRepository {
 
     static {
         try (InputStream stream = Files.newInputStream(new File(Main.resourcesDir,
-                "artifact-ignores.properties").toPath())) {
+                        "artifact-ignores.properties").toPath())) {
             IGNORE.load(stream);
         } catch (IOException e) {
             throw new Error(e);
         }
     }
+
+    public static Stream<Object> getIgnoresWithDeprecationUrl() {
+        return IGNORE.keySet().stream().filter(s -> isUrl(IGNORE.getProperty(s.toString())));
+    }
+
+    private static boolean isUrl(String property) {
+        return !StringUtils.isEmpty(property) && !property.trim().startsWith("#");
+    }
+
+    public static String getIgnoreNoticeUrl(String artifactId) {
+        return IGNORE.getProperty(artifactId);
+    }
+
     public Collection<Plugin> listJenkinsPlugins() throws IOException {
 
         Map<String, Plugin> plugins =

--- a/src/main/java/io/jenkins/update_center/Deprecations.java
+++ b/src/main/java/io/jenkins/update_center/Deprecations.java
@@ -4,9 +4,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
-import java.util.List;
 import java.util.Properties;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class Deprecations {
     private Deprecations() {}
@@ -15,8 +14,10 @@ public class Deprecations {
         return DEPRECATIONS.getProperty(pluginName);
     }
 
-    public static List<String> getDeprecatedPlugins() {
-        return DEPRECATIONS.keySet().stream().map(Object::toString).collect(Collectors.toList());
+    public static Stream<String> getDeprecatedPlugins() {
+        return Stream.concat(DEPRECATIONS.keySet().stream(),
+                BaseMavenRepository.getIgnoresWithDeprecationUrl())
+                .map(Object::toString);
     }
 
     private static final Properties DEPRECATIONS = new Properties();

--- a/src/main/java/io/jenkins/update_center/json/UpdateCenterRoot.java
+++ b/src/main/java/io/jenkins/update_center/json/UpdateCenterRoot.java
@@ -4,10 +4,11 @@ import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.annotation.JSONField;
 import com.google.common.base.Functions;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.jenkins.update_center.BaseMavenRepository;
 import io.jenkins.update_center.Deprecations;
 import io.jenkins.update_center.MavenRepository;
-import io.jenkins.update_center.PluginUpdateCenterEntry;
 import io.jenkins.update_center.Plugin;
+import io.jenkins.update_center.PluginUpdateCenterEntry;
 
 import java.io.File;
 import java.io.IOException;
@@ -48,7 +49,7 @@ public class UpdateCenterRoot extends WithSignature {
         warnings = Arrays.asList(JSON.parseObject(warningsJsonText, UpdateCenterWarning[].class));
 
         // load deprecations
-        deprecations = new TreeMap<>(Deprecations.getDeprecatedPlugins().stream().collect(Collectors.toMap(Functions.identity(), UpdateCenterRoot::deprecationForPlugin)));
+        deprecations = new TreeMap<>(Deprecations.getDeprecatedPlugins().collect(Collectors.toMap(Functions.identity(), UpdateCenterRoot::deprecationForPlugin)));
 
         for (Plugin plugin : repo.listJenkinsPlugins()) {
             PluginUpdateCenterEntry entry = new PluginUpdateCenterEntry(plugin);
@@ -59,6 +60,8 @@ public class UpdateCenterRoot extends WithSignature {
     }
 
     private static UpdateCenterDeprecation deprecationForPlugin(String artifactId) {
-        return new UpdateCenterDeprecation(Deprecations.getCustomDeprecationUri(artifactId));
+        String deprecationUrl = Deprecations.getCustomDeprecationUri(artifactId);
+        String noticeUrl = deprecationUrl != null ? deprecationUrl : BaseMavenRepository.getIgnoreNoticeUrl(artifactId);
+        return new UpdateCenterDeprecation(noticeUrl);
     }
 }

--- a/src/test/java/io/jenkins/update_center/DeprecationTest.java
+++ b/src/test/java/io/jenkins/update_center/DeprecationTest.java
@@ -23,10 +23,10 @@ public class DeprecationTest {
                 "deprecations.properties").toPath());
         deprecations.load(stream);
         for (String key: deprecations.stringPropertyNames()) {
-            assertFalse(ignore.containsKey(key));
+            assertFalse(key, ignore.containsKey(key));
         }
         for (String key: ignore.stringPropertyNames()) {
-            assertFalse(deprecations.containsKey(key));
+            assertFalse(key, deprecations.containsKey(key));
         }
     }
 }

--- a/src/test/java/io/jenkins/update_center/DeprecationTest.java
+++ b/src/test/java/io/jenkins/update_center/DeprecationTest.java
@@ -1,0 +1,32 @@
+package io.jenkins.update_center;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.Properties;
+
+import static org.junit.Assert.assertFalse;
+
+public class DeprecationTest {
+
+    @Test
+    public void noOverlap() throws IOException {
+        Properties ignore = new Properties();
+        InputStream stream = Files.newInputStream(new File(Main.resourcesDir,
+                "artifact-ignores.properties").toPath());
+        ignore.load(stream);
+        Properties deprecations = new Properties();
+        stream = Files.newInputStream(new File(Main.resourcesDir,
+                "deprecations.properties").toPath());
+        deprecations.load(stream);
+        for (String key: deprecations.stringPropertyNames()) {
+            assertFalse(ignore.containsKey(key));
+        }
+        for (String key: ignore.stringPropertyNames()) {
+            assertFalse(deprecations.containsKey(key));
+        }
+    }
+}


### PR DESCRIPTION
@daniel-beck this should make it easier to inform users about suspended plugins (no duplication between ignores and deprecations). General thoughts 👍 / 👎 ? If it's OK I'll double-check that no information got lost here. 