### PR TITLE
Deprecating Coding Webhook

### DIFF
--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -62,6 +62,8 @@ codeclimate-plugin = https://issues.jenkins.io/browse/INFRA-2487
 # https://github.com/jenkins-infra/update-center2/pull/299
 codescanner = https://issues.jenkins.io/browse/INFRA-2487
 codescan = https://git.io/JfaQb
+# https://github.com/jenkinsci/coding-webhook-plugin/commit/20e1449513628ad24476b47331ea7bd6a2e82583
+coding-webhook = https://git.io/JE3Wn
 # https://github.com/jenkinsci/jenkins/pull/5320
 config-rotator = https://git.io/Jn6Co
 # https://github.com/jenkinsci/configuration-as-code-plugin/releases/tag/configuration-as-code-1.18


### PR DESCRIPTION
As of [commit 20e1449](https://github.com/jenkinsci/coding-webhook-plugin/commit/20e1449513628ad24476b47331ea7bd6a2e82583) by @tsl0922 Coding Webhook has been "archived in favor of coding's [official jenkins integration](https://help.coding.net/docs/project-settings/service-hook/service.html#jenkins)."