### PR TITLE
Remove carbonetes-serverless-container-scanning-and-policy-compliance…

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -659,3 +659,6 @@ ca-mat-performance-benchmarking-by-broadcom-1.2
 
 # INFRA-3067
 credentials-2.6
+
+# Cache file name too long
+carbonetes-serverless-container-scanning-and-policy-compliance-1.8.1


### PR DESCRIPTION
…-1.8.1 for being too long

----

@carbonetes
A current infra limitation results in failures when you publish version numbers longer than 3 characters for this plugin. `1.8` is fine, but `1.8.1` is longer than that.

Please stop doing that or we'll need to suspend distribution of your plugin.

CC @timja @halkeye In hosting review, please stop people from having unnecessarily long plugin IDs.