### PR TITLE
Ignore opentelemetry-1.0.0 that contains multiple versions for the same dependency

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -663,3 +663,6 @@ credentials-2.6
 
 # Cache file name too long
 carbonetes-serverless-container-scanning-and-policy-compliance-1.8.1
+
+# Multiple OpenTelemetry SDK versions. See https://github.com/jenkinsci/opentelemetry-plugin/issues/230
+opentelemetry-1.0.0


### PR DESCRIPTION
### What

Ignore opentelemetry-1.0.0 that contains multiple versions for the same dependency.

### Issues

Caused by https://github.com/jenkinsci/opentelemetry-plugin/issues/230

