### PR TITLE
Deprecating non-Java plugins

### DIFF
--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -7,33 +7,58 @@
 BlameSubversion = https://git.io/Jn6Co
 # https://github.com/jenkins-infra/update-center2/pull/521
 blueocean-executor-info = https://issues.jenkins.io/browse/JENKINS-56773
+buddycloud = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+capitomcat = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+chef = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+ci-skip = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
 # https://github.com/jenkinsci/jenkins/pull/5320
 cloverphp = https://git.io/Jn6Co
 # https://github.com/jenkinsci/jenkins/pull/5320
 cmvc = https://git.io/Jn6Co
 # https://github.com/jenkinsci/coding-webhook-plugin/commit/20e1449513628ad24476b47331ea7bd6a2e82583
 coding-webhook = https://git.io/JE3Wn
+commit-message-trigger-plugin = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
 # https://github.com/jenkinsci/jenkins/pull/5320
 config-rotator = https://git.io/Jn6Co
+cucumber = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+devstack = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
 # https://github.com/jenkinsci/jenkins/pull/5320
 emma = https://git.io/Jn6Co
+gitlab-hook = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+git-notes = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
 # https://github.com/jenkinsci/jenkins/pull/5320
 harvest = https://git.io/Jn6Co
+ikachan = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+installshield = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
 # https://github.com/jenkinsci/jenkins/pull/5320
 javatest-report = https://git.io/Jn6Co
+jenkinspider = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+mysql-job-databases = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
 # https://github.com/jenkinsci/jenkins/pull/5521
 nis-notification-lamp = https://git.io/Jn6Wf
+pathignore = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+perl = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+perl-smoke-test = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+pry = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+pyenv = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+python-wrapper = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+rbenv = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+ruby-runtime = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+rvm = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
 # https://github.com/jenkinsci/jenkins/pull/5560
 sicci_for_xcode = https://git.io/Jc69a
+singleuseslave = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
 # https://github.com/jenkinsci/jenkins/pull/5526
 slave-prerequisites = https://git.io/Jn6WI
 # https://github.com/jenkinsci/jenkins/pull/5320
 synergy = https://git.io/Jn6Co
 # https://github.com/jenkinsci/jenkins/pull/5560
 tmpcleaner = https://git.io/Jc69a
+travis-yml = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
 # https://github.com/jenkinsci/jenkins/pull/5526
 vertx = https://git.io/Jn6WI
 # https://github.com/jenkinsci/jenkins/pull/5320
 vs-code-metrics = https://git.io/Jn6Co
 # https://github.com/jenkinsci/jenkins/pull/5320
 vss = https://git.io/Jn6Co
+yammer = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/


### PR DESCRIPTION
From [JEP-7](https://github.com/jenkinsci/jep/tree/70474800713263f42e20ca549f7c8a52e3dfec19/jep/7):

> Plugins will be deprecated in the Update site immediately after the announcement. The deprecation notice will reference the announcement blogpost as justification.

@halkeye does not appear to have completed this task. :man_shrugging: