### PR TITLE
Remove unused AWS API plugins

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -18,10 +18,11 @@ aws-lambda-jenkins-plugin        # renamed to aws-lambda
 aws-lambda-plugin                # renamed to aws-lambda
 aws-yum-paramater                # renamed to package-parameter
 # merged into aws-java-sdk-minimal in https://github.com/jenkinsci/aws-java-sdk-plugin/pull/540
-aws-java-sdk-core = https://git.io/JSTvz
-aws-java-sdk-kms  = https://git.io/JSTvz
-aws-java-sdk-s3   = https://git.io/JSTvz
-aws-java-sdk-sts  = https://git.io/JSTvz
+aws-java-sdk-core     = https://git.io/JSTvz
+aws-java-sdk-jmespath = https://git.io/JSTvz
+aws-java-sdk-kms      = https://git.io/JSTvz
+aws-java-sdk-s3       = https://git.io/JSTvz
+aws-java-sdk-sts      = https://git.io/JSTvz
 # deprecated -- https://github.com/jenkinsci/azure-iot-edge-plugin/blob/master/Readme.md
 azure-iot-edge = https://git.io/JtOjd
 bees-sdk-plugin                  # removal requested by ndeloof: RUN@cloud service no longer exists

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -15,14 +15,14 @@ assembla-oauth = https://groups.google.com/d/msg/jenkinsci-dev/TVz-D5etsUM/Knx9z
 assembla-jenkins                 # Renamed to assembla
 associated-files-plugin          # renamed to associated-files
 aws-lambda-jenkins-plugin        # renamed to aws-lambda
-aws-lambda-plugin                # renamed to aws-lambda
-aws-yum-paramater                # renamed to package-parameter
 # merged into aws-java-sdk-minimal in https://github.com/jenkinsci/aws-java-sdk-plugin/pull/540
 aws-java-sdk-core     = https://git.io/JSTvz
 aws-java-sdk-jmespath = https://git.io/JSTvz
 aws-java-sdk-kms      = https://git.io/JSTvz
 aws-java-sdk-s3       = https://git.io/JSTvz
 aws-java-sdk-sts      = https://git.io/JSTvz
+aws-lambda-plugin                # renamed to aws-lambda
+aws-yum-paramater                # renamed to package-parameter
 # deprecated -- https://github.com/jenkinsci/azure-iot-edge-plugin/blob/master/Readme.md
 azure-iot-edge = https://git.io/JtOjd
 bees-sdk-plugin                  # removal requested by ndeloof: RUN@cloud service no longer exists

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -17,6 +17,11 @@ associated-files-plugin          # renamed to associated-files
 aws-lambda-jenkins-plugin        # renamed to aws-lambda
 aws-lambda-plugin                # renamed to aws-lambda
 aws-yum-paramater                # renamed to package-parameter
+# merged into aws-java-sdk-minimal in https://github.com/jenkinsci/aws-java-sdk-plugin/pull/540
+aws-java-sdk-core = https://git.io/JSTvz
+aws-java-sdk-kms  = https://git.io/JSTvz
+aws-java-sdk-s3   = https://git.io/JSTvz
+aws-java-sdk-sts  = https://git.io/JSTvz
 # deprecated -- https://github.com/jenkinsci/azure-iot-edge-plugin/blob/master/Readme.md
 azure-iot-edge = https://git.io/JtOjd
 bees-sdk-plugin                  # removal requested by ndeloof: RUN@cloud service no longer exists

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -14,13 +14,13 @@ appthwack = https://wiki.jenkins.io/x/cwchB
 assembla-oauth = https://groups.google.com/d/msg/jenkinsci-dev/TVz-D5etsUM/Knx9zXtEnSwJ
 assembla-jenkins                 # Renamed to assembla
 associated-files-plugin          # renamed to associated-files
-aws-lambda-jenkins-plugin        # renamed to aws-lambda
 # merged into aws-java-sdk-minimal in https://github.com/jenkinsci/aws-java-sdk-plugin/pull/540
 aws-java-sdk-core     = https://git.io/JSTvz
 aws-java-sdk-jmespath = https://git.io/JSTvz
 aws-java-sdk-kms      = https://git.io/JSTvz
 aws-java-sdk-s3       = https://git.io/JSTvz
 aws-java-sdk-sts      = https://git.io/JSTvz
+aws-lambda-jenkins-plugin        # renamed to aws-lambda
 aws-lambda-plugin                # renamed to aws-lambda
 aws-yum-paramater                # renamed to package-parameter
 # deprecated -- https://github.com/jenkinsci/azure-iot-edge-plugin/blob/master/Readme.md


### PR DESCRIPTION
Since https://github.com/jenkinsci/aws-java-sdk-plugin/pull/540 these plugins are no longer released separately, they are all part of https://plugins.jenkins.io/aws-java-sdk-minimal . I think it's safe to just remove them since nothing depends on them, but if the preference is to deprecate for a while, remove later, I can do that instead.

@vlatombe OK?
CC @daniel-beck 
