### PR TITLE
Update warnings.json

### DIFF
--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -1561,7 +1561,8 @@
     "url": "https://jenkins.io/security/advisory/2018-02-26/#SECURITY-248",
     "versions": [
       {
-        "pattern": "(Affected even if up to date|.*)"
+        "lastVersion": "1.90",
+        "pattern": "(0|1[.][0-9]|1[.][1-8][0-9]|1[.]90)(|[.-].+)"
       }
     ]
   },


### PR DESCRIPTION
(Internal note) Generated with `./advisory-tool.sh --mode=WarningRegex --plugin-id=envinject --fixed-version=1.91,1.91.1,1.91.2,1.91.3,1.91.4,1.92,1.92.0-beta-1,1.92.1,1.93,1.93.1,2.0,2.1,2.1.1,2.1.2,2.1.3,2.1.4,2.1.5,2.1.6,2.2.0,2.2.1,2.3.0,2.4.0`

=> `(0|1[.][0-9]|1[.]1[0-9]|1[.]2[0-9]|1[.]3[0-9]|1[.]4[0-9]|1[.]5[0-9]|1[.]6[0-9]|1[.]7[0-9]|1[.]8[0-9]|1[.]90)(|[.-].+)`

Simplified to `(0|1[.][0-9]|1[.][1-8][0-9]|1[.]90)(|[.-].+)`