### PR TITLE
Suspend distribution of non-Java plugins

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -677,3 +677,30 @@ carbonetes-serverless-container-scanning-and-policy-compliance-1.8.1
 batch-task = https://www.jenkins.io/security/plugins/#suspensions
 debian-package-builder = https://www.jenkins.io/security/plugins/#suspensions
 publish-over-ssh = https://www.jenkins.io/security/plugins/#suspensions
+
+# https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+buddycloud = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+capitomcat = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+chef = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+ci-skip = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+commit-message-trigger-plugin = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+cucumber = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+devstack = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+gitlab-hook = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+git-notes = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+ikachan = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+installshield = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+jenkinspider = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+mysql-job-databases = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+pathignore = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+perl = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+perl-smoke-test = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+pry = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+pyenv = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+python-wrapper = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+rbenv = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+ruby-runtime = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+rvm = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+singleuseslave = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+travis-yml = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
+yammer = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/

--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -7,58 +7,33 @@
 BlameSubversion = https://git.io/Jn6Co
 # https://github.com/jenkins-infra/update-center2/pull/521
 blueocean-executor-info = https://issues.jenkins.io/browse/JENKINS-56773
-buddycloud = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
-capitomcat = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
-chef = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
-ci-skip = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
 # https://github.com/jenkinsci/jenkins/pull/5320
 cloverphp = https://git.io/Jn6Co
 # https://github.com/jenkinsci/jenkins/pull/5320
 cmvc = https://git.io/Jn6Co
 # https://github.com/jenkinsci/coding-webhook-plugin/commit/20e1449513628ad24476b47331ea7bd6a2e82583
 coding-webhook = https://git.io/JE3Wn
-commit-message-trigger-plugin = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
 # https://github.com/jenkinsci/jenkins/pull/5320
 config-rotator = https://git.io/Jn6Co
-cucumber = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
-devstack = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
 # https://github.com/jenkinsci/jenkins/pull/5320
 emma = https://git.io/Jn6Co
-gitlab-hook = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
-git-notes = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
 # https://github.com/jenkinsci/jenkins/pull/5320
 harvest = https://git.io/Jn6Co
-ikachan = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
-installshield = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
 # https://github.com/jenkinsci/jenkins/pull/5320
 javatest-report = https://git.io/Jn6Co
-jenkinspider = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
-mysql-job-databases = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
 # https://github.com/jenkinsci/jenkins/pull/5521
 nis-notification-lamp = https://git.io/Jn6Wf
-pathignore = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
-perl = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
-perl-smoke-test = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
-pry = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
-pyenv = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
-python-wrapper = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
-rbenv = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
-ruby-runtime = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
-rvm = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
 # https://github.com/jenkinsci/jenkins/pull/5560
 sicci_for_xcode = https://git.io/Jc69a
-singleuseslave = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
 # https://github.com/jenkinsci/jenkins/pull/5526
 slave-prerequisites = https://git.io/Jn6WI
 # https://github.com/jenkinsci/jenkins/pull/5320
 synergy = https://git.io/Jn6Co
 # https://github.com/jenkinsci/jenkins/pull/5560
 tmpcleaner = https://git.io/Jc69a
-travis-yml = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
 # https://github.com/jenkinsci/jenkins/pull/5526
 vertx = https://git.io/Jn6WI
 # https://github.com/jenkinsci/jenkins/pull/5320
 vs-code-metrics = https://git.io/Jn6Co
 # https://github.com/jenkinsci/jenkins/pull/5320
 vss = https://git.io/Jn6Co
-yammer = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/


### PR DESCRIPTION
And it came to pass [at the end of thirty days](https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/) that no users complained about the deprecation of non-Java plugins. And @basil said, may these plugins be suspended from distribution. And it was so, and no longer did the non-Java plugins roam the face of the earth.

CC @daniel-beck @halkeye