### PR TITLE
Suspend nexus-jenkins-plugin-3.13.20220124-204320.8222771 without pom

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -660,6 +660,7 @@ spotinst-2.0.26
 nexus-jenkins-plugin-3.9.20201203-135942.e9f4ebc
 nexus-jenkins-plugin-3.9.20201203-151437.f2f6b16
 nexus-jenkins-plugin-3.9.20201203-120425.a87655e
+nexus-jenkins-plugin-3.13.20220124-204320.8222771
 
 # Typo in version, should have been 1.122
 github-api-1.222


### PR DESCRIPTION
https://github.com/jenkins-infra/update-center2/pull/473 all over again.

I propose next time we suspend the entire plugin.