### PR TITLE
Use maven-8 docker image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,20 +5,14 @@ properties([
         buildDiscarder(logRotator(numToKeepStr: '10', artifactNumToKeepStr: '2')),
 ])
 
-node('linux') {
+node('maven-8') {
     stage('Prepare') {
         deleteDir()
         checkout scm
     }
 
     stage('Generate') {
-        withEnv([
-                "PATH+MVN=${tool 'mvn'}/bin",
-                "JAVA_HOME=${tool 'jdk8'}",
-                "PATH+JAVA=${tool 'jdk8'}/bin"
-        ]) {
-            sh 'mvn -e clean verify'
-        }
+        sh 'mvn -e clean verify'
     }
 
     stage('Archive Test Report') {


### PR DESCRIPTION
## Use maven-8 docker image

Rely on the maven tool already being installed.  Also relies on Java 8 already being installed.

As suggested by @dduportal 

Fixes https://github.com/jenkins-infra/helpdesk/issues/2747