### PR TITLE
Simplify symlink creation, update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>3.4.6</version>
+      <version>4.3.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.18.1</version>
+        <version>3.0.0-M5</version>
         <configuration>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
     <dependency>
       <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
       <artifactId>owasp-java-html-sanitizer</artifactId>
-      <version>20200713.1</version>
+      <version>20211018.2</version>
     </dependency>
     <dependency>
       <groupId>com.github.spotbugs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
     <dependency>
       <groupId>io.jenkins.lib</groupId>
       <artifactId>support-log-formatter</artifactId>
-      <version>1.0</version>
+      <version>1.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>version-number</artifactId>
-      <version>1.7</version>
+      <version>1.9</version>
     </dependency>
     <dependency>
       <groupId>bouncycastle</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.11</version>
+      <version>3.12.0</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <version>1.6.10</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
     <dependency>
       <groupId>com.alibaba</groupId>
       <artifactId>fastjson</artifactId>
-      <version>1.2.73</version>
+      <version>1.2.79</version>
     </dependency>
     <dependency>
       <groupId>org.dom4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,16 @@
       <groupId>com.alibaba</groupId>
       <artifactId>fastjson</artifactId>
       <version>1.2.79</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.squareup.okhttp3</groupId>
+          <artifactId>okhttp</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.dom4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.7</version>
+      <version>2.11.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.14</version>
+      <version>1.15</version>
     </dependency>
     <dependency>
       <groupId>args4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
     <dependency>
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
-      <version>1.14.2</version>
+      <version>1.14.3</version>
     </dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,7 @@
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
-      <version>4.1.1</version>
+      <version>4.5.3</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
-      <version>4.8.0</version>
+      <version>4.9.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.54</version>
+    <version>1.70</version>
   </parent>
 
   <artifactId>update-center2</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp-urlconnection</artifactId>
-      <version>4.8.0</version>
+      <version>4.9.3</version>
     </dependency>
     <dependency>
       <groupId>jaxen</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp-urlconnection</artifactId>
-      <version>4.9.3</version>
+      <version>4.10.0</version>
     </dependency>
     <dependency>
       <groupId>jaxen</groupId>
@@ -199,7 +199,7 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>version-number</artifactId>
-      <version>1.9</version>
+      <version>1.10</version>
     </dependency>
     <dependency>
       <groupId>bouncycastle</groupId>
@@ -214,18 +214,18 @@
     <dependency>
       <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
       <artifactId>owasp-java-html-sanitizer</artifactId>
-      <version>20211018.2</version>
+      <version>20220608.1</version>
     </dependency>
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
-      <version>4.5.3</version>
+      <version>4.7.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
-      <version>1.14.3</version>
+      <version>1.15.2</version>
     </dependency>
 
 
@@ -233,7 +233,7 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.6.10</version>
+      <version>1.7.10</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
@@ -251,7 +251,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>4.3.1</version>
+      <version>4.6.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -263,7 +263,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
-      <version>4.9.3</version>
+      <version>4.10.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>4.2.0</version>
+        <version>4.5.3.0</version>
         <configuration><excludeFilterFile>${project.basedir}/spotbugs-excludes.xml</excludeFilterFile></configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
     <dependency>
       <groupId>org.apache.ant</groupId>
       <artifactId>ant</artifactId>
-      <version>1.10.11</version>
+      <version>1.10.12</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>

--- a/spotbugs-excludes.xml
+++ b/spotbugs-excludes.xml
@@ -7,4 +7,24 @@
         <!-- All @JsonField fields are considered unwritten -->
         <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD" />
     </Match>
+    <Match>
+        <!-- CRLF injection risk from logging is not relevant here -->
+        <Bug pattern="CRLF_INJECTION_LOGS" />
+    </Match>
+    <Match>
+        <!-- Internal representation exposure is not a risk in this utility -->
+        <Bug pattern="EI_EXPOSE_REP" />
+    </Match>
+    <Match>
+        <!-- Internal representation exposure is not a risk in this utility -->
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <!-- Internal representation exposure is not a risk in this utility -->
+        <Bug pattern="MS_EXPOSE_REP" />
+    </Match>
+    <Match>
+        <!-- SHA1 digest is required for checksums -->
+        <Bug pattern="WEAK_MESSAGE_DIGEST_SHA1" />
+    </Match>
 </FindBugsFilter>

--- a/spotbugs-excludes.xml
+++ b/spotbugs-excludes.xml
@@ -27,4 +27,8 @@
         <!-- SHA1 digest is required for checksums -->
         <Bug pattern="WEAK_MESSAGE_DIGEST_SHA1" />
     </Match>
+    <Match>
+        <!-- Reading user specified files is part of the role of this utility -->
+        <Bug pattern="PATH_TRAVERSAL_IN" />
+    </Match>
 </FindBugsFilter>

--- a/src/main/java/io/jenkins/update_center/ArtifactoryRepositoryImpl.java
+++ b/src/main/java/io/jenkins/update_center/ArtifactoryRepositoryImpl.java
@@ -1,6 +1,7 @@
 package io.jenkins.update_center;
 
 import com.alibaba.fastjson.JSON;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.jenkins.update_center.util.Environment;
 import io.jenkins.update_center.util.HttpHelper;
 import okhttp3.Credentials;
@@ -172,6 +173,8 @@ public class ArtifactoryRepositoryImpl extends BaseMavenRepository {
     }
 
     @Override
+    @SuppressFBWarnings(value="DCN_NULLPOINTER_EXCEPTION",
+                        justification="Catching NPE is safer than trying to guard all cases")
     public ArtifactMetadata getMetadata(MavenArtifact artifact) throws IOException {
         ensureInitialized();
         ArtifactMetadata ret = new ArtifactMetadata();

--- a/src/main/java/io/jenkins/update_center/DirectoryTreeBuilder.java
+++ b/src/main/java/io/jenkins/update_center/DirectoryTreeBuilder.java
@@ -1,5 +1,6 @@
 package io.jenkins.update_center;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.util.VersionNumber;
 import org.apache.commons.io.IOUtils;
 import org.kohsuke.args4j.Option;
@@ -114,6 +115,8 @@ public class DirectoryTreeBuilder {
      *
      * @param hpi The plugin to create a latest symlink for
      */
+    @SuppressFBWarnings(value="COMMAND_INJECTION",
+                        justification="No signfiicant command injection vulnerability risk in ProcessBuilder calls here")
     private void createLatestSymlink(Plugin hpi) throws IOException {
         File dir = new File(download, "plugins/" + hpi.getArtifactId());
         final File latest = new File(dir, "latest");
@@ -144,6 +147,8 @@ public class DirectoryTreeBuilder {
      * @param dst the staging location
      * @throws IOException when a problem occurs during file operations
      */
+    @SuppressFBWarnings(value="COMMAND_INJECTION",
+                        justification="No signfiicant command injection vulnerability risk in ProcessBuilder calls here")
     protected void stage(MavenArtifact a, File dst) throws IOException {
         File src = a.resolve();
         if (dst.exists() && dst.lastModified() == src.lastModified() && dst.length() == src.length()) {


### PR DESCRIPTION
## Update dependencies

Use the current parent pom and other dependencies.  Update the spotbugs exclusions for new warnings reported with the most recent spotbugs.  Create symbolic links and hard links with Java NIO methods instead of making calls to the operating system.  The change to Java NIO calls avoids a spotbugs warning related to ProcessBuilder command injection.

Exclude okhttp and annotation-api from fastjson because newer versions are being provided by other dependencies.

Update owasp-java-html-sanitizer to 20211018.2 to resolve a security warning.

- Use fastjson 1.2.79, not 1.2.73
- Use okhttp-urlconnection 4.9.3, not 4.8.0
- Use commons-io 2.11.0, not 2.7
- Use commons-lang3 3.12.0, not 3.11
- Use commons-codec 1.15, not 1.14
- Use support-log-formatter 1.1, not 1.0
- Use version-number 1.9, not 1.7
- Use ant 1.10.12, not 1.10.11
- Use owasp-java-html-sanitizer 20211018.2, not 20200713.1
- Use spotbugs-annotations 4.5.3, not 4.1.1
- Use jsoup 1.14.3, not 1.14.2
- Use kotlin-stdlib-common 1.6.10, not 1.3.72
- Use mockito-core 4.3.1, not 3.4.6
- Use junit 4.13.2, not 4.13.1
- Use mockwebserver 4.9.3, not 4.8.0
- Use parent pom 1.70, not 1.54
- Use spotbugs 4.5.3.0, not 4.2.0
- Use surefire 3.0.0-M5, not 2.18.1
- Exclude okhttp and annotation-api from fastjson
- Exclude several spotbugs warnings
- Allow catch of NPE in getMetaData()
- Exclude command injection vulnerability
- Replace ProcessBuilder with Java 8 file calls
- Exclude path traversal spotbugs warnings
