### PR TITLE
Suspend distribution of StarTeam plugin, it's closed source since 2015

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -711,4 +711,4 @@ team-views = https://www.jenkins.io/security/plugins/#suspensions
 sinatra-chef-builder = https://www.jenkins.io/security/plugins/#suspensions
 
 # The plugin has been closed source since 2015
-starteam = https://wiki.jenkins.io/display/JENKINS/StarTeam
+starteam = https://github.com/jenkins-infra/update-center2/pull/571

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -709,3 +709,6 @@ yammer = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
 # https://www.jenkins.io/security/advisory/2022-02-15/
 team-views = https://www.jenkins.io/security/plugins/#suspensions
 sinatra-chef-builder = https://www.jenkins.io/security/plugins/#suspensions
+
+# The plugin has been closed source since 2015
+starteam = https://wiki.jenkins.io/display/JENKINS/StarTeam


### PR DESCRIPTION
Per their own documentation on the wiki page https://github.com/jenkins-infra/docker-confluence-data/blob/main/content/JENKINS/StarTeam.html currently rendered on https://plugins.jenkins.io/starteam/ :

> <img width="854" alt="Screenshot 2022-02-21 at 14 21 08" src="https://user-images.githubusercontent.com/1831569/154963698-ee228e02-832c-48df-83b6-1d6578a49488.png">

The last release in https://github.com/jenkinsci/starteam-plugin/commits/master was 0.6.12 in 2013, so suspend distribution.