### PR TITLE
Unsuspend publish-over-ssh since 1.24

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -677,7 +677,45 @@ carbonetes-serverless-container-scanning-and-policy-compliance-1.8.1
 # https://www.jenkins.io/security/advisory/2022-01-12/
 batch-task = https://www.jenkins.io/security/plugins/#suspensions
 debian-package-builder = https://www.jenkins.io/security/plugins/#suspensions
-publish-over-ssh = https://www.jenkins.io/security/plugins/#suspensions
+publish-over-ssh-0.1
+publish-over-ssh-0.2
+publish-over-ssh-0.3
+publish-over-ssh-0.4
+publish-over-ssh-0.5
+publish-over-ssh-0.6
+publish-over-ssh-0.7
+publish-over-ssh-0.8
+publish-over-ssh-0.9
+publish-over-ssh-0.10
+publish-over-ssh-0.11
+publish-over-ssh-0.12
+publish-over-ssh-0.13
+publish-over-ssh-0.14
+publish-over-ssh-1.0
+publish-over-ssh-1.1
+publish-over-ssh-1.2
+publish-over-ssh-1.3
+publish-over-ssh-1.4
+publish-over-ssh-1.5
+publish-over-ssh-1.6
+publish-over-ssh-1.7
+publish-over-ssh-1.8
+publish-over-ssh-1.9
+publish-over-ssh-1.10
+publish-over-ssh-1.11
+publish-over-ssh-1.12
+publish-over-ssh-1.13
+publish-over-ssh-1.14
+publish-over-ssh-1.17
+publish-over-ssh-1.18
+publish-over-ssh-1.19
+publish-over-ssh-1.19.1
+publish-over-ssh-1.20
+publish-over-ssh-1.20.1
+publish-over-ssh-1.21
+publish-over-ssh-1.22
+publish-over-ssh-1.23
+# fixes were proposed since publish-over-ssh-1.24
 
 # https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
 buddycloud = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -677,7 +677,6 @@ carbonetes-serverless-container-scanning-and-policy-compliance-1.8.1
 # https://www.jenkins.io/security/advisory/2022-01-12/
 batch-task = https://www.jenkins.io/security/plugins/#suspensions
 debian-package-builder = https://www.jenkins.io/security/plugins/#suspensions
-# publish-over-ssh => fixes were proposed since publish-over-ssh-1.24, adjust warnings
 
 # https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
 buddycloud = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -677,45 +677,7 @@ carbonetes-serverless-container-scanning-and-policy-compliance-1.8.1
 # https://www.jenkins.io/security/advisory/2022-01-12/
 batch-task = https://www.jenkins.io/security/plugins/#suspensions
 debian-package-builder = https://www.jenkins.io/security/plugins/#suspensions
-publish-over-ssh-0.1
-publish-over-ssh-0.2
-publish-over-ssh-0.3
-publish-over-ssh-0.4
-publish-over-ssh-0.5
-publish-over-ssh-0.6
-publish-over-ssh-0.7
-publish-over-ssh-0.8
-publish-over-ssh-0.9
-publish-over-ssh-0.10
-publish-over-ssh-0.11
-publish-over-ssh-0.12
-publish-over-ssh-0.13
-publish-over-ssh-0.14
-publish-over-ssh-1.0
-publish-over-ssh-1.1
-publish-over-ssh-1.2
-publish-over-ssh-1.3
-publish-over-ssh-1.4
-publish-over-ssh-1.5
-publish-over-ssh-1.6
-publish-over-ssh-1.7
-publish-over-ssh-1.8
-publish-over-ssh-1.9
-publish-over-ssh-1.10
-publish-over-ssh-1.11
-publish-over-ssh-1.12
-publish-over-ssh-1.13
-publish-over-ssh-1.14
-publish-over-ssh-1.17
-publish-over-ssh-1.18
-publish-over-ssh-1.19
-publish-over-ssh-1.19.1
-publish-over-ssh-1.20
-publish-over-ssh-1.20.1
-publish-over-ssh-1.21
-publish-over-ssh-1.22
-publish-over-ssh-1.23
-# fixes were proposed since publish-over-ssh-1.24
+# publish-over-ssh => fixes were proposed since publish-over-ssh-1.24, adjust warnings
 
 # https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/
 buddycloud = https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/

--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -10699,8 +10699,8 @@
     "url": "https://www.jenkins.io/security/advisory/2022-01-12/#SECURITY-2287",
     "versions": [
       {
-        "lastVersion": "1.22",
-        "pattern": ".*"
+        "lastVersion": "1.23",
+        "pattern": "(0|1[.][0-9]|1[.]1[01234789]|1[.]2[0-3])(|[.-].+)"
       }
     ]
   },
@@ -10712,8 +10712,8 @@
     "url": "https://www.jenkins.io/security/advisory/2022-01-12/#SECURITY-2290",
     "versions": [
       {
-        "lastVersion": "1.22",
-        "pattern": ".*"
+        "lastVersion": "1.23",
+        "pattern": "(0|1[.][0-9]|1[.]1[01234789]|1[.]2[0-3])(|[.-].+)"
       }
     ]
   },
@@ -10725,8 +10725,8 @@
     "url": "https://www.jenkins.io/security/advisory/2022-01-12/#SECURITY-2291",
     "versions": [
       {
-        "lastVersion": "1.22",
-        "pattern": ".*"
+        "lastVersion": "1.23",
+        "pattern": "(0|1[.][0-9]|1[.]1[01234789]|1[.]2[0-3])(|[.-].+)"
       }
     ]
   },
@@ -10738,8 +10738,8 @@
     "url": "https://www.jenkins.io/security/advisory/2022-01-12/#SECURITY-2307",
     "versions": [
       {
-        "lastVersion": "1.22",
-        "pattern": ".*"
+        "lastVersion": "1.23",
+        "pattern": "(0|1[.][0-9]|1[.]1[01234789]|1[.]2[0-3])(|[.-].+)"
       }
     ]
   },


### PR DESCRIPTION
FYI @gmcdonald @olamy 

Corrections:
- SECURITY-2287, https://github.com/jenkinsci/publish-over-ssh-plugin/pull/50 and https://github.com/jenkinsci/publish-over-ssh-plugin/pull/59
- SECURITY-2290, https://github.com/jenkinsci/publish-over-ssh-plugin/pull/51 and https://github.com/jenkinsci/publish-over-ssh-plugin/pull/58
- SECURITY-2291, https://github.com/jenkinsci/publish-over-ssh-plugin/pull/52
- SECURITY-2307, https://github.com/jenkinsci/publish-over-ssh-plugin/pull/54

Fix version with the fixes: 1.24

With its companion to remove the entry in the https://www.jenkins.io/security/plugins/#suspensions list: https://github.com/jenkins-infra/jenkins.io/pull/4940