### PR TITLE
Suspend nexus-jenkins-plugin

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -657,11 +657,8 @@ brakeman = https://git.io/JT2XI
 # Suppress a release with regression that causes node's computer to be null
 spotinst-2.0.26
 
-# INFRA-2838 - no pom published, causes update center generation to break
-nexus-jenkins-plugin-3.9.20201203-135942.e9f4ebc
-nexus-jenkins-plugin-3.9.20201203-151437.f2f6b16
-nexus-jenkins-plugin-3.9.20201203-120425.a87655e
-nexus-jenkins-plugin-3.13.20220124-204320.8222771
+# INFRA-2838 etc. - repeated bad releases breaking update site generation
+nexus-jenkins-plugin = https://github.com/jenkins-infra/update-center2/pull/576
 
 # Typo in version, should have been 1.122
 github-api-1.222


### PR DESCRIPTION
Admittedly our infra is more brittle than it should be, but it works well enough for basically every plugin/maintainer.

After https://github.com/jenkins-infra/update-center2/pull/473 and https://github.com/jenkins-infra/update-center2/pull/566, today is yet another time that bad release content of `nexus-jenkins-plugins` breaks the generation ([first because `.hpi` was uploaded 45+ minutes after the `.pom`, then because it's a 0 byte file](https://repo.jenkins-ci.org/releases/org/sonatype/nexus/ci/nexus-jenkins-plugin/3.13.20220304-155321.e7fcac5/)), so I propose we suspend the plugin.

The plugin should be updated to be released using JEP-229 CD, so that whatever is currently going on here stops.

FYI @eduard-tita