### PR TITLE
Revert "Suspend nexus-jenkins-plugin"

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -657,8 +657,11 @@ brakeman = https://git.io/JT2XI
 # Suppress a release with regression that causes node's computer to be null
 spotinst-2.0.26
 
-# INFRA-2838 etc. - repeated bad releases breaking update site generation
-nexus-jenkins-plugin = https://github.com/jenkins-infra/update-center2/pull/576
+# INFRA-2838 - no pom published, causes update center generation to break
+nexus-jenkins-plugin-3.9.20201203-135942.e9f4ebc
+nexus-jenkins-plugin-3.9.20201203-151437.f2f6b16
+nexus-jenkins-plugin-3.9.20201203-120425.a87655e
+nexus-jenkins-plugin-3.13.20220124-204320.8222771
 
 # Typo in version, should have been 1.122
 github-api-1.222

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -662,6 +662,7 @@ nexus-jenkins-plugin-3.9.20201203-135942.e9f4ebc
 nexus-jenkins-plugin-3.9.20201203-151437.f2f6b16
 nexus-jenkins-plugin-3.9.20201203-120425.a87655e
 nexus-jenkins-plugin-3.13.20220124-204320.8222771
+nexus-jenkins-plugin-3.13.20220304-155321.e7fcac5
 
 # Typo in version, should have been 1.122
 github-api-1.222


### PR DESCRIPTION
Reverts jenkins-infra/update-center2#576

Given https://groups.google.com/g/jenkinsci-dev/c/TZakKUjUm9Q/m/Pirq0fqEBAAJ it's possible this failed release is not (only) caused by the maintainer/release process side of things, so reverting this and instead only suspend the known broken release.