### PR TITLE
Suspend castecho and itms-junit-report-publisher after rename

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -713,3 +713,10 @@ sinatra-chef-builder = https://www.jenkins.io/security/plugins/#suspensions
 
 # The plugin has been closed source since 2015
 starteam = https://github.com/jenkins-infra/update-center2/pull/571
+
+# Renamed to 'carl'
+castecho = https://github.com/jenkins-infra/repository-permissions-updater/pull/1461
+
+# Renamed to 'itms-for-jira'
+itms-junit-report-publisher = https://github.com/jenkins-infra/repository-permissions-updater/pull/1379
+


### PR DESCRIPTION
These artifact IDs are obsolete after these PRs:
* https://github.com/jenkins-infra/repository-permissions-updater/pull/1461
* https://github.com/jenkins-infra/repository-permissions-updater/pull/1379 + https://github.com/jenkins-infra/repository-permissions-updater/pull/1418

CC @iTMSJenkins @castnightlybuild
