### PR TITLE
Exclude agc-app-upload 1.0, includes no pom file

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -249,6 +249,7 @@ kubernetes-pipeline-aggregator-1.3
 
 # specific releases
 active-directory-2.1     		    	 # JENKINS-42739
+agc-app-upload-1.0				 # https://github.com/jenkins-infra/helpdesk/issues/2853
 BlameSubversion-1.121    		    	 # big number but not the latest release
 fortify-on-demand-uploader-1.0 		    	 # removal requested by Ryan Black, plugin wasn't ready for release
 gradle-1.27              		    	 # JENKINS-45126


### PR DESCRIPTION
## Exclude agc-app-upload plugin 1.0

The March 25, 2022 release of [agc-app-upload 1.0](https://repo.jenkins-ci.org/artifactory/releases/com/huawei/jenkins/agc-app-upload/1.0/) includes only the hpi file, but not the pom file.  Without the pom file, the update center job fails.
