### PR TITLE
Deprecate AdoptOpenJDK plugin

### DIFF
--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -37,3 +37,4 @@ vertx = https://git.io/Jn6WI
 vs-code-metrics = https://git.io/Jn6Co
 # https://github.com/jenkinsci/jenkins/pull/5320
 vss = https://git.io/Jn6Co
+adoptopenjdk = https://blog.adoptopenjdk.net/2021/03/transition-to-eclipse-an-update/


### PR DESCRIPTION
AdoptOpenJDK as service itself is deprecated since late 2020 in favor of the transition to the Eclipse foundation.