### PR TITLE
Suspend plugins for discontinued services

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -73,6 +73,7 @@ create-fingerprint-plugin        # renamed to create-fingerprint
 datadog-build-reporter           # renamed to datadog
 delphix-plugin                   # renamed to delphix
 description-column               # renamed to description-column-plugin
+discobit-autoconfig= TODO
 # removal requested by teilo, superceded by dockerhub-notification -- https://github.com/jenkins-infra/update-center2/commit/e5a138873113d0e2d6af59d5699215a1835c15b7
 dockerhub = https://git.io/JfaQF
 drools                           # deprecated
@@ -84,6 +85,7 @@ essentials                       # replaced by evergreen
 evergreen                        # not supposed to be installed manually. We use Incrementals http://repo.jenkins-ci.org/incrementals/io/jenkins/plugins/evergreen
 # deprecated -- https://github.com/jenkins-infra/update-center2/pull/257
 external-scheduler = https://git.io/JfaQ5
+fabric-beta-publisher = TODO
 first-plugin                     # INFRA-1108: Unintended release as part of a plugin tutorial workshop
 foofoo                           # junk: contains only the HelloWorldBuilder sample
 foreman-node-sharing             # Reimplemented as https://github.com/jenkinsci/node-sharing-plugin/
@@ -138,6 +140,7 @@ jslint-checkstyle                # renamed to jshint-checkstyle
 kanboard-publisher = https://git.io/JfaQH
 karotz                           # service discontinued: https://twitter.com/Karotz/status/527852693960658944 -- https://wiki.jenkins-ci.org/display/JENKINS/Karotz+Plugin
 kato                             # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Kato+Plugin
+kmap-jenkins = TODO
 koji-plugin                      # renamed to koji
 kundo                            # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Kundo+Plugin
 lechat                           # renamed to Kata which was discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/LeChat+Plugin

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -73,7 +73,7 @@ create-fingerprint-plugin        # renamed to create-fingerprint
 datadog-build-reporter           # renamed to datadog
 delphix-plugin                   # renamed to delphix
 description-column               # renamed to description-column-plugin
-discobit-autoconfig= TODO
+discobit-autoconfig = https://github.com/jenkins-infra/update-center2/pull/587
 # removal requested by teilo, superceded by dockerhub-notification -- https://github.com/jenkins-infra/update-center2/commit/e5a138873113d0e2d6af59d5699215a1835c15b7
 dockerhub = https://git.io/JfaQF
 drools                           # deprecated
@@ -85,7 +85,7 @@ essentials                       # replaced by evergreen
 evergreen                        # not supposed to be installed manually. We use Incrementals http://repo.jenkins-ci.org/incrementals/io/jenkins/plugins/evergreen
 # deprecated -- https://github.com/jenkins-infra/update-center2/pull/257
 external-scheduler = https://git.io/JfaQ5
-fabric-beta-publisher = TODO
+fabric-beta-publisher = https://github.com/jenkins-infra/update-center2/pull/587
 first-plugin                     # INFRA-1108: Unintended release as part of a plugin tutorial workshop
 foofoo                           # junk: contains only the HelloWorldBuilder sample
 foreman-node-sharing             # Reimplemented as https://github.com/jenkinsci/node-sharing-plugin/
@@ -140,7 +140,7 @@ jslint-checkstyle                # renamed to jshint-checkstyle
 kanboard-publisher = https://git.io/JfaQH
 karotz                           # service discontinued: https://twitter.com/Karotz/status/527852693960658944 -- https://wiki.jenkins-ci.org/display/JENKINS/Karotz+Plugin
 kato                             # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Kato+Plugin
-kmap-jenkins = TODO
+kmap-jenkins = https://github.com/jenkins-infra/update-center2/pull/587
 koji-plugin                      # renamed to koji
 kundo                            # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Kundo+Plugin
 lechat                           # renamed to Kata which was discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/LeChat+Plugin

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -84,7 +84,7 @@ essentials                       # replaced by evergreen
 evergreen                        # not supposed to be installed manually. We use Incrementals http://repo.jenkins-ci.org/incrementals/io/jenkins/plugins/evergreen
 # deprecated
 external-scheduler = https://github.com/jenkins-infra/update-center2/pull/257
-fabric-beta-publisher = https://github.com/jenkins-infra/update-center2/pull/587
+fabric-beta-publisher = https://github.com/jenkinsci/fabric-beta-publisher-plugin#deprecation-notice
 first-plugin                     # INFRA-1108: Unintended release as part of a plugin tutorial workshop
 foofoo                           # junk: contains only the HelloWorldBuilder sample
 foreman-node-sharing             # Reimplemented as https://github.com/jenkinsci/node-sharing-plugin/


### PR DESCRIPTION
* [Fabric Beta was replaced by Firebase](https://github.com/jenkinsci/fabric-beta-publisher-plugin#deprecation-notice) -- users should migrate to Firebase
* Kmap: this plugin depends on Keivox Kmap service previously available at keivox.com (domain for sale), company's online activity seems to end in [2015](https://twitter.com/keivoxdev)
* Discobit AutoConfig: domain discobit.com is up for sale