### PR TITLE
Address git.io deprecation

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -6,42 +6,42 @@
 #   See the header of deprecations.properties for details about deprecation messages.
 
 AntepediaReporter-CI-plugin      # closed-souce plugin; removal confirmed with owner, Guillaume Rousseau
-# service discontinued. Alternative: https://plugins.jenkins.io/appetize/ -- https://github.com/jenkins-infra/update-center2/pull/465
-appio = https://git.io/JT9ZT
+# service discontinued. Alternative: https://plugins.jenkins.io/appetize/
+appio = https://github.com/jenkins-infra/update-center2/pull/465
 # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/AppThwack+Plugin
 appthwack = https://wiki.jenkins.io/x/cwchB
 # renamed to assembla-auth
 assembla-oauth = https://groups.google.com/d/msg/jenkinsci-dev/TVz-D5etsUM/Knx9zXtEnSwJ
 assembla-jenkins                 # Renamed to assembla
 associated-files-plugin          # renamed to associated-files
-# merged into aws-java-sdk-minimal in https://github.com/jenkinsci/aws-java-sdk-plugin/pull/540
-aws-java-sdk-core     = https://git.io/JSTvz
-aws-java-sdk-jmespath = https://git.io/JSTvz
-aws-java-sdk-kms      = https://git.io/JSTvz
-aws-java-sdk-s3       = https://git.io/JSTvz
-aws-java-sdk-sts      = https://git.io/JSTvz
+# merged into aws-java-sdk-minimal
+aws-java-sdk-core     = https://github.com/jenkinsci/aws-java-sdk-plugin/pull/540
+aws-java-sdk-jmespath = https://github.com/jenkinsci/aws-java-sdk-plugin/pull/540
+aws-java-sdk-kms      = https://github.com/jenkinsci/aws-java-sdk-plugin/pull/540
+aws-java-sdk-s3       = https://github.com/jenkinsci/aws-java-sdk-plugin/pull/540
+aws-java-sdk-sts      = https://github.com/jenkinsci/aws-java-sdk-plugin/pull/540
 aws-lambda-jenkins-plugin        # renamed to aws-lambda
 aws-lambda-plugin                # renamed to aws-lambda
 aws-yum-paramater                # renamed to package-parameter
 # deprecated -- https://github.com/jenkinsci/azure-iot-edge-plugin/blob/master/Readme.md
-azure-iot-edge = https://git.io/JtOjd
+azure-iot-edge = https://github.com/jenkinsci/azure-iot-edge-plugin/blob/master/Readme.md
 bees-sdk-plugin                  # removal requested by ndeloof: RUN@cloud service no longer exists
 binary-deployer                  # removal requested by alecharp: this plugin was never meant to be deployed. POC project.
 # "This plugin is no longer supported and should not be used." -- https://wiki.jenkins-ci.org/display/JENKINS/Black+Duck+Vulnerability+Installer+Plugin
 blackduck-installer = https://wiki.jenkins.io/x/nYHHB
-# End of life.  Replaced with Detect. -- https://github.com/jenkins-infra/update-center2/pull/261
-blackduck-hub = https://git.io/JfaQa
+# End of life.  Replaced with Detect
+blackduck-hub = https://github.com/jenkins-infra/update-center2/pull/261
 blitz.io-jenkins                 # renamed to blitz_io-jenkins
-# service discontinued: https://en.wikipedia.org/wiki/Blitz_(software) -- https://github.com/jenkins-infra/update-center2/pull/521
-blitz_io-jenkins = https://git.io/J3d1Y
+# service discontinued: https://en.wikipedia.org/wiki/Blitz_(software)
+blitz_io-jenkins = https://github.com/jenkins-infra/update-center2/pull/521
 # superseded by Extra Columns Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Build+Node+Column+Plugin
 build-node-column = https://wiki.jenkins.io/x/1QiMAw
 # service discontinued: https://github.com/github/github-services/pull/538 -- https://wiki.jenkins-ci.org/display/JENKINS/Buildcoin+Plugin
 buildcoin-plugin = https://wiki.jenkins.io/x/KoyhAw
 # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Buildheroes
 buildheroes = https://wiki.jenkins.io/x/_AD8Aw
-# service discontinued -- see https://www.codescan.io for alternative ways of running -- https://github.com/jenkins-infra/update-center2/pull/299
-codescan = https://git.io/JfaQb
+# service discontinued -- see https://www.codescan.io for alternative ways of running
+codescan = https://github.com/jenkins-infra/update-center2/pull/299
 # service shut down -- https://wiki.jenkins-ci.org/display/JENKINS/Caroline+Plugin
 caroline = https://wiki.jenkins.io/x/AwOMAw
 ChatRoom                          # junk plugin; developer has been banned
@@ -49,20 +49,19 @@ ChatRoom                          # junk plugin; developer has been banned
 chrome-frame-plugin = https://www.chromium.org/developers/how-tos/chrome-frame-getting-started
 # Superseded by Publish Over CIFS Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/CIFS-Publisher+Plugin
 cifs = https://wiki.jenkins.io/x/lwC2Ag
-# renamed to clang-scanbuild in https://github.com/jenkinsci/clang-scanbuild-plugin/commit/a6d57b67f6fbd0a9893ecf6436c54ecb670d5829
-clang-scanbuild-plugin = https://git.io/JfaQr
+# renamed to clang-scanbuild
+clang-scanbuild-plugin = https://github.com/jenkinsci/clang-scanbuild-plugin/commit/a6d57b67f6fbd0a9893ecf6436c54ecb670d5829
 # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Cloudbees+Deployer+Plugin
 cloudbees-deployer-plugin = https://wiki.jenkins.io/x/24RoAw
 # Unsupported and retracted by service provider -- https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Jenkins+Enterprise
 cloudbees-enterprise-plugins = https://wiki.jenkins.io/x/3gX8Aw
 # "This feature is no longer relevant." -- https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Registration+Plugin
 cloudbees-registration = https://wiki.jenkins.io/x/z4FLB
-# renamed to cloudbees-disk-usage-simple several years ago -- https://github.com/jenkins-infra/update-center2/pull/179
-cloudbees-disk-usage-simple-plugin = https://git.io/JfaQN
+# renamed to cloudbees-disk-usage-simple several years ago
+cloudbees-disk-usage-simple-plugin = https://github.com/jenkins-infra/update-center2/pull/179
 ColumnPack-plugin                 # renamed to ColumnsPlugin
 ConfigurationSlicing              # renamed into configurationslicing, and this double causes a check out problem on Windows
-# deprecated -- https://github.com/jenkinsci/configuration-as-code-plugin/releases/tag/configuration-as-code-1.18
-configuration-as-code-support = https://git.io/JfaHz
+configuration-as-code-support = https://github.com/jenkinsci/configuration-as-code-plugin/releases/tag/configuration-as-code-1.18
 convert-to-declarative            # renamed to declarative-pipeline-migration-assistant-plugin
 convert-to-declarative-api       # renamed to declarative-pipeline-migration-assistant-plugin
 # superseded by ArtifactDeployer Plugin  -- https://wiki.jenkins-ci.org/display/JENKINS/CopyArchiver+Plugin
@@ -73,8 +72,8 @@ create-fingerprint-plugin        # renamed to create-fingerprint
 datadog-build-reporter           # renamed to datadog
 delphix-plugin                   # renamed to delphix
 description-column               # renamed to description-column-plugin
-# removal requested by teilo, superceded by dockerhub-notification -- https://github.com/jenkins-infra/update-center2/commit/e5a138873113d0e2d6af59d5699215a1835c15b7
-dockerhub = https://git.io/JfaQF
+# removal requested by teilo, superceded by dockerhub-notification
+dockerhub = https://github.com/jenkins-infra/update-center2/commit/e5a138873113d0e2d6af59d5699215a1835c15b7
 drools                           # deprecated
 # deprecated -- eggplant-plugin
 eggplant-plugin = https://github.com/jenkins-infra/update-center2/pull/578#issuecomment-1073702439
@@ -82,8 +81,8 @@ eggplant-plugin = https://github.com/jenkins-infra/update-center2/pull/578#issue
 emotional-hudson = https://wiki.jenkins.io/x/C4DX
 essentials                       # replaced by evergreen
 evergreen                        # not supposed to be installed manually. We use Incrementals http://repo.jenkins-ci.org/incrementals/io/jenkins/plugins/evergreen
-# deprecated -- https://github.com/jenkins-infra/update-center2/pull/257
-external-scheduler = https://git.io/JfaQ5
+# deprecated
+external-scheduler = https://github.com/jenkins-infra/update-center2/pull/257
 first-plugin                     # INFRA-1108: Unintended release as part of a plugin tutorial workshop
 foofoo                           # junk: contains only the HelloWorldBuilder sample
 foreman-node-sharing             # Reimplemented as https://github.com/jenkinsci/node-sharing-plugin/
@@ -130,12 +129,11 @@ jenkow-activiti-explorer = https://wiki.jenkins.io/x/yQH8Aw
 jenkow-plugin = https://wiki.jenkins.io/x/WIuhAw
 jgiven-plugin                    # renamed to jgiven
 jmeter                           # renamed to performance
-# deprecated -- https://github.com/jenkins-infra/update-center2/pull/21
-jshint-checkstyle = https://git.io/JsmW2
+# deprecated
+jshint-checkstyle = https://github.com/jenkins-infra/update-center2/pull/21
 jslint-checkstyle                # renamed to jshint-checkstyle
 # renamed to kanboard, see https://issues.jenkins-ci.org/browse/HOSTING-241?focusedCommentId=280720&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-280720
-# https://github.com/jenkins-infra/update-center2/pull/94
-kanboard-publisher = https://git.io/JfaQH
+kanboard-publisher = https://github.com/jenkins-infra/update-center2/pull/94
 karotz                           # service discontinued: https://twitter.com/Karotz/status/527852693960658944 -- https://wiki.jenkins-ci.org/display/JENKINS/Karotz+Plugin
 kato                             # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Kato+Plugin
 koji-plugin                      # renamed to koji
@@ -148,8 +146,8 @@ m2-extra-steps = https://wiki.jenkins.io/x/FIc5Ag
 # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Cloud+Connector+Plugin
 mansion-cloud = https://wiki.jenkins.io/x/YwdRB
 mber                             # service discontinued -- https://wiki.jenkins.io/display/JENKINS/Mber+Plugin
-# superseded by Relution Publisher (see https://github.com/mwaylabs/jenkins-mcap-eas-plugin)
-mcap-eas-plugin = https://git.io/JfaQ9
+# superseded by Relution Publisher
+mcap-eas-plugin = https://github.com/mwaylabs/jenkins-mcap-eas-plugin
 mogotest                         # deprecated: mogotest service no longer exists
 # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/MyPeople+Plugin
 mypeople = https://wiki.jenkins.io/x/xQRCB
@@ -167,8 +165,8 @@ openstack-plugin                 # renamed to openstack-cloud
 origo-issue-notifier = https://wiki.jenkins.io/x/qgabAg
 otabuilder                       # latest sources at https://github.com/jeslyvarghese/otabuilder-plugin but discontinued due to tool chain discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Over-the-Air+Ad+Hoc+Deployment+Plugin+For+iOS
 paaslane                         # renamed to paaslane-estimate
-# renamed to extended-security-settings -- https://github.com/jenkins-infra/update-center2/pull/291
-paranoia = https://git.io/JfaQS
+# renamed to extended-security-settings
+paranoia = https://github.com/jenkins-infra/update-center2/pull/291
 pathignore-plugin                # renamed to pathignore
 # plugin obsolete, replaced by https://plugins.jenkins.io/perfecto/
 perfectomobile = https://developers.perfectomobile.com/display/PD/Legacy+%7C+Jenkins+plugin
@@ -176,10 +174,10 @@ perfectomobile-jenkins           # renamed to perfectomobile
 PerfPublisher                    # latest releases use "perfpublisher"
 # https://jenkins.io/security/advisory/2017-03-20
 pipeline-classpath = https://www.jenkins.io/security/plugins/#suspensions
-# Removed by author -- https://github.com/jenkinsci/pipeline-editor-plugin
-pipeline-editor = https://git.io/JfaQy
-# renamed to poll-mailbox-trigger-plugin :( -- https://github.com/jenkins-infra/update-center2/pull/42
-poll-mailbox-trigger = https://git.io/JfaQM
+# Removed by author
+pipeline-editor = https://github.com/jenkinsci/pipeline-editor-plugin
+# renamed to poll-mailbox-trigger-plugin
+poll-mailbox-trigger = https://github.com/jenkins-infra/update-center2/pull/42
 # discontinued PoC, use Pretested Integration Plugin instead -- https://wiki.jenkins-ci.org/display/JENKINS/Pretest+Commit+Plugin
 pretest-commit = https://wiki.jenkins.io/x/5gB-B
 # superseded by ClearCase UCM Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/pucm+plugin
@@ -189,20 +187,20 @@ rally-update-plugin-1            # renamed to rally-plugin(!)
 release-multi-test               # junk: contains only the HelloWorldBuilder sample
 release-test                     # junk: contains only the HelloWorldBuilder sample
 Relution                         # renamed to relution-publisher
-# superseded by Team Concert Plugin -- https://github.com/jenkins-infra/update-center2/pull/13
-rtc = https://git.io/JfaQ1
+# superseded by Team Concert Plugin
+rtc = https://github.com/jenkins-infra/update-center2/pull/13
 sahagin-jenkins-plugin           # renamed to sahagin-plugin
 sample                           # junk plugin; developer has been banned
 schedule-build-plugin            # renamed to schedule-build
 # superseded by Naginator Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Retry+Failed+Builds+Plugin
 schedule-failed-builds = https://wiki.jenkins.io/x/roM5Ag
-# deprecated -- https://github.com/jenkins-infra/update-center2/commit/5f3f5ae66ea0e819c27d6d1fed9fdb00781f636c
-scis-ad = https://git.io/JfaQX
+# deprecated
+scis-ad = https://github.com/jenkins-infra/update-center2/commit/5f3f5ae66ea0e819c27d6d1fed9fdb00781f636c
 # renamed shortly after publication for https://github.com/jenkins-infra/repository-permissions-updater/pull/459#issuecomment-334702817
 scm-branch-pr-filter = https://issues.jenkins.io/browse/INFRA-1358
 script-realm-extended            # fork of a plugin and has since been subsumed -- https://wiki.jenkins-ci.org/display/JENKINS/Script+Security+Realm+Extended
-# plugin obsolete, replaced by Gradle-based invocation; depublishing as requested by 'silk' in SECURITY-1521, see https://github.com/jenkins-infra/update-center2/pull/324
-SCTMExecutor = https://git.io/JfaQP
+# plugin obsolete, replaced by Gradle-based invocation; depublishing as requested by 'silk' in SECURITY-1521
+SCTMExecutor = https://github.com/jenkins-infra/update-center2/pull/324
 # superseded by Credentials Binding Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Build+Secret+Plugin
 secret = https://wiki.jenkins.io/x/9ghSAg
 security-no-captcha              # Functionality integrated in Jenkins 1.416 -- https://wiki.jenkins-ci.org/display/JENKINS/Security+No+CAPTCHA
@@ -211,8 +209,8 @@ serenitec                        # gbossert asked to remove this plugin
 setenv = https://wiki.jenkins.io/x/YAtSAg
 skytap-cloud-plugin              # renamed to skytap
 sms-notification                 # renamed to sms
-# superseded by sonargraph-integration -- https://github.com/jenkins-infra/update-center2/pull/405
-sonargraph-plugin = https://git.io/JJ5h1
+# superseded by sonargraph-integration --
+sonargraph-plugin = https://github.com/jenkins-infra/update-center2/pull/405
 # deprecated (see Sonatype CLM: https://wiki.jenkins-ci.org/x/iYDPAw)
 sonatype-ci = https://wiki.jenkins.io/x/iYDPAw
 squashtm-publisher                   # removal due to security issue JIRA SECURITY-2525
@@ -235,8 +233,8 @@ vagrant-plugin                    # renamed to vagrant, herpderp
 vessel = https://groups.google.com/d/msg/jenkinsci-dev/L34eAMMWA5o/-AxtRdGsAAAJ
 weibo4jenkins                    # renamed to weibo
 wsnotifier                       # renamed to websocket
-# renamed to xltestview-plugin in https://github.com/jenkinsci/xltestview-plugin/commit/ea034f9929b520e63b9ce15aed9bdb62354146cf
-xltest-plugin = https://git.io/JfaQK
+# renamed to xltestview-plugin
+xltest-plugin = https://github.com/jenkinsci/xltestview-plugin/commit/ea034f9929b520e63b9ce15aed9bdb62354146cf
 # superseded by zap -- https://wiki.jenkins-ci.org/display/JENKINS/ZAProxy+Plugin
 zaproxy = https://wiki.jenkins.io/x/JgCsB
 zaproxy-jenkins                  # renamed to zaproxy
@@ -464,8 +462,7 @@ git-client-3.0.0-rc
 
 # Replaced by the official fortify plugin https://wiki.jenkins.io/display/JENKINS/Fortify+Plugin
 fortify360
-# https://github.com/jenkinsci/fortify-cloudscan-plugin#deprecation-notice
-fortify-cloudscan-jenkins-plugin = https://git.io/JfhPD
+fortify-cloudscan-jenkins-plugin = https://github.com/jenkinsci/fortify-cloudscan-plugin#deprecation-notice
 
 # Failed shading Snakeyaml, 1.9 has both shaded and direct dependency inside
 configuration-as-code-1.9
@@ -491,8 +488,7 @@ kubernetes-pipeline-aggregator = https://www.jenkins.io/security/plugins/#suspen
 puppet-enterprise-pipeline
 
 # not actively maintained (https://wiki.jenkins.io/display/JENKINS/Veracode+Scanner+Plugin), replaced by official Veracode plugin https://help.veracode.com/reader/PgbNZUD7j8aY7iG~hQZWxQ/yQtYXnlbLA6wsWodLn5zdw
-# https://github.com/jenkins-infra/update-center2/pull/302
-veracode-scanner = https://git.io/JfaQ6
+veracode-scanner = https://github.com/jenkins-infra/update-center2/pull/302
 
 # https://issues.jenkins-ci.org/browse/JENKINS-59903 and https://issues.jenkins-ci.org/browse/JENKINS-59907
 durable-task-1.31
@@ -609,8 +605,8 @@ ci-with-toad-edge-1.2
 ci-with-toad-edge-2.0
 ci-with-toad-devops-toolkit
 
-# Depublished as agreed with maintainer after SECURITY-1879 in 2020-06-03 security advisory -- https://github.com/jenkins-infra/update-center2/pull/384
-play-autotest-plugin = https://git.io/JsmWA
+# Depublished as agreed with maintainer after SECURITY-1879 in 2020-06-03 security advisory
+play-autotest-plugin = https://github.com/jenkins-infra/update-center2/pull/384
 
 # Depublishing for RCE vulnerability, see https://www.jenkins.io/security/advisory/2020-07-02/#SECURITY-1738
 kubernetes-ci = https://www.jenkins.io/security/plugins/#suspensions
@@ -654,8 +650,8 @@ pmd = https://issues.jenkins.io/browse/INFRA-2487
 swamp = https://issues.jenkins.io/browse/INFRA-2487
 tasks = https://issues.jenkins.io/browse/INFRA-2487
 warnings = https://issues.jenkins.io/browse/INFRA-2487
-# Functionality merged into warnings-ng to support INFRA-2487 -- https://github.com/jenkinsci/brakeman-plugin/issues/23
-brakeman = https://git.io/JT2XI
+# Functionality merged into warnings-ng to support INFRA-2487
+brakeman = https://github.com/jenkinsci/brakeman-plugin/issues/23
 
 # Suppress a release with regression that causes node's computer to be null
 spotinst-2.0.26

--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -1,39 +1,22 @@
 # This file contains deprecated plugins (keys) and the URL the deprecation notice on plugins.jenkins.io and in Jenkins
 # should link to (value). Use this file to mark a plugin as deprecated while continuing to distribute it. If a plugin
 # should be removed from distribution entirely, instead set a deprecation notice URL in artifact-ignores.properties.
-# Shorten URLs if and only if the URLs are to github.com (git.io) or wiki.jenkins.io. Record the real URL in a comment.
 
-# https://github.com/jenkinsci/jenkins/pull/5320
-BlameSubversion = https://git.io/Jn6Co
+BlameSubversion = https://github.com/jenkinsci/jenkins/pull/5320
 # https://github.com/jenkins-infra/update-center2/pull/521
 blueocean-executor-info = https://issues.jenkins.io/browse/JENKINS-56773
-# https://github.com/jenkinsci/jenkins/pull/5320
-cloverphp = https://git.io/Jn6Co
-# https://github.com/jenkinsci/jenkins/pull/5320
-cmvc = https://git.io/Jn6Co
-# https://github.com/jenkinsci/coding-webhook-plugin/commit/20e1449513628ad24476b47331ea7bd6a2e82583
-coding-webhook = https://git.io/JE3Wn
-# https://github.com/jenkinsci/jenkins/pull/5320
-config-rotator = https://git.io/Jn6Co
-# https://github.com/jenkinsci/jenkins/pull/5320
-emma = https://git.io/Jn6Co
-# https://github.com/jenkinsci/jenkins/pull/5320
-harvest = https://git.io/Jn6Co
-# https://github.com/jenkinsci/jenkins/pull/5320
-javatest-report = https://git.io/Jn6Co
-# https://github.com/jenkinsci/jenkins/pull/5521
-nis-notification-lamp = https://git.io/Jn6Wf
-# https://github.com/jenkinsci/jenkins/pull/5560
-sicci_for_xcode = https://git.io/Jc69a
-# https://github.com/jenkinsci/jenkins/pull/5526
-slave-prerequisites = https://git.io/Jn6WI
-# https://github.com/jenkinsci/jenkins/pull/5320
-synergy = https://git.io/Jn6Co
-# https://github.com/jenkinsci/jenkins/pull/5560
-tmpcleaner = https://git.io/Jc69a
-# https://github.com/jenkinsci/jenkins/pull/5526
-vertx = https://git.io/Jn6WI
-# https://github.com/jenkinsci/jenkins/pull/5320
-vs-code-metrics = https://git.io/Jn6Co
-# https://github.com/jenkinsci/jenkins/pull/5320
-vss = https://git.io/Jn6Co
+cloverphp = https://github.com/jenkinsci/jenkins/pull/5320
+cmvc = https://github.com/jenkinsci/jenkins/pull/5320
+coding-webhook = https://github.com/jenkinsci/coding-webhook-plugin/commit/20e1449513628ad24476b47331ea7bd6a2e82583
+config-rotator = https://github.com/jenkinsci/jenkins/pull/5320
+emma = https://github.com/jenkinsci/jenkins/pull/5320
+harvest = https://github.com/jenkinsci/jenkins/pull/5320
+javatest-report = https://github.com/jenkinsci/jenkins/pull/5320
+nis-notification-lamp = https://github.com/jenkinsci/jenkins/pull/5521
+sicci_for_xcode = https://github.com/jenkinsci/jenkins/pull/5560
+slave-prerequisites = https://github.com/jenkinsci/jenkins/pull/5526
+synergy = https://github.com/jenkinsci/jenkins/pull/5320
+tmpcleaner = https://github.com/jenkinsci/jenkins/pull/5560
+vertx = https://github.com/jenkinsci/jenkins/pull/5526
+vs-code-metrics = https://github.com/jenkinsci/jenkins/pull/5320
+vss = https://github.com/jenkinsci/jenkins/pull/5320

--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -3,7 +3,6 @@
 # should be removed from distribution entirely, instead set a deprecation notice URL in artifact-ignores.properties.
 
 BlameSubversion = https://github.com/jenkinsci/jenkins/pull/5320
-# https://github.com/jenkins-infra/update-center2/pull/521
 blueocean-executor-info = https://issues.jenkins.io/browse/JENKINS-56773
 cloverphp = https://github.com/jenkinsci/jenkins/pull/5320
 cmvc = https://github.com/jenkinsci/jenkins/pull/5320


### PR DESCRIPTION
git.io is deprecated since January 2022 and now scheduled for sunset on the 29th of April.
See the relevant blogpost: https://github.blog/changelog/2022-04-25-git-io-deprecation/

I went ahead and replaced all git.io URLs in this repository to not be impacted by the forthcoming change.