### PR TITLE
Depublish jx-pipelines and jx-resources

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -715,3 +715,7 @@ starteam = https://github.com/jenkins-infra/update-center2/pull/571
 
 # https://www.jenkins.io/security/advisory/2022-03-29/
 phoenix-autotest = https://www.jenkins.io/security/plugins/#suspensions
+
+# Obsolete and no longer used by Jenkins X, see https://github.com/jenkins-x/jx/issues/7020
+jx-pipelines
+jx-resources

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -717,5 +717,5 @@ starteam = https://github.com/jenkins-infra/update-center2/pull/571
 phoenix-autotest = https://www.jenkins.io/security/plugins/#suspensions
 
 # Obsolete and no longer used by Jenkins X, see https://github.com/jenkins-x/jx/issues/7020
-jx-pipelines
-jx-resources
+jx-pipelines = https://github.com/jenkins-infra/update-center2/pull/590
+jx-resources = https://github.com/jenkins-infra/update-center2/pull/590


### PR DESCRIPTION
This PR depublishes https://plugins.jenkins.io/jx-pipelines/ and https://plugins.jenkins.io/jx-resources/.

These plugins have been obsolete since Jenkins X removed support for static Jenkins controllers around April 2020. See https://github.com/jenkins-x/jx/issues/7020 and https://jenkins-x.io/blog/2020/03/11/tekton/. My understanding is that `jx-pipelines` was technically obsolete even before that, see https://github.com/jenkins-x/jenkins-x-image/pull/8.