### PR TITLE
[JEP-230] Proactively block `instance-identity` 3.1

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -524,9 +524,10 @@ kubesphere-extension-0.2.0
 sshd-1.0
 sshd-1.1
 sshd-1.2
-# pending https://github.com/jenkinsci/jenkins/pull/5304
+# pending completion of JEP-230
 instance-identity-3.0
 instance-identity-3.0.1
+instance-identity-3.1
 
 # released twice, with different groupIds
 selfie-trigger-plugin-1.0


### PR DESCRIPTION
Want to be able to release https://github.com/jenkinsci/instance-identity-plugin/pull/22 without it appearing on the UC, at least for now.

(I am not sure I have permission to release by the way? Says `@core` but I am not sure if I am in that group or not. How would I check? Recently I have been using JEP-229 exclusively for releases, which I _could_ do here but it would be tricky since I need to predict the version number in advance.)

@timja