### PR TITLE
Deprecate bmc-rpd-plugin

### DIFF
--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -4,7 +4,7 @@
 
 BlameSubversion = https://github.com/jenkinsci/jenkins/pull/5320
 blueocean-executor-info = https://issues.jenkins.io/browse/JENKINS-56773
-bmc-rpd-plugin = https://github.com/jenkins-infra/update-center2/pull/597
+bmc-rpd = https://github.com/jenkins-infra/update-center2/pull/597
 cloverphp = https://github.com/jenkinsci/jenkins/pull/5320
 cmvc = https://github.com/jenkinsci/jenkins/pull/5320
 coding-webhook = https://github.com/jenkinsci/coding-webhook-plugin/commit/20e1449513628ad24476b47331ea7bd6a2e82583

--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -4,6 +4,7 @@
 
 BlameSubversion = https://github.com/jenkinsci/jenkins/pull/5320
 blueocean-executor-info = https://issues.jenkins.io/browse/JENKINS-56773
+bmc-rpd-plugin = 
 cloverphp = https://github.com/jenkinsci/jenkins/pull/5320
 cmvc = https://github.com/jenkinsci/jenkins/pull/5320
 coding-webhook = https://github.com/jenkinsci/coding-webhook-plugin/commit/20e1449513628ad24476b47331ea7bd6a2e82583

--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -4,7 +4,7 @@
 
 BlameSubversion = https://github.com/jenkinsci/jenkins/pull/5320
 blueocean-executor-info = https://issues.jenkins.io/browse/JENKINS-56773
-bmc-rpd-plugin = 
+bmc-rpd-plugin = https://github.com/jenkins-infra/update-center2/pull/597
 cloverphp = https://github.com/jenkinsci/jenkins/pull/5320
 cmvc = https://github.com/jenkinsci/jenkins/pull/5320
 coding-webhook = https://github.com/jenkinsci/coding-webhook-plugin/commit/20e1449513628ad24476b47331ea7bd6a2e82583

--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -4,7 +4,7 @@
 
 BlameSubversion = https://github.com/jenkinsci/jenkins/pull/5320
 blueocean-executor-info = https://issues.jenkins.io/browse/JENKINS-56773
-bmc-rpd = https://github.com/jenkins-infra/update-center2/pull/597
+bmc-rpd = https://www.jenkins.io/changelog/#v2.355
 cloverphp = https://github.com/jenkinsci/jenkins/pull/5320
 cmvc = https://github.com/jenkinsci/jenkins/pull/5320
 coding-webhook = https://github.com/jenkinsci/coding-webhook-plugin/commit/20e1449513628ad24476b47331ea7bd6a2e82583

--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -4,7 +4,7 @@
 
 BlameSubversion = https://github.com/jenkinsci/jenkins/pull/5320
 blueocean-executor-info = https://issues.jenkins.io/browse/JENKINS-56773
-bmc-rpd = https://www.jenkins.io/changelog/#v2.355
+bmc-rpd = https://github.com/jenkins-infra/update-center2/pull/597
 cloverphp = https://github.com/jenkinsci/jenkins/pull/5320
 cmvc = https://github.com/jenkinsci/jenkins/pull/5320
 coding-webhook = https://github.com/jenkinsci/coding-webhook-plugin/commit/20e1449513628ad24476b47331ea7bd6a2e82583


### PR DESCRIPTION
The way form validation works in Jenkins is changing as part of https://github.com/jenkinsci/jenkins/pull/6460, 'bmc-rpd-plugin' uses custom logic in this area and as such won't work when 6460 is merged. 

Due to the plugins age and inactivity (six years) and that it has an active security warning it's been decided to deprecate the plugin.

----

The corresponding core PR was merged in 2.355, https://www.jenkins.io/changelog/#v2.355