### PR TITLE
chore: add an anchor within the readme for the CA cert key owners

### DIFF
--- a/resources/certificates/README.md
+++ b/resources/certificates/README.md
@@ -24,6 +24,7 @@ It is included in Jenkins 2.117 and newer as a trust anchor.
 
 This certificate is valid from 2018-04-08 to 2028-04-05.
 
+## `CA-key-owners`
 As of May 2020, Kohsuke, Oleg Nenashev, and Olivier Vernin have the corresponding private key.
 
 [INFRA-1502]: https://issues.jenkins-ci.org/browse/INFRA-1502


### PR DESCRIPTION
just to provide a direct link from other readme