### PR TITLE
Block `workflow-api` at `1162.va_1e49062a_00e`

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -737,3 +737,6 @@ monkit-plugin = https://groups.google.com/g/jenkinsci-dev/c/1bIdZr8P_Ms
 # https://www.jenkins.io/security/advisory/2022-05-17/
 storable-configs-plugin = https://www.jenkins.io/security/plugins/#suspensions
 autocomplete-parameter = https://www.jenkins.io/security/plugins/#suspensions
+
+# https://github.com/jenkinsci/workflow-api-plugin/pull/226
+workflow-api-1162.va_1e49062a_00e


### PR DESCRIPTION
Realized post release that https://github.com/jenkinsci/workflow-api-plugin/pull/221 would be offered to 2.289.x–2.319.x UCs without https://github.com/jenkinsci/workflow-cps-plugin/pull/534 which it requires to avoid some anomalous behavior. Best to block it from those lines, and let 2.332.x— pick up https://github.com/jenkinsci/workflow-api-plugin/pull/226. @dwnusbaum @car-roll