### PR TITLE
[JENKINS-68727] Block `workflow-durable-task-step-plugin` @ `1144.vd77b_57189936`

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -740,3 +740,5 @@ autocomplete-parameter = https://www.jenkins.io/security/plugins/#suspensions
 
 # https://github.com/jenkinsci/workflow-api-plugin/pull/226
 workflow-api-1162.va_1e49062a_00e
+# https://issues.jenkins.io/browse/JENKINS-68727
+workflow-durable-task-step-1144.vd77b_57189936


### PR DESCRIPTION
https://issues.jenkins.io/browse/JENKINS-68727

After https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/233 release, to follow up #599.