### PR TITLE
Deprecate Maven Repository Scheduled Cleanup

### DIFF
--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -15,6 +15,7 @@ extreme-feedback = https://www.jenkins.io/blog/2021/11/09/guava-upgrade/
 google-cloud-health-check = https://www.jenkins.io/blog/2021/11/09/guava-upgrade/
 harvest = https://github.com/jenkinsci/jenkins/pull/5320
 javatest-report = https://github.com/jenkinsci/jenkins/pull/5320
+maven-repo-cleaner = https://github.com/jenkinsci/jenkins/pull/6323
 nis-notification-lamp = https://github.com/jenkinsci/jenkins/pull/5521
 openshift-deployer = https://www.jenkins.io/blog/2021/11/09/guava-upgrade/
 performance-signature-dynatrace = https://github.com/jenkins-infra/update-center2/pull/531


### PR DESCRIPTION
JNR was removed in https://github.com/jenkinsci/jenkins/pull/6323. https://github.com/jenkinsci/maven-repo-cleaner-plugin/pull/4 dropped the dependency on JNR in Maven Repository Scheduled Cleanup, and that PR was merged on June 26, 2018; however, it has not been released.