### PR TITLE
Switch cache to SHA-256

### DIFF
--- a/src/main/java/io/jenkins/update_center/ArtifactoryRepositoryImpl.java
+++ b/src/main/java/io/jenkins/update_center/ArtifactoryRepositoryImpl.java
@@ -25,7 +25,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Date;
@@ -38,6 +37,7 @@ import java.util.jar.Manifest;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import org.apache.commons.codec.digest.DigestUtils;
 
 public class ArtifactoryRepositoryImpl extends BaseMavenRepository {
     private static final Logger LOGGER = Logger.getLogger(ArtifactoryRepositoryImpl.class.getName());
@@ -227,8 +227,7 @@ public class ArtifactoryRepositoryImpl extends BaseMavenRepository {
     }
 
     private File getFile(final String url) throws IOException {
-        String urlBase64 = Base64.encodeBase64String(new URL(url).getPath().getBytes(StandardCharsets.UTF_8));
-        File cacheFile = new File(cacheDirectory, urlBase64);
+        File cacheFile = new File(cacheDirectory, DigestUtils.sha256Hex(url));
 
         if (!cacheFile.exists()) {
             // High log level, but during regular operation this will indicate when an artifact is newly picked up, so useful to know.

--- a/src/main/java/io/jenkins/update_center/ArtifactoryRepositoryImpl.java
+++ b/src/main/java/io/jenkins/update_center/ArtifactoryRepositoryImpl.java
@@ -26,6 +26,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Date;
@@ -227,7 +228,12 @@ public class ArtifactoryRepositoryImpl extends BaseMavenRepository {
     }
 
     private File getFile(final String url) throws IOException {
-        File cacheFile = new File(cacheDirectory, DigestUtils.sha256Hex(url));
+        String urlBase64 = Base64.encodeBase64String(new URL(url).getPath().getBytes(StandardCharsets.UTF_8));
+        File cacheFile = new File(cacheDirectory, urlBase64);
+        if (!cacheFile.exists()) {
+            // Preferred new location (guaranteed maximum filename length):
+            cacheFile = new File(cacheDirectory, DigestUtils.sha256Hex(url));
+        }
 
         if (!cacheFile.exists()) {
             // High log level, but during regular operation this will indicate when an artifact is newly picked up, so useful to know.

--- a/src/main/java/io/jenkins/update_center/ArtifactoryRepositoryImpl.java
+++ b/src/main/java/io/jenkins/update_center/ArtifactoryRepositoryImpl.java
@@ -13,6 +13,7 @@ import okhttp3.ResponseBody;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.TeeOutputStream;
@@ -37,7 +38,6 @@ import java.util.jar.Manifest;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-import org.apache.commons.codec.digest.DigestUtils;
 
 public class ArtifactoryRepositoryImpl extends BaseMavenRepository {
     private static final Logger LOGGER = Logger.getLogger(ArtifactoryRepositoryImpl.class.getName());


### PR DESCRIPTION
Fixes https://github.com/jenkins-infra/helpdesk/issues/1968 by making all cache files have 64-char names. **Untested.**