### PR TITLE
Remove hostname from cache key

### DIFF
--- a/src/main/java/io/jenkins/update_center/ArtifactoryRepositoryImpl.java
+++ b/src/main/java/io/jenkins/update_center/ArtifactoryRepositoryImpl.java
@@ -229,11 +229,12 @@ public class ArtifactoryRepositoryImpl extends BaseMavenRepository {
 
     private File getFile(final String url) throws IOException {
         // TODO remove old base64 based cache paths once the cache is migrated
-        String urlBase64 = Base64.encodeBase64String(new URL(url).getPath().getBytes(StandardCharsets.UTF_8));
+        final String path = new URL(url).getPath();
+        String urlBase64 = Base64.encodeBase64String(path.getBytes(StandardCharsets.UTF_8));
         File cacheFile = new File(cacheDirectory, urlBase64);
         if (!cacheFile.exists()) {
             // Preferred new location (guaranteed maximum filename length):
-            final String sha256 = DigestUtils.sha256Hex(url);
+            final String sha256 = DigestUtils.sha256Hex(path);
             final String sha256prefix = sha256.substring(0, 2); // to limit number of files in top-level directory
             final File cachePrefixDir = new File(cacheDirectory, sha256prefix);
             if (!cachePrefixDir.exists() && !cachePrefixDir.mkdirs()) {
@@ -244,7 +245,7 @@ public class ArtifactoryRepositoryImpl extends BaseMavenRepository {
 
         if (!cacheFile.exists()) {
             // High log level, but during regular operation this will indicate when an artifact is newly picked up, so useful to know.
-            LOGGER.log(Level.INFO, "Downloading : " + url + " (not found in cache)");
+            LOGGER.log(Level.INFO, "Downloading : " + url + " (not found in cache) to " + cacheFile.getName());
 
             final File parentFile = cacheFile.getParentFile();
             if (!parentFile.mkdirs() && !parentFile.isDirectory()) {

--- a/src/main/java/io/jenkins/update_center/json/TieredUpdateSitesGenerator.java
+++ b/src/main/java/io/jenkins/update_center/json/TieredUpdateSitesGenerator.java
@@ -89,7 +89,7 @@ public class TieredUpdateSitesGenerator extends WithoutSignature {
             try {
                 return v.getRequiredJenkinsVersion();
             } catch (IOException e) {
-                LOGGER.log(Level.WARNING, "Failed to determine required Jenkins version for " + v.getGavId());
+                LOGGER.log(Level.WARNING, "Failed to determine required Jenkins version for " + v.getGavId(), e);
                 return null;
             }
         }).filter(Objects::nonNull).collect(Collectors.toSet()).stream().map(VersionNumber::new).sorted(Comparator.reverseOrder()).collect(Collectors.toList());


### PR DESCRIPTION
Since Artifactory is still on `repo.jenkins-ci.org` while everything else is on jenkins.io, I didn't want the cache key to include the host name.

I missed the discrepancy between https://github.com/jenkins-infra/update-center2/blob/95235d6ed1357a483f15b2584dc59d41aa6d5494/src/main/java/io/jenkins/update_center/ArtifactoryRepositoryImpl.java#L232 and https://github.com/jenkins-infra/update-center2/blob/95235d6ed1357a483f15b2584dc59d41aa6d5494/src/main/java/io/jenkins/update_center/ArtifactoryRepositoryImpl.java#L236 in #605, and so the script for migration of the cache from base64 to sha256 (see #609) did it incorrectly.

While we could update the cache keys to include the protocol/host name, the original motivation still applies. This also makes the base64 and sha256 behaviors consistent, at the cost of being incompatible with files cached with 3.11.

Also improve some log messages.