### PR TITLE
Replace broken wiki short URLs with full URLs

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -216,7 +216,7 @@ sms-notification                 # renamed to sms
 # superseded by sonargraph-integration --
 sonargraph-plugin = https://github.com/jenkins-infra/update-center2/pull/405
 # deprecated (see Sonatype CLM: https://wiki.jenkins-ci.org/x/iYDPAw)
-sonatype-ci = https://wiki.jenkins.io/x/iYDPAw
+sonatype-ci = https://wiki.jenkins.io/display/JENKINS/63930505
 squashtm-publisher                   # removal due to security issue JIRA SECURITY-2525
 ssh2easy-plugin                  # removal requested by plugin author, accidental rename
 # unused?

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -8,8 +8,8 @@
 AntepediaReporter-CI-plugin      # closed-souce plugin; removal confirmed with owner, Guillaume Rousseau
 # service discontinued. Alternative: https://plugins.jenkins.io/appetize/
 appio = https://github.com/jenkins-infra/update-center2/pull/465
-# service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/AppThwack+Plugin
-appthwack = https://wiki.jenkins.io/x/cwchB
+# service discontinued
+appthwack = https://wiki.jenkins-ci.org/display/JENKINS/AppThwack+Plugin
 # renamed to assembla-auth
 assembla-oauth = https://groups.google.com/d/msg/jenkinsci-dev/TVz-D5etsUM/Knx9zXtEnSwJ
 assembla-jenkins                 # Renamed to assembla
@@ -27,36 +27,36 @@ aws-yum-paramater                # renamed to package-parameter
 azure-iot-edge = https://github.com/jenkinsci/azure-iot-edge-plugin/blob/master/Readme.md
 bees-sdk-plugin                  # removal requested by ndeloof: RUN@cloud service no longer exists
 binary-deployer                  # removal requested by alecharp: this plugin was never meant to be deployed. POC project.
-# "This plugin is no longer supported and should not be used." -- https://wiki.jenkins-ci.org/display/JENKINS/Black+Duck+Vulnerability+Installer+Plugin
-blackduck-installer = https://wiki.jenkins.io/x/nYHHB
+# "This plugin is no longer supported and should not be used."
+blackduck-installer = https://wiki.jenkins-ci.org/display/JENKINS/Black+Duck+Vulnerability+Installer+Plugin
 # End of life.  Replaced with Detect
 blackduck-hub = https://github.com/jenkins-infra/update-center2/pull/261
 blitz.io-jenkins                 # renamed to blitz_io-jenkins
 # service discontinued: https://en.wikipedia.org/wiki/Blitz_(software)
 blitz_io-jenkins = https://github.com/jenkins-infra/update-center2/pull/521
-# superseded by Extra Columns Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Build+Node+Column+Plugin
-build-node-column = https://wiki.jenkins.io/x/1QiMAw
-# service discontinued: https://github.com/github/github-services/pull/538 -- https://wiki.jenkins-ci.org/display/JENKINS/Buildcoin+Plugin
-buildcoin-plugin = https://wiki.jenkins.io/x/KoyhAw
-# service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Buildheroes
-buildheroes = https://wiki.jenkins.io/x/_AD8Aw
+# superseded by Extra Columns Plugin
+build-node-column = https://wiki.jenkins-ci.org/display/JENKINS/Build+Node+Column+Plugin
+# service discontinued: https://github.com/github/github-services/pull/538
+buildcoin-plugin = https://wiki.jenkins-ci.org/display/JENKINS/Buildcoin+Plugin
+# service discontinued
+buildheroes = https://wiki.jenkins-ci.org/display/JENKINS/Buildheroes
 # service discontinued -- see https://www.codescan.io for alternative ways of running
 codescan = https://github.com/jenkins-infra/update-center2/pull/299
-# service shut down -- https://wiki.jenkins-ci.org/display/JENKINS/Caroline+Plugin
-caroline = https://wiki.jenkins.io/x/AwOMAw
+# service shut down
+caroline = https://wiki.jenkins-ci.org/display/JENKINS/Caroline+Plugin
 ChatRoom                          # junk plugin; developer has been banned
 # service discontinued https://www.chromium.org/developers/how-tos/chrome-frame-getting-started
 chrome-frame-plugin = https://www.chromium.org/developers/how-tos/chrome-frame-getting-started
-# Superseded by Publish Over CIFS Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/CIFS-Publisher+Plugin
-cifs = https://wiki.jenkins.io/x/lwC2Ag
+# Superseded by Publish Over CIFS Plugin
+cifs = https://wiki.jenkins-ci.org/display/JENKINS/CIFS-Publisher+Plugin
 # renamed to clang-scanbuild
 clang-scanbuild-plugin = https://github.com/jenkinsci/clang-scanbuild-plugin/commit/a6d57b67f6fbd0a9893ecf6436c54ecb670d5829
-# service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Cloudbees+Deployer+Plugin
-cloudbees-deployer-plugin = https://wiki.jenkins.io/x/24RoAw
-# Unsupported and retracted by service provider -- https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Jenkins+Enterprise
-cloudbees-enterprise-plugins = https://wiki.jenkins.io/x/3gX8Aw
-# "This feature is no longer relevant." -- https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Registration+Plugin
-cloudbees-registration = https://wiki.jenkins.io/x/z4FLB
+# service discontinued
+cloudbees-deployer-plugin = https://wiki.jenkins-ci.org/display/JENKINS/Cloudbees+Deployer+Plugin
+# Unsupported and retracted by service provider
+cloudbees-enterprise-plugins = https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Jenkins+Enterprise
+# "This feature is no longer relevant."
+cloudbees-registration = https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Registration+Plugin
 # renamed to cloudbees-disk-usage-simple several years ago
 cloudbees-disk-usage-simple-plugin = https://github.com/jenkins-infra/update-center2/pull/179
 ColumnPack-plugin                 # renamed to ColumnsPlugin
@@ -64,10 +64,10 @@ ConfigurationSlicing              # renamed into configurationslicing, and this 
 configuration-as-code-support = https://github.com/jenkinsci/configuration-as-code-plugin/releases/tag/configuration-as-code-1.18
 convert-to-declarative            # renamed to declarative-pipeline-migration-assistant-plugin
 convert-to-declarative-api       # renamed to declarative-pipeline-migration-assistant-plugin
-# superseded by ArtifactDeployer Plugin  -- https://wiki.jenkins-ci.org/display/JENKINS/CopyArchiver+Plugin
-copyarchiver = https://wiki.jenkins.io/x/ywJAAg
-# Incompatible with Hudson 1.355+ and superseded by xUnit Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/CppUnit+Plugin
-cppunit = https://wiki.jenkins.io/x/6oE5Ag
+# superseded by ArtifactDeployer Plugin
+copyarchiver = https://wiki.jenkins-ci.org/display/JENKINS/CopyArchiver+Plugin
+# Incompatible with Hudson 1.355+ and superseded by xUnit Plugin
+cppunit = https://wiki.jenkins-ci.org/display/JENKINS/CppUnit+Plugin
 create-fingerprint-plugin        # renamed to create-fingerprint
 datadog-build-reporter           # renamed to datadog
 delphix-plugin                   # renamed to delphix
@@ -78,8 +78,8 @@ dockerhub = https://github.com/jenkins-infra/update-center2/commit/e5a138873113d
 drools                           # deprecated
 # deprecated -- eggplant-plugin
 eggplant-plugin = https://github.com/jenkins-infra/update-center2/pull/578#issuecomment-1073702439
-# Superseded by Emotional Jenkins -- https://wiki.jenkins-ci.org/display/JENKINS/Emotional+Hudson+Plugin
-emotional-hudson = https://wiki.jenkins.io/x/C4DX
+# Superseded by Emotional Jenkins
+emotional-hudson = https://wiki.jenkins-ci.org/display/JENKINS/Emotional+Hudson+Plugin
 essentials                       # replaced by evergreen
 evergreen                        # not supposed to be installed manually. We use Incrementals http://repo.jenkins-ci.org/incrementals/io/jenkins/plugins/evergreen
 # deprecated
@@ -88,48 +88,48 @@ fabric-beta-publisher = https://github.com/jenkinsci/fabric-beta-publisher-plugi
 first-plugin                     # INFRA-1108: Unintended release as part of a plugin tutorial workshop
 foofoo                           # junk: contains only the HelloWorldBuilder sample
 foreman-node-sharing             # Reimplemented as https://github.com/jenkinsci/node-sharing-plugin/
-# superseded by Gerrit Trigger Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Gerrit+Plugin
-gerrit = https://wiki.jenkins.io/x/9ICVAg
-# no... just... no -- https://wiki.jenkins-ci.org/display/JENKINS/Girls+Plugin
-girls = https://wiki.jenkins.io/x/OAWbAg
-# service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Gitorious+Plugin
-gitorious = https://wiki.jenkins.io/x/ngDiAw
-# Google Desktop has been discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Hudson+Google+Desktop+Gadget
-google-desktop-gadget = https://wiki.jenkins.io/x/E4A3AQ
-# service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Google+Code+Plugin
-googlecode = https://wiki.jenkins.io/x/DQC7
+# superseded by Gerrit Trigger Plugin
+gerrit = https://wiki.jenkins-ci.org/display/JENKINS/Gerrit+Plugin
+# no... just... no
+girls = https://wiki.jenkins-ci.org/display/JENKINS/Girls+Plugin
+# service discontinued
+gitorious = https://wiki.jenkins-ci.org/display/JENKINS/Gitorious+Plugin
+# Google Desktop has been discontinued
+google-desktop-gadget = https://wiki.jenkins-ci.org/display/JENKINS/Hudson+Google+Desktop+Gadget
+# service discontinued
+googlecode = https://wiki.jenkins-ci.org/display/JENKINS/Google+Code+Plugin
 groovy-events-listener-plugin-master # unintentional fork of groovy-events-listener-plugin
-# service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Hall+Plugin
-hall-jenkins = https://wiki.jenkins.io/x/qQghB
+# service discontinued
+hall-jenkins = https://wiki.jenkins-ci.org/display/JENKINS/Hall+Plugin
 hello-world                      # people shouldn't actually *publish* the sample project!
 HiddenParameter                  # renamed to hidden-parameter
 hipchat-plugin                   # renamed to hipchat
-# service discontinued -- https://wiki.jenkins.io/display/JENKINS/HockeyApp+Plugin
-hockeyapp = https://wiki.jenkins.io/x/7oPPAw
+# service discontinued
+hockeyapp = https://wiki.jenkins.io/display/JENKINS/HockeyApp+Plugin
 hpe-network-virtualization = https://support.microfocus.com/kb/kmdoc.php?id=KM03806543
 hudson-logaction-plugin          # renamed to logaction-plugin
 hudson-startup-trigger           # renamed to startup-trigger-plugin
 icon-shim-plugin                 # renamed to icon-shim
 integrity                        # renamed to integrity-plugin
 incapptic-connect-uploader = https://github.com/jenkins-infra/update-center2/pull/574
-# service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/iON+Deployer+Plugin
-ion-deployer-plugin = https://wiki.jenkins.io/x/FhOMAw
+# service discontinued
+ion-deployer-plugin = https://wiki.jenkins-ci.org/display/JENKINS/iON+Deployer+Plugin
 ivy2                             # subsumed into the ivy plugin
-# service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Java.net+Plugin
-javanet = https://wiki.jenkins.io/x/AgDL
-# service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/java.net+uploader+Plugin
-javanet-uploader = https://wiki.jenkins.io/x/ZoAL
+# service discontinued
+javanet = https://wiki.jenkins-ci.org/display/JENKINS/Java.net+Plugin
+# service discontinued
+javanet-uploader = https://wiki.jenkins-ci.org/display/JENKINS/java.net+uploader+Plugin
 jbehave-hudson-plugin            # renamed to jbehave-jenkins-plugin
 jenkins-leiningen                # renamed to leiningen-plugin :'(
 # deleted by maintainers
 jenkins-tracker = https://issues.jenkins.io/browse/INFRA-1531
 jenkinswalldisplay-pom           # renamed to jenkinswalldisplay
-# unmaintained -- https://wiki.jenkins-ci.org/display/JENKINS/Jenkow+Activiti+Designer
-jenkow-activiti-designer = https://wiki.jenkins.io/x/ngnqAw
-# unmaintained -- https://wiki.jenkins-ci.org/display/JENKINS/Jenkow+Activiti+Explorer
-jenkow-activiti-explorer = https://wiki.jenkins.io/x/yQH8Aw
-# unmaintained -- https://wiki.jenkins-ci.org/display/JENKINS/Jenkow+Plugin
-jenkow-plugin = https://wiki.jenkins.io/x/WIuhAw
+# unmaintained
+jenkow-activiti-designer = https://wiki.jenkins-ci.org/display/JENKINS/Jenkow+Activiti+Designer
+# unmaintained
+jenkow-activiti-explorer = https://wiki.jenkins-ci.org/display/JENKINS/Jenkow+Activiti+Explorer
+# unmaintained
+jenkow-plugin = https://wiki.jenkins-ci.org/display/JENKINS/Jenkow+Plugin
 jgiven-plugin                    # renamed to jgiven
 jmeter                           # renamed to performance
 # deprecated
@@ -145,28 +145,28 @@ kundo                            # service discontinued -- https://wiki.jenkins-
 lechat                           # renamed to Kata which was discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/LeChat+Plugin
 loadrunner                       # closed-source plugin, removal requested by plugin author
 liverebel-deploy                 # only worked with obsolete releases -- https://wiki.jenkins-ci.org/display/JENKINS/LiveRebel+Plugin
-# part of core functionality since 1.433 -- https://wiki.jenkins-ci.org/display/JENKINS/M2+Extra+Steps+Plugin
-m2-extra-steps = https://wiki.jenkins.io/x/FIc5Ag
-# service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Cloud+Connector+Plugin
-mansion-cloud = https://wiki.jenkins.io/x/YwdRB
+# part of core functionality since 1.433
+m2-extra-steps = https://wiki.jenkins-ci.org/display/JENKINS/M2+Extra+Steps+Plugin
+# service discontinued
+mansion-cloud = https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Cloud+Connector+Plugin
 mber                             # service discontinued -- https://wiki.jenkins.io/display/JENKINS/Mber+Plugin
 # superseded by Relution Publisher
 mcap-eas-plugin = https://github.com/mwaylabs/jenkins-mcap-eas-plugin
 mogotest                         # deprecated: mogotest service no longer exists
-# service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/MyPeople+Plugin
-mypeople = https://wiki.jenkins.io/x/xQRCB
-# service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Nabaztag+Plugin
-nabaztag = https://wiki.jenkins.io/x/dIEuAg
-# product discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Netio-Plugin
-netio-plugin = https://wiki.jenkins.io/x/7gMHB
-# superseded by Mail Watcher Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Node+Offline+Notification+Plugin
-nodeofflinenotification = https://wiki.jenkins.io/x/0IKhAw
-# service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Notifo+Plugin
-notifo = https://wiki.jenkins.io/x/0ADDAg
+# service discontinued
+mypeople = https://wiki.jenkins-ci.org/display/JENKINS/MyPeople+Plugin
+# service discontinued
+nabaztag = https://wiki.jenkins-ci.org/display/JENKINS/Nabaztag+Plugin
+# product discontinued
+netio-plugin = https://wiki.jenkins-ci.org/display/JENKINS/Netio-Plugin
+# superseded by Mail Watcher Plugin
+nodeofflinenotification = https://wiki.jenkins-ci.org/display/JENKINS/Node+Offline+Notification+Plugin
+# service discontinued
+notifo = https://wiki.jenkins-ci.org/display/JENKINS/Notifo+Plugin
 octoperf-jenkins-plugin          # released from wrong repository; will be renamed
 openstack-plugin                 # renamed to openstack-cloud
-# service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Origo+Issue+Notifier
-origo-issue-notifier = https://wiki.jenkins.io/x/qgabAg
+# service discontinued
+origo-issue-notifier = https://wiki.jenkins-ci.org/display/JENKINS/Origo+Issue+Notifier
 otabuilder                       # latest sources at https://github.com/jeslyvarghese/otabuilder-plugin but discontinued due to tool chain discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Over-the-Air+Ad+Hoc+Deployment+Plugin+For+iOS
 paaslane                         # renamed to paaslane-estimate
 # renamed to extended-security-settings
@@ -182,10 +182,10 @@ pipeline-classpath = https://www.jenkins.io/security/plugins/#suspensions
 pipeline-editor = https://github.com/jenkinsci/pipeline-editor-plugin
 # renamed to poll-mailbox-trigger-plugin
 poll-mailbox-trigger = https://github.com/jenkins-infra/update-center2/pull/42
-# discontinued PoC, use Pretested Integration Plugin instead -- https://wiki.jenkins-ci.org/display/JENKINS/Pretest+Commit+Plugin
-pretest-commit = https://wiki.jenkins.io/x/5gB-B
-# superseded by ClearCase UCM Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/pucm+plugin
-PUCM = https://wiki.jenkins.io/x/fIBVAw
+# discontinued PoC, use Pretested Integration Plugin instead
+pretest-commit = https://wiki.jenkins-ci.org/display/JENKINS/Pretest+Commit+Plugin
+# superseded by ClearCase UCM Plugin
+PUCM = https://wiki.jenkins-ci.org/display/JENKINS/pucm+plugin
 rally-bookkeeper                 # removal requested by Mike Rogers: will be Rally plugin 2.0
 rally-update-plugin-1            # renamed to rally-plugin(!)
 release-multi-test               # junk: contains only the HelloWorldBuilder sample
@@ -196,8 +196,8 @@ rtc = https://github.com/jenkins-infra/update-center2/pull/13
 sahagin-jenkins-plugin           # renamed to sahagin-plugin
 sample                           # junk plugin; developer has been banned
 schedule-build-plugin            # renamed to schedule-build
-# superseded by Naginator Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Retry+Failed+Builds+Plugin
-schedule-failed-builds = https://wiki.jenkins.io/x/roM5Ag
+# superseded by Naginator Plugin
+schedule-failed-builds = https://wiki.jenkins-ci.org/display/JENKINS/Retry+Failed+Builds+Plugin
 # deprecated
 scis-ad = https://github.com/jenkins-infra/update-center2/commit/5f3f5ae66ea0e819c27d6d1fed9fdb00781f636c
 # renamed shortly after publication for https://github.com/jenkins-infra/repository-permissions-updater/pull/459#issuecomment-334702817
@@ -205,12 +205,12 @@ scm-branch-pr-filter = https://issues.jenkins.io/browse/INFRA-1358
 script-realm-extended            # fork of a plugin and has since been subsumed -- https://wiki.jenkins-ci.org/display/JENKINS/Script+Security+Realm+Extended
 # plugin obsolete, replaced by Gradle-based invocation; depublishing as requested by 'silk' in SECURITY-1521
 SCTMExecutor = https://github.com/jenkins-infra/update-center2/pull/324
-# superseded by Credentials Binding Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Build+Secret+Plugin
-secret = https://wiki.jenkins.io/x/9ghSAg
+# superseded by Credentials Binding Plugin
+secret = https://wiki.jenkins-ci.org/display/JENKINS/Build+Secret+Plugin
 security-no-captcha              # Functionality integrated in Jenkins 1.416 -- https://wiki.jenkins-ci.org/display/JENKINS/Security+No+CAPTCHA
 serenitec                        # gbossert asked to remove this plugin
-# superseded by envinject -- https://wiki.jenkins-ci.org/display/JENKINS/Setenv+Plugin
-setenv = https://wiki.jenkins.io/x/YAtSAg
+# superseded by envinject
+setenv = https://wiki.jenkins-ci.org/display/JENKINS/Setenv+Plugin
 skytap-cloud-plugin              # renamed to skytap
 sms-notification                 # renamed to sms
 # superseded by sonargraph-integration --
@@ -219,20 +219,20 @@ sonargraph-plugin = https://github.com/jenkins-infra/update-center2/pull/405
 sonatype-ci = https://wiki.jenkins.io/x/iYDPAw
 squashtm-publisher                   # removal due to security issue JIRA SECURITY-2525
 ssh2easy-plugin                  # removal requested by plugin author, accidental rename
-# unused? -- https://wiki.jenkins-ci.org/display/JENKINS/TEPCO+Plugin
-tepco = https://wiki.jenkins.io/x/zoBoAw
-# unused? -- https://wiki.jenkins-ci.org/display/JENKINS/TEPCO+Electric+Power+Usage+Widget
-tepco-epuw = https://wiki.jenkins.io/x/vohoAw
+# unused?
+tepco = https://wiki.jenkins-ci.org/display/JENKINS/TEPCO+Plugin
+# unused?
+tepco-epuw = https://wiki.jenkins-ci.org/display/JENKINS/TEPCO+Electric+Power+Usage+Widget
 TestExecuter                     # renamed to selected-tests-executor
-# service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Testflight+Plugin
-testflight = https://wiki.jenkins.io/x/pwZ1Aw
+# service discontinued
+testflight = https://wiki.jenkins-ci.org/display/JENKINS/Testflight+Plugin
 TestResultsAnalyzer              # renamed to test-results-analyzer
 tusarnotifier                    # superseded by DTKit Plugin with automatic migration -- https://wiki.jenkins-ci.org/display/JENKINS/TusarNotifier
 ui-samples-plugin = https://groups.google.com/g/jenkinsci-dev/c/2vGn3t9gZ0Y
 uithemes                         # removal requested by tfennelly
 upload-artifacts-to-nexus        # renamed, see https://issues.jenkins-ci.org/browse/HOSTING-41?focusedCommentId=250383&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-250383
-# Superseded by URLTrigger Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/URL+Change+Trigger
-url-change-trigger = https://wiki.jenkins.io/x/BQBJ
+# Superseded by URLTrigger Plugin
+url-change-trigger = https://wiki.jenkins-ci.org/display/JENKINS/URL+Change+Trigger
 vagrant-plugin                    # renamed to vagrant, herpderp
 # service discontinued --- https://wiki.jenkins-ci.org/display/JENKINS/Vessel+plugin https://groups.google.com/d/msg/jenkinsci-dev/L34eAMMWA5o/-AxtRdGsAAAJ
 vessel = https://groups.google.com/d/msg/jenkinsci-dev/L34eAMMWA5o/-AxtRdGsAAAJ
@@ -240,8 +240,8 @@ weibo4jenkins                    # renamed to weibo
 wsnotifier                       # renamed to websocket
 # renamed to xltestview-plugin
 xltest-plugin = https://github.com/jenkinsci/xltestview-plugin/commit/ea034f9929b520e63b9ce15aed9bdb62354146cf
-# superseded by zap -- https://wiki.jenkins-ci.org/display/JENKINS/ZAProxy+Plugin
-zaproxy = https://wiki.jenkins.io/x/JgCsB
+# superseded by zap
+zaproxy = https://wiki.jenkins-ci.org/display/JENKINS/ZAProxy+Plugin
 zaproxy-jenkins                  # renamed to zaproxy
 zubhium                          # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Zubhium+Plugin
 


### PR DESCRIPTION
Short URLs were nice to save bytes on `update-center.json`, but they no longer work.