### PR TITLE
Block mergebase-sca because its version numbers cause trouble

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -744,3 +744,6 @@ autocomplete-parameter = https://www.jenkins.io/security/plugins/#suspensions
 workflow-api-1162.va_1e49062a_00e
 # https://issues.jenkins.io/browse/JENKINS-68727
 workflow-durable-task-step-1144.vd77b_57189936
+
+# Block mergebase-sca because its version numbers cause trouble with this tool: https://repo.jenkins-ci.org/artifactory/releases/com/mergebase/mergebase-sca/
+mergebase-sca


### PR DESCRIPTION
We invoke `ln` with the version number as second arg without `--`, so `ln` thinks this is a flag. That'll be the proper fix (or, even properer, apply https://github.com/jenkins-infra/update-center2/pull/569), but for now this needs to work again to unblock today's security advisory delivery.

FYI @delanAtMergebase, we'll readmit your plugin later today or tomorrow once we've made this tool more robust.
