### PR TITLE
[JENKINS-69229] Suspend distribution of trilead-api-1.71.v9e7860a_67a_df

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -749,3 +749,6 @@ workflow-durable-task-step-1144.vd77b_57189936
 mergebase-sca
 
 katalon = https://issues.jenkins.io/browse/JENKINS-69164
+
+# Incompatible with Java 8, but does not require 2.357+ to restrict itself to Java 11 only releases of Jenkins
+trilead-api-1.71.v9e7860a_67a_df


### PR DESCRIPTION
While the Java 11 requirement is documented in https://github.com/jenkinsci/trilead-api-plugin/releases/tag/1.71.v9e7860a_67a_df, the plugin does not require a Java 11 only release of Jenkins, and does not set the incompatibility flag (whose message wouldn't be great but at least folks would read the changelog).

I suggest we do the following:

* Suspend this release of `trilead-api`
* @kuisathaverat bumps the core dependency of `trilead-api` to 2.357 so it's only offered to Java 11 only update sites.

Thoughts?