### PR TITLE
Fix symlink creation when it already exists

### DIFF
--- a/src/main/java/io/jenkins/update_center/DirectoryTreeBuilder.java
+++ b/src/main/java/io/jenkins/update_center/DirectoryTreeBuilder.java
@@ -132,7 +132,7 @@ public class DirectoryTreeBuilder {
         try {
             Files.createSymbolicLink(newLink, existingFile);
         } catch (IOException | UnsupportedOperationException ex) {
-            LOGGER.log(Level.WARNING, "Failed to link ");
+            LOGGER.log(Level.WARNING, "Failed to link", ex);
         }
     }
 

--- a/src/main/java/io/jenkins/update_center/DirectoryTreeBuilder.java
+++ b/src/main/java/io/jenkins/update_center/DirectoryTreeBuilder.java
@@ -130,6 +130,7 @@ public class DirectoryTreeBuilder {
         Path newLink = Paths.get("latest");
         Path existingFile = Paths.get(hpi.getLatest().version);
         try {
+            Files.deleteIfExists(newLink);
             Files.createSymbolicLink(newLink, existingFile);
         } catch (IOException | UnsupportedOperationException ex) {
             LOGGER.log(Level.WARNING, "Failed to link", ex);
@@ -162,6 +163,7 @@ public class DirectoryTreeBuilder {
         Path newLink = Paths.get(dst.getAbsolutePath());
         Path existingFile = Paths.get(src.getAbsolutePath());
         try {
+            Files.deleteIfExists(newLink);
             Files.createSymbolicLink(newLink, existingFile);
         } catch (IOException | UnsupportedOperationException ex) {
             LOGGER.log(Level.WARNING, "Failed to create " + dst + " from " + src, ex);


### PR DESCRIPTION
The Java API does not overwrite existing symlinks, so we need to delete what's there first.

Also add better logging when things go wrong.

Amends #569.