### PR TITLE
Do not wipe options with default values when using --arguments-file

### DIFF
--- a/src/main/java/io/jenkins/update_center/Main.java
+++ b/src/main/java/io/jenkins/update_center/Main.java
@@ -27,6 +27,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.util.VersionNumber;
 import io.jenkins.lib.support_log_formatter.SupportLogFormatter;
+import io.jenkins.update_center.args4j.Default;
 import io.jenkins.update_center.args4j.LevelOptionHandler;
 import io.jenkins.update_center.json.PlatformPluginsRoot;
 import io.jenkins.update_center.json.RecentReleasesRoot;
@@ -136,9 +137,11 @@ public class Main {
     public boolean prettyPrint;
 
     @Option(name = "--id", usage = "Uniquely identifies this update center. We recommend you use a dot-separated name like \"com.sun.wts.jenkins\". This value is not exposed to users, but instead internally used by Jenkins.")
+    @Default(value = "default")
     @CheckForNull public String id = "default";
 
     @Option(name = "--connection-check-url", usage = "Specify an URL of the 'always up' server for performing connection check.")
+    @Default(value = "https://www.google.com/")
     @CheckForNull public String connectionCheckUrl = "https://www.google.com/";
 
 
@@ -210,13 +213,21 @@ public class Main {
                 if (field.getAnnotation(Option.class) != null && !Modifier.isStatic(field.getModifiers())) {
                     if (Object.class.isAssignableFrom(field.getType())) {
                         try {
-                            field.set(o, null);
+                            if (field.getAnnotation(Default.class) != null) {
+                                field.set(o, field.getAnnotation(Default.class).value());
+                            } else {
+                                field.set(o, null);
+                            }
                         } catch (IllegalAccessException e) {
                             LOGGER.log(Level.WARNING, "Failed to reset argument", e);
                         }
                     } else if (boolean.class.isAssignableFrom(field.getType())) {
                         try {
-                            field.set(o, false);
+                            if (field.getAnnotation(Default.class) != null) {
+                                field.set(o, Boolean.parseBoolean(field.getAnnotation(Default.class).value()));
+                            } else {
+                                field.set(o, false);
+                            }
                         } catch (IllegalAccessException e) {
                             LOGGER.log(Level.WARNING, "Failed to reset boolean option", e);
                         }

--- a/src/main/java/io/jenkins/update_center/args4j/Default.java
+++ b/src/main/java/io/jenkins/update_center/args4j/Default.java
@@ -1,0 +1,14 @@
+package io.jenkins.update_center.args4j;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Provide a way to define default values for {@link org.kohsuke.args4j.Option}s
+ * that cannot be reset in {@link io.jenkins.update_center.Main#run} when taking
+ * an arguments file.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Default {
+    String value();
+}


### PR DESCRIPTION
Amends #561.

Without this, using `--arguments-file` with reset the arguments to `null`.

There's redundancy between the annotation and the actual field. This isn't great but I couldn't think quickly of a way to record default values, and args4j prints field values as part of `--help` output, so leaving the fields at their empty default would be misleading.