### PR TITLE
Add 'releaseTimestamp' with second resolution to plugin-versions.json

### DIFF
--- a/src/main/java/io/jenkins/update_center/json/PluginVersionsEntry.java
+++ b/src/main/java/io/jenkins/update_center/json/PluginVersionsEntry.java
@@ -5,7 +5,9 @@ import io.jenkins.update_center.MavenRepository;
 import io.jenkins.update_center.HPI;
 
 import java.io.IOException;
+import java.text.SimpleDateFormat;
 import java.util.List;
+import java.util.Locale;
 
 public class PluginVersionsEntry {
     @JSONField
@@ -24,6 +26,8 @@ public class PluginVersionsEntry {
     public final String version;
     @JSONField
     public final String compatibleSinceVersion;
+    @JSONField
+    public final String releaseTimestamp;
 
     @JSONField
     public final List<HPI.Dependency> dependencies;
@@ -39,5 +43,8 @@ public class PluginVersionsEntry {
         buildDate = hpi.getTimestampAsString();
         dependencies = hpi.getDependencies();
         compatibleSinceVersion = hpi.getCompatibleSinceVersion();
+        releaseTimestamp = TIMESTAMP_FORMATTER.format(hpi.getTimestamp());
     }
+
+    private static final SimpleDateFormat TIMESTAMP_FORMATTER = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'.00Z'", Locale.US);
 }


### PR DESCRIPTION
Add higher resolution field for release timestamps for https://github.com/jenkins-infra/plugin-site/issues/1220.

The field name and date format is consistent with the corresponding field in `update-center.json`

As a side effect, this adds 45 bytes for each plugin release (of which there are 26k), roughly increasing file size by 9%.