### PR TITLE
[JENKINS-69164] Restore distribution of Katalon (only suspend old releases)

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -748,7 +748,31 @@ workflow-durable-task-step-1144.vd77b_57189936
 # Block mergebase-sca because its version numbers cause trouble with this tool: https://repo.jenkins-ci.org/artifactory/releases/com/mergebase/mergebase-sca/
 mergebase-sca
 
-katalon = https://issues.jenkins.io/browse/JENKINS-69164
+# https://issues.jenkins.io/browse/JENKINS-69164
+katalon-1.0.30
+katalon-1.0.29
+katalon-1.0.28
+katalon-1.0.27
+katalon-1.0.26
+katalon-1.0.25
+katalon-1.0.23
+katalon-1.0.22
+katalon-1.0.21
+katalon-1.0.20
+katalon-1.0.19
+katalon-1.0.18
+katalon-1.0.11
+katalon-1.0.10
+katalon-1.0.9
+katalon-1.0.8
+katalon-1.0.7
+katalon-1.0.6
+katalon-1.0.5
+katalon-1.0.4
+katalon-1.0.3
+katalon-1.0.2
+katalon-1.0.1
+katalon-1.0.0
 
 # Incompatible with Java 8, but does not require 2.357+ to restrict itself to Java 11 only releases of Jenkins
 trilead-api-1.71.v9e7860a_67a_df

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -749,6 +749,7 @@ workflow-durable-task-step-1144.vd77b_57189936
 mergebase-sca
 
 # https://issues.jenkins.io/browse/JENKINS-69164
+katalon-1.0.31
 katalon-1.0.30
 katalon-1.0.29
 katalon-1.0.28


### PR DESCRIPTION
[JENKINS-69164](https://issues.jenkins.io/browse/JENKINS-69164)

Amends #626.

https://github.com/jenkinsci/katalon-plugin/pull/25 updates the utils library to include https://github.com/katalon-studio/utils/releases/tag/v1.0.16

CC @halkeye @MarkEWaite 