### PR TITLE
Suspend distribution of build-publisher, cons3rt, walti

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -763,6 +763,6 @@ DotCi-InstallPackages = https://www.jenkins.io/security/plugins/#suspensions
 DotCiInstallPackages = https://www.jenkins.io/security/plugins/#suspensions
 
 # Various plugins with severe issues appearing in https://jenkins.io/security/advisory/2022-09-21/
-build-publisher = https://github.com/jenkins-infra/update-center2/issues/644
-cons3rt = https://github.com/jenkins-infra/update-center2/issues/644
-walti = https://github.com/jenkins-infra/update-center2/issues/644
+build-publisher = https://github.com/jenkins-infra/update-center2/pull/644
+cons3rt = https://github.com/jenkins-infra/update-center2/pull/644
+walti = https://github.com/jenkins-infra/update-center2/pull/644

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -761,3 +761,8 @@ DotCi-DockerPublish = https://www.jenkins.io/security/plugins/#suspensions
 DotCi-Fig-template = https://www.jenkins.io/security/plugins/#suspensions
 DotCi-InstallPackages = https://www.jenkins.io/security/plugins/#suspensions
 DotCiInstallPackages = https://www.jenkins.io/security/plugins/#suspensions
+
+# Various plugins with severe issues appearing in https://jenkins.io/security/advisory/2022-09-21/
+build-publisher = https://github.com/jenkins-infra/update-center2/issues/644
+cons3rt = https://github.com/jenkins-infra/update-center2/issues/644
+walti = https://github.com/jenkins-infra/update-center2/issues/644


### PR DESCRIPTION
### Build Publisher

The plugin is incompatible with JEP-200, Jenkins 2.266+ (it hardcodes the `j_acegi_security_check` URL), and possibly even always-on CSRF protection (2.222+); so it doesn't really make sense to continue distributing it.

### CONS3RT

The maintainer asked that we suspend distribution with the following explanation:

> The tool it is associated with has moved to a different authentication path than the plugin currently supports, making the plugin no longer valid for use against the tool. As such are no longer looking to support, distribute, or update the plugin.

### Walti

The domain walti.io is for sale, the service seems to no longer exist.
