### PR TITLE
Suspend plugins that block global config save

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -766,3 +766,11 @@ DotCiInstallPackages = https://www.jenkins.io/security/plugins/#suspensions
 build-publisher = https://github.com/jenkins-infra/update-center2/pull/644
 cons3rt = https://github.com/jenkins-infra/update-center2/pull/644
 walti = https://github.com/jenkins-infra/update-center2/pull/644
+
+# Various plugins with long-standing tables to divs issues that block global configuration save
+# No reason to distribute plugins that block global configuration editing
+# Blocking job configuration editing is not enough to be included in this list
+aws-sqs = https://issues.jenkins.io/browse/JENKINS-65834
+github-sqs = https://issues.jenkins.io/browse/JENKINS-65729
+job-direct-mail = https://issues.jenkins.io/browse/JENKINS-65478
+openstack-heat = https://issues.jenkins.io/browse/JENKINS-65514

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -771,6 +771,6 @@ walti = https://github.com/jenkins-infra/update-center2/pull/644
 # No reason to distribute plugins that block global configuration editing
 # Blocking job configuration editing is not enough to be included in this list
 aws-sqs = https://issues.jenkins.io/browse/JENKINS-65834
-github-sqs = https://issues.jenkins.io/browse/JENKINS-65729
+github-sqs-plugin = https://issues.jenkins.io/browse/JENKINS-65729
 job-direct-mail = https://issues.jenkins.io/browse/JENKINS-65478
 openstack-heat = https://issues.jenkins.io/browse/JENKINS-65514


### PR DESCRIPTION
## Suspend plugins that block global configuration save

Suspend distribution of plugins with long-standing global configuration issues due to the tables to divs transition in Jenkins 2.277.1.  Stop distributing plugins that block global configuration save for actively maintained Jenkins versions.

All the suspended plugins have decreasing installation counts over the last 12 months.  That is expected because users detect the problem and remove the plugin from their installation when they upgrade to Jenkins 2.277.1 or later.

Suspended plugins include:

* [aws-sqs](https://plugins.jenkins.io/aws-sqs/) - [JENKINS-65834](https://issues.jenkins.io/browse/JENKINS-65834)
* [github-sqs-plugin](https://plugins.jenkins.io/github-sqs-plugin/) - [JENKINS-65729](https://issues.jenkins.io/browse/JENKINS-65729)
* [job-direct-mail](https://plugins.jenkins.io/job-direct-mail/) - [JENKINS-65478](https://issues.jenkins.io/browse/JENKINS-65478)
* [openstack-heat](https://plugins.jenkins.io/openstack-heat/) - [JENKINS-65514](https://issues.jenkins.io/browse/JENKINS-65514) - also has 2 open security issues
