### PR TITLE
Query repositories in alphabetical order

### DIFF
--- a/src/main/java/io/jenkins/update_center/GitHubSource.java
+++ b/src/main/java/io/jenkins/update_center/GitHubSource.java
@@ -75,7 +75,7 @@ public class GitHubSource {
             JSONObject jsonObject = new JSONObject();
             jsonObject.put("query", String.format("{%n" +
                             "  organization(login: %s) {%n" +
-                            "    repositories(first: 100, after: %s) {%n" +
+                            "    repositories(first: 100, after: %s, orderBy:{field:NAME,direction:ASC}) {%n" +
                             "      pageInfo {%n" +
                             "        startCursor%n" +
                             "        hasNextPage%n" +


### PR DESCRIPTION
Fixes https://github.com/jenkins-infra/helpdesk/issues/3190 (when running locally).

Though it is a workaround for a GitHub issue, it may still be worth merging since it makes the code more deterministic.