### PR TITLE
Mark async-http-client as deprecated

### DIFF
--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -2,6 +2,7 @@
 # should link to (value). Use this file to mark a plugin as deprecated while continuing to distribute it. If a plugin
 # should be removed from distribution entirely, instead set a deprecation notice URL in artifact-ignores.properties.
 
+async-http-client = https://github.com/jenkins-infra/update-center2/pull/650
 BlameSubversion = https://github.com/jenkinsci/jenkins/pull/5320
 blueocean-executor-info = https://issues.jenkins.io/browse/JENKINS-56773
 bmc-rpd = https://github.com/jenkins-infra/update-center2/pull/597


### PR DESCRIPTION
This library wrapper plugin is for the long-obsolete 1.x line of https://github.com/AsyncHttpClient/async-http-client whose [last release](https://github.com/AsyncHttpClient/async-http-client/releases/tag/async-http-client-1.9.40) was six years ago.

WDYT @batmat @rsandell as some of its maintainers?