### PR TITLE
Restore distribution of neuvector-vulnerability-scanner

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -802,7 +802,6 @@ openstack-heat = https://issues.jenkins.io/browse/JENKINS-65514
 
 # https://jenkins.io/security/advisory/2022-10-19/
 fireline = https://www.jenkins.io/security/plugins/#suspensions
-neuvector-vulnerability-scanner = https://www.jenkins.io/security/plugins/#suspensions
 screenrecorder = https://www.jenkins.io/security/plugins/#suspensions
 xframium = https://www.jenkins.io/security/plugins/#suspensions
 


### PR DESCRIPTION
Warnings update to follow (too lazy to write it myself, and the script we have needs to have the plugin distributed).