### PR TITLE
Update warning for neuvector-vulnerability-scanner / SECURITY-2865

### DIFF
--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -14416,8 +14416,8 @@
     "url": "https://www.jenkins.io/security/advisory/2022-10-19/#SECURITY-2865",
     "versions": [
       {
-        "lastVersion": "1.20",
-        "pattern": ".*"
+        "lastVersion": "1.21",
+        "pattern": "(1[.][0-9]|1[.]1[0-9]|1[.]2[01])(|[.-].+)"
       }
     ]
   },


### PR DESCRIPTION
[SECURITY-2865](https://www.jenkins.io/security/advisory/2022-10-19/#SECURITY-2865) is addressed in 1.22: https://github.com/jenkinsci/neuvector-vulnerability-scanner-plugin/compare/neuvector-vulnerability-scanner-1.21...neuvector-vulnerability-scanner-1.22