### PR TITLE
Mark warning as fixed for cloudformation plugin

### DIFF
--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -3858,7 +3858,8 @@
     "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1042",
     "versions": [
       {
-        "pattern": ".*"
+        "lastVersion": "1.3",
+        "pattern": "jenkins-cloudformation-plugin-[0-1][.][0-9]+"
       }
     ]
   },

--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -3858,8 +3858,8 @@
     "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1042",
     "versions": [
       {
-        "lastVersion": "1.3",
-        "pattern": "jenkins-cloudformation-plugin-[0-1][.][0-9]+"
+        "lastVersion": "1.2",
+        "pattern": "(0|1[.][02])(|[.-].+)"
       }
     ]
   },


### PR DESCRIPTION
This CVE was fixed in https://github.com/jenkinsci/jenkins-cloudformation-plugin/pull/58 and released in version [1.4196.v59065a_32f38a](https://github.com/jenkinsci/jenkins-cloudformation-plugin/releases/tag/1.4196.v59065a_32f38a).
