### PR TITLE
Add suspensions for additional plugins after 2022-11-15 advisory

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -25,6 +25,7 @@ aws-lambda-plugin                # renamed to aws-lambda
 aws-yum-paramater                # renamed to package-parameter
 # deprecated -- https://github.com/jenkinsci/azure-iot-edge-plugin/blob/master/Readme.md
 azure-iot-edge = https://github.com/jenkinsci/azure-iot-edge-plugin/blob/master/Readme.md
+bart = https://github.com/jenkins-infra/update-center2/pull/658
 bees-sdk-plugin                  # removal requested by ndeloof: RUN@cloud service no longer exists
 binary-deployer                  # removal requested by alecharp: this plugin was never meant to be deployed. POC project.
 # "This plugin is no longer supported and should not be used."
@@ -167,6 +168,7 @@ octoperf-jenkins-plugin          # released from wrong repository; will be renam
 openstack-plugin                 # renamed to openstack-cloud
 # service discontinued
 origo-issue-notifier = https://wiki.jenkins-ci.org/display/JENKINS/Origo+Issue+Notifier
+osf-builder-suite-xml-linter = https://github.com/jenkins-infra/update-center2/pull/658
 otabuilder                       # latest sources at https://github.com/jeslyvarghese/otabuilder-plugin but discontinued due to tool chain discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Over-the-Air+Ad+Hoc+Deployment+Plugin+For+iOS
 paaslane                         # renamed to paaslane-estimate
 # renamed to extended-security-settings


### PR DESCRIPTION
### BART (`bart`)

This plugin [does not work and has never worked unless used with `hpi:run`](https://github.com/jenkinsci/bart-plugin/blob/30d19e0ded8588c84601c7ffbcd0dd91c08ef945/src/main/java/org/jenkinsci/plugins/bart/LogParserBuildAction.java#L85). Given the age and low (single digit) install count, suspend it.

### OSF Builder Suite :: XML Linter (`osf-builder-suite-xml-linter`)

When the maintainer responded to [SECURITY-2937](https://www.jenkins.io/security/advisory/2022-11-15/#SECURITY-2937), they asked that the plugin be suspended (#651) and archived the repo already: https://github.com/jenkinsci/osf-builder-suite-xml-linter-plugin

Supersedes #651.