### PR TITLE
Mark SECURITY-2910 (2) fixed in 4.8.0.148

### DIFF
--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -14625,8 +14625,8 @@
     "url": "https://www.jenkins.io/security/advisory/2022-11-15/#SECURITY-2910%20(2)",
     "versions": [
       {
-        "lastVersion": "4.8.0.146",
-        "pattern": ".*"
+        "lastVersion": "4.8.0.147",
+        "pattern": "(4[.]6|4[.]8[.]0[.]129|4[.]8[.]0[.]13[04]|4[.]8[.]0[.]14[2367]|4[.]8[.]0[.]77)(|[.-].+)"
       }
     ]
   },


### PR DESCRIPTION
The maintainers informed us that this issue is resolved.

We'll still need to confirm that, but then merging this PR will remove the warning.