### PR TITLE
Update label-definitions.properties

### DIFF
--- a/resources/label-definitions.properties
+++ b/resources/label-definitions.properties
@@ -543,6 +543,7 @@ kanboard=notifier
 keepSlaveOffline=slaves
 kerberos-sso=user security
 keyboard-shortcuts-plugin=misc ui
+keycloak=adopt-this-plugin deprecated
 kiuwanJenkinsPlugin=external post-build
 klaros-testmanagement=external
 klocwork=report


### PR DESCRIPTION
keycloak-plugin is not maintained anymore. there are other alternative plugins which could be used instead. so i mark this plugin as deprecated and open for adoption.