### PR TITLE
Update label-definitions.properties to deprecate plugin

### DIFF
--- a/resources/label-definitions.properties
+++ b/resources/label-definitions.properties
@@ -1103,3 +1103,4 @@ zephyr-for-jira-test-management=post-build external
 zmq-event-publisher=external
 zos-connector=scm builder misc
 maven-snapshot-check=builder
+lightstep-incident-response-plugin=deprecated


### PR DESCRIPTION
Update label-definitions.properties to deprecate the plugin "lightstep-incident-response-plugin"