### PR TITLE
Remove warning from compuware-topaz-for-total-test

### DIFF
--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -14144,8 +14144,8 @@
     "url": "https://www.jenkins.io/security/advisory/2022-10-19/#SECURITY-2623",
     "versions": [
       {
-        "lastVersion": "2.4.8",
-        "pattern": ".*"
+        "lastVersion": "2.4.9",
+        "pattern": "(1|2[.][0-3]|2[.]4[.][1234578])(|[.-].+)"
       }
     ]
   },
@@ -14157,8 +14157,8 @@
     "url": "https://www.jenkins.io/security/advisory/2022-10-19/#SECURITY-2624",
     "versions": [
       {
-        "lastVersion": "2.4.8",
-        "pattern": ".*"
+        "lastVersion": "2.4.9",
+        "pattern": "(1|2[.][0-3]|2[.]4[.][1234578])(|[.-].+)"
       }
     ]
   },
@@ -14170,8 +14170,8 @@
     "url": "https://www.jenkins.io/security/advisory/2022-10-19/#SECURITY-2625",
     "versions": [
       {
-        "lastVersion": "2.4.8",
-        "pattern": ".*"
+        "lastVersion": "2.4.9",
+        "pattern": "(1|2[.][0-3]|2[.]4[.][1234578])(|[.-].+)"
       }
     ]
   },


### PR DESCRIPTION
[SECURITY-2623](https://issues.jenkins.io/browse/SECURITY-2623) corrected by https://github.com/jenkinsci/compuware-topaz-for-total-test-plugin/pull/51 which landed on 2.4.10

[SECURITY-2624](https://issues.jenkins.io/browse/SECURITY-2624) corrected by https://github.com/jenkinsci/compuware-topaz-for-total-test-plugin/pull/52 which landed on 2.4.10

[SECURITY-2625](https://issues.jenkins.io/browse/SECURITY-2625) corrected by https://github.com/jenkinsci/compuware-topaz-for-total-test-plugin/pull/50 which landed on 2.4.10