### PR TITLE
Suspend cloudbees-plugin-gateway

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -56,6 +56,7 @@ clang-scanbuild-plugin = https://github.com/jenkinsci/clang-scanbuild-plugin/com
 cloudbees-deployer-plugin = https://wiki.jenkins-ci.org/display/JENKINS/Cloudbees+Deployer+Plugin
 # Unsupported and retracted by service provider
 cloudbees-enterprise-plugins = https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Jenkins+Enterprise
+cloudbees-plugin-gateway = https://github.com/jenkinsci/cloudbees-plugin-gateway/blob/master/README.md
 # "This feature is no longer relevant."
 cloudbees-registration = https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Registration+Plugin
 # renamed to cloudbees-disk-usage-simple several years ago


### PR DESCRIPTION
According to the [repository readme](https://github.com/jenkinsci/cloudbees-plugin-gateway/blob/master/README.md), the plugin is already removed from the update center when it's not.

This PR suspends future installations, provided the service the plugin builds upon has shut down.