### PR TITLE
Remove BearyChat plugin from distribution

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -818,3 +818,5 @@ xframium = https://www.jenkins.io/security/plugins/#suspensions
 
 # https://jenkins.io/security/advisory/2022-11-15/
 config-rotator = https://www.jenkins.io/security/plugins/#suspensions
+
+bearychat = https://github.com/jenkinsci/bearychat-plugin/blob/master/README.markdown


### PR DESCRIPTION
Since https://bearychat.com has been closed in last few years, this plugins is out-of-maintain and no longer available.