### PR TITLE
Suspend lightstep-incident-response plugin

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -146,6 +146,8 @@ koji-plugin                      # renamed to koji
 kundo                            # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Kundo+Plugin
 lechat                           # renamed to Kata which was discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/LeChat+Plugin
 loadrunner                       # closed-source plugin, removal requested by plugin author
+# service discontinued
+lightstep-incident-response = https://github.com/jenkinsci/lightstep-incident-response-plugin#readme
 liverebel-deploy                 # only worked with obsolete releases -- https://wiki.jenkins-ci.org/display/JENKINS/LiveRebel+Plugin
 # part of core functionality since 1.433
 m2-extra-steps = https://wiki.jenkins-ci.org/display/JENKINS/M2+Extra+Steps+Plugin


### PR DESCRIPTION
The service is EOL according to the readme linked, and the repository has been archived.

https://github.com/jenkinsci/lightstep-incident-response-plugin

cc https://github.com/jenkins-infra/repository-permissions-updater/issues/3022 for cross-linking.