### PR TITLE
Deprecate handlebars plugin

### DIFF
--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -15,6 +15,7 @@ emma = https://github.com/jenkinsci/jenkins/pull/5320
 extreme-feedback = https://www.jenkins.io/blog/2021/11/09/guava-upgrade/
 google-cloud-health-check = https://www.jenkins.io/blog/2021/11/09/guava-upgrade/
 harvest = https://github.com/jenkinsci/jenkins/pull/5320
+handlebars = https://github.com/jenkins-infra/update-center2/pull/677
 javatest-report = https://github.com/jenkinsci/jenkins/pull/5320
 maven-repo-cleaner = https://github.com/jenkinsci/jenkins/pull/6323
 nis-notification-lamp = https://github.com/jenkinsci/jenkins/pull/5521


### PR DESCRIPTION
Handlebars 3 is [abandoned](https://github.com/handlebars-lang/handlebars.js/tree/3.x), [has unresolved vulnerabilities](https://github.com/handlebars-lang/handlebars.js/issues/1736#issuecomment-836430832), and [no other plugin depends on this one anymore](https://plugins.jenkins.io/handlebars/#dependencies).

So far only marking it as deprecated instead of suspending distribution, but could go either way. CasC would probably be impacted by the latter?

Maintainers @batmat @rsandell to approve this PR.