### PR TITLE
Suspend keycloak plugin

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -822,5 +822,8 @@ config-rotator = https://www.jenkins.io/security/plugins/#suspensions
 
 bearychat = https://github.com/jenkinsci/bearychat-plugin/blob/master/README.markdown
 
+# requested by maintainer
+keycloak = https://github.com/jenkins-infra/update-center2/pull/678
+
 # abusive
 ascii-magician


### PR DESCRIPTION
We have been notified by the maintainers that this plugin is no longer maintained and that they wish to depublish it.