### PR TITLE
Suspend Remoting Security Workaround Plugin

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -194,6 +194,7 @@ rally-update-plugin-1            # renamed to rally-plugin(!)
 release-multi-test               # junk: contains only the HelloWorldBuilder sample
 release-test                     # junk: contains only the HelloWorldBuilder sample
 Relution                         # renamed to relution-publisher
+remoting-security-workaround = https://github.com/jenkins-infra/update-center2/pull/680
 # superseded by Team Concert Plugin
 rtc = https://github.com/jenkins-infra/update-center2/pull/13
 sahagin-jenkins-plugin           # renamed to sahagin-plugin


### PR DESCRIPTION
https://github.com/jenkinsci/remoting-security-workaround-plugin was only ever intended as a temporary workaround for admins unable to immediately update to Jenkins 2.303.3 or 2.319.

Those releases are now long obsolete and no longer supported by update center tiers, and by now most users of the plugin have updated to releases with fixes anyway: https://stats.jenkins.io/pluginversions/remoting-security-workaround.html

For that reason, it makes no sense to continue distributing this plugin.