### PR TITLE
Deprecate `ace-editor`

### DIFF
--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -2,6 +2,7 @@
 # should link to (value). Use this file to mark a plugin as deprecated while continuing to distribute it. If a plugin
 # should be removed from distribution entirely, instead set a deprecation notice URL in artifact-ignores.properties.
 
+ace-editor = https://github.com/jenkins-infra/update-center2/pull/681
 async-http-client = https://github.com/jenkins-infra/update-center2/pull/650
 BlameSubversion = https://github.com/jenkinsci/jenkins/pull/5320
 blueocean-executor-info = https://issues.jenkins.io/browse/JENKINS-56773


### PR DESCRIPTION
As of https://github.com/jenkinsci/workflow-cps-plugin/releases/tag/3611.v201b_d9f9eb_f7, Pipeline: Groovy Plugin no longer depends on `ace-editor`, making it a library plugin without dependents that can safely be uninstalled by everyone who's keeping their Jenkins up to date.

This is the last plugin in https://github.com/jenkinsci/js-libs/ to be deprecated (after #679 and #677); perhaps we can consider archiving this repo?

Maintainers @batmat @rsandell to approve.

Thanks @basil for making this possible.