### PR TITLE
[SECURITY-2910] Mark (2) fixed in 4.8.0.149

### DIFF
--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -14625,8 +14625,8 @@
     "url": "https://www.jenkins.io/security/advisory/2022-11-15/#SECURITY-2910%20(2)",
     "versions": [
       {
-        "lastVersion": "4.8.0.146",
-        "pattern": ".*"
+        "lastVersion": "4.8.0.149",
+        "pattern": "(4[.]6|4[.]8[.]0[.]129|4[.]8[.]0[.]13[04]|4[.]8[.]0[.]14[23678]|4[.]8[.]0[.]77)(|[.-].+)"
       }
     ]
   },


### PR DESCRIPTION
The maintainers informed us that SECURITY-2910 (2) was resolved.

It looks like https://github.com/jenkinsci/cavisson-ns-nd-integration-plugin/commit/3aecf18565ab399f7e37240412a1745fc4338164 in 4.8.0.149 did it.