### PR TITLE
Validate core dependencies

### DIFF
--- a/src/main/java/io/jenkins/update_center/DirectoryTreeBuilder.java
+++ b/src/main/java/io/jenkins/update_center/DirectoryTreeBuilder.java
@@ -188,7 +188,11 @@ public class DirectoryTreeBuilder {
         try (IndexHtmlBuilder index = service.newIndexHtmlBuilder(dir, title).withSubtitle(subtitle)) {
             index.add(permalink, "permalink to the latest");
             for (MavenArtifact a : list) {
-                index.add(a);
+                try {
+                    index.add(a);
+                } catch (IOException ex) {
+                    LOGGER.log(Level.INFO, "Failed to add " + a, ex);
+                }
             }
         }
     }

--- a/src/main/java/io/jenkins/update_center/Plugin.java
+++ b/src/main/java/io/jenkins/update_center/Plugin.java
@@ -151,4 +151,9 @@ public final class Plugin {
     public TreeMap<VersionNumber, HPI> getArtifacts() {
         return artifacts;
     }
+
+    @Override
+    public String toString() {
+        return "Plugin '" + artifactId + "'";
+    }
 }

--- a/src/main/java/io/jenkins/update_center/PluginUpdateCenterEntry.java
+++ b/src/main/java/io/jenkins/update_center/PluginUpdateCenterEntry.java
@@ -40,7 +40,7 @@ public class PluginUpdateCenterEntry {
         this.previousOffered = previousOffered;
     }
 
-    public PluginUpdateCenterEntry(Plugin plugin) {
+    public PluginUpdateCenterEntry(Plugin plugin) throws IOException {
         this.artifactId = plugin.getArtifactId();
         HPI previous = null, latest = null;
 
@@ -49,7 +49,7 @@ public class PluginUpdateCenterEntry {
         while (latest == null && it.hasNext()) {
             HPI h = it.next();
             try {
-                h.getManifest();
+                h.validate();
             } catch (IOException e) {
                 LOGGER.log(Level.WARNING, "Failed to resolve "+h+". Dropping this version.",e);
                 continue;
@@ -60,12 +60,16 @@ public class PluginUpdateCenterEntry {
         while (previous == null && it.hasNext()) {
             HPI h = it.next();
             try {
-                h.getManifest();
+                h.validate();
             } catch (IOException e) {
                 LOGGER.log(Level.WARNING, "Failed to resolve "+h+". Dropping this version.",e);
                 continue;
             }
             previous = h;
+        }
+
+        if (latest == null) {
+            throw new IOException("Plugin '" + artifactId + "' has no valid release");
         }
 
         this.latestOffered = latest;

--- a/src/main/java/io/jenkins/update_center/json/PluginVersionsRoot.java
+++ b/src/main/java/io/jenkins/update_center/json/PluginVersionsRoot.java
@@ -26,6 +26,7 @@ public class PluginVersionsRoot extends WithSignature {
         if (plugins == null) {
             plugins = new TreeMap<>(repository.listJenkinsPlugins().stream().collect(Collectors.toMap(Plugin::getArtifactId, plugin -> new PluginVersions(plugin.getArtifacts()))));
         }
+        plugins.entrySet().removeIf(e -> e.getValue().releases.isEmpty());
         return plugins;
     }
 }

--- a/src/main/java/io/jenkins/update_center/json/UpdateCenterRoot.java
+++ b/src/main/java/io/jenkins/update_center/json/UpdateCenterRoot.java
@@ -18,10 +18,14 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
 public class UpdateCenterRoot extends WithSignature {
+    private static final Logger LOGGER = Logger.getLogger(UpdateCenterRoot.class.getName());
+
     @JSONField
     @SuppressFBWarnings(value = "SS_SHOULD_BE_STATIC", justification = "Accessed by JSON serializer")
     public final String updateCenterVersion = "1";
@@ -62,8 +66,12 @@ public class UpdateCenterRoot extends WithSignature {
         deprecations = new TreeMap<>(Deprecations.getDeprecatedPlugins().collect(Collectors.toMap(Functions.identity(), UpdateCenterRoot::deprecationForPlugin)));
 
         for (Plugin plugin : repo.listJenkinsPlugins()) {
-            PluginUpdateCenterEntry entry = new PluginUpdateCenterEntry(plugin);
-            plugins.put(plugin.getArtifactId(), entry);
+            try {
+                PluginUpdateCenterEntry entry = new PluginUpdateCenterEntry(plugin);
+                plugins.put(plugin.getArtifactId(), entry);
+            } catch (IOException ex) {
+                LOGGER.log(Level.INFO, "Failed to add update center entry for: " + plugin, ex);
+            }
         }
 
         core = new UpdateCenterCore(repo.getJenkinsWarsByVersionNumber());

--- a/src/main/java/io/jenkins/update_center/wrappers/VersionCappedMavenRepository.java
+++ b/src/main/java/io/jenkins/update_center/wrappers/VersionCappedMavenRepository.java
@@ -74,7 +74,7 @@ public class VersionCappedMavenRepository extends MavenRepositoryWrapper {
                         }
                     }
                 } catch (IOException x) {
-                    LOGGER.log(Level.WARNING, "Failed to filter plugin for plugin: " + h.getArtifactId(), x);
+                    LOGGER.log(Level.WARNING, "Failed to filter version " + e.getKey() + " by core dependency for plugin: " + h.getArtifactId(), x);
                 }
             }
 

--- a/src/test/java/io/jenkins/update_center/HPITest.java
+++ b/src/test/java/io/jenkins/update_center/HPITest.java
@@ -1,0 +1,22 @@
+package io.jenkins.update_center;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class HPITest {
+    @Test
+    public void isValidCoreDependencyTest() {
+        assertTrue(HPI.isValidCoreDependency("1.0"));
+        assertTrue(HPI.isValidCoreDependency("1.654"));
+        assertTrue(HPI.isValidCoreDependency("2.0"));
+        assertTrue(HPI.isValidCoreDependency("2.1"));
+        assertTrue(HPI.isValidCoreDependency("2.1000"));
+        assertFalse(HPI.isValidCoreDependency("2.00"));
+        assertFalse(HPI.isValidCoreDependency("2.01"));
+        assertFalse(HPI.isValidCoreDependency("2.100-SNAPSHOT"));
+        assertFalse(HPI.isValidCoreDependency("2.0-rc-1"));
+        assertFalse(HPI.isValidCoreDependency("2.0-rc-1.vabcd1234"));
+    }
+}


### PR DESCRIPTION
Plugins can declare any version number as a core dependency in their metadata.

If a plugin were to specify an incremental or similar non-release, e.g., due to an accidentally merged and released PR depending on future core features, this will result in unpredictable behavior (usually errors of some kind).

Therefore filter out plugins that specify core dependencies that look like irregular releases (RC, incrementals, snapshots, …)

Currently published plugin releases this applies to (and that would be removed):

https://updates.jenkins.io/download/plugins/build-symlink/ 1.0 (2.185-rc28469.6af78cb11bf8)
https://updates.jenkins.io/download/plugins/jcaptcha-plugin/ 1.0 (1.416-SNAPSHOT)
https://updates.jenkins.io/download/plugins/sshd/ 3.0.1 (2.282-rc30905.2ddf35821c11)

Impact should be non-existent, since they're all obsolete releases anyway.

Additionally, use this opportunity to improve robustness: If there is no release of a plugin that is valid, don't throw an NPE somewhere, just skip it. Also don't have an empty entry if there are no releases in `plugin-versions.json`.

A future iteration of this feature could obtain the list of actually existing core releases so that `2.1000` would not be considered valid (as of early 2023 at least 😁), but this should be a reasonable start.