### PR TITLE
Further limit allowed characters in file path

### DIFF
--- a/src/main/java/io/jenkins/update_center/ArtifactoryRepositoryImpl.java
+++ b/src/main/java/io/jenkins/update_center/ArtifactoryRepositoryImpl.java
@@ -79,7 +79,12 @@ public class ArtifactoryRepositoryImpl extends BaseMavenRepository {
     }
 
     private static boolean containsIllegalChars(String test) {
-        return !test.chars().allMatch(c -> c >= 0x2B && c < 0x7B);
+        return !test.chars().allMatch(c ->
+                c >= 0x30 && c <= 0x39 // allow digits 0-9
+                || c >= 0x41 && c <= 0x5A // allows letter A-Z
+                || c >= 0x61 && c <= 0x7A // allows letter a-z
+                || c == 0x2B || c >= 0x2D && c <= 0x2F || c == 0x5F // allows: +-./_
+        );
     }
 
     private static ArtifactCoordinates toGav(JsonFile f) {
@@ -87,7 +92,7 @@ public class ArtifactoryRepositoryImpl extends BaseMavenRepository {
         String path = f.path;
 
         if (containsIllegalChars(fileName) || containsIllegalChars(path)) {
-            LOGGER.log(Level.INFO, "Not only printable ascii: " + f.path + " / " + f.name);
+            LOGGER.log(Level.INFO, "Characters outside allowed set: " + f.path + " / " + f.name);
             return null;
         }
 

--- a/src/main/java/io/jenkins/update_center/ArtifactoryRepositoryImpl.java
+++ b/src/main/java/io/jenkins/update_center/ArtifactoryRepositoryImpl.java
@@ -80,10 +80,10 @@ public class ArtifactoryRepositoryImpl extends BaseMavenRepository {
 
     private static boolean containsIllegalChars(String test) {
         return !test.chars().allMatch(c ->
-                c >= 0x30 && c <= 0x39 // allow digits 0-9
-                || c >= 0x41 && c <= 0x5A // allows letter A-Z
-                || c >= 0x61 && c <= 0x7A // allows letter a-z
-                || c == 0x2B || c >= 0x2D && c <= 0x2F || c == 0x5F // allows: +-./_
+                c >= '0' && c <= '9'
+                || c >= 'A' && c <= 'Z'
+                || c >= 'a' && c <= 'z'
+                || c == '+' || c == '-' || c == '.' || c == '/' || c == '_'
         );
     }
 


### PR DESCRIPTION
Amends #364 and https://github.com/jenkins-infra/update-center2/pull/673.

This filters out paths that include a bunch of characters that indicate something has gone wrong during the Maven release process. While there are already several characters (notably unprintable ASCII, originally motivating this filter) being filtered, this adds more, based on what is actually used: Keep basic ASCII letters, digits, `_+.-`, as well as `/` since we're looking at paths at this point.

Compared to the current filter, this doesn't remove anything that is being distributed at the moment.

Also fix the message, it hasn't been correct in a long time, most of the stuff filtered is due to `%` from percent-encoded characters.