### PR TITLE
Make it easier to use with custom repositories

### DIFF
--- a/src/main/java/io/jenkins/update_center/ArtifactoryRepositoryImpl.java
+++ b/src/main/java/io/jenkins/update_center/ArtifactoryRepositoryImpl.java
@@ -46,14 +46,16 @@ import java.util.stream.Collectors;
 public class ArtifactoryRepositoryImpl extends BaseMavenRepository {
     private static final Logger LOGGER = Logger.getLogger(ArtifactoryRepositoryImpl.class.getName());
 
-    private static final String ARTIFACTORY_URL = "https://repo.jenkins-ci.org/";
-    private static final String ARTIFACTORY_API_URL = "https://repo.jenkins-ci.org/api/";
+    private static final String ARTIFACTORY_URL = Environment.getString("ARTIFACTORY_URL", "https://repo.jenkins-ci.org/");
+    private static final String ARTIFACTORY_API_URL = Environment.getString("ARTIFACTORY_API_URL", "https://repo.jenkins-ci.org/api/");
+    private static final String ARTIFACTORY_REPOSITORY = Environment.getString("ARTIFACTORY_REPOSITORY", "releases");
+
     private static final String ARTIFACTORY_AQL_URL = ARTIFACTORY_API_URL + "search/aql";
     private static final String ARTIFACTORY_MANIFEST_URL = ARTIFACTORY_URL + "%s/%s!/META-INF/MANIFEST.MF";
     private static final String ARTIFACTORY_ZIP_ENTRY_URL = ARTIFACTORY_URL + "%s/%s!%s";
     private static final String ARTIFACTORY_FILE_URL = ARTIFACTORY_URL + "%s/%s";
 
-    private static final String AQL_QUERY = "items.find({\"repo\":{\"$eq\":\"releases\"},\"$or\":[{\"name\":{\"$match\":\"*.hpi\"}},{\"name\":{\"$match\":\"*.jpi\"}},{\"name\":{\"$match\":\"*.war\"}},{\"name\":{\"$match\":\"*.pom\"}}]}).include(\"repo\", \"path\", \"name\", \"modified\", \"created\", \"sha256\", \"actual_sha1\", \"size\")";
+    private static final String AQL_QUERY = "items.find({\"repo\":{\"$eq\":\"" + ARTIFACTORY_REPOSITORY + "\"},\"$or\":[{\"name\":{\"$match\":\"*.hpi\"}},{\"name\":{\"$match\":\"*.jpi\"}},{\"name\":{\"$match\":\"*.war\"}},{\"name\":{\"$match\":\"*.pom\"}}]}).include(\"repo\", \"path\", \"name\", \"modified\", \"created\", \"sha256\", \"actual_sha1\", \"size\")";
 
     private final String username;
     private final String password;
@@ -231,7 +233,7 @@ public class ArtifactoryRepositoryImpl extends BaseMavenRepository {
 
     @Override
     public Manifest getManifest(MavenArtifact artifact) throws IOException {
-        try (InputStream is = getFileContent(String.format(ARTIFACTORY_MANIFEST_URL, "releases", getUri(artifact.artifact)))) {
+        try (InputStream is = getFileContent(String.format(ARTIFACTORY_MANIFEST_URL, ARTIFACTORY_REPOSITORY, getUri(artifact.artifact)))) {
             return new Manifest(is);
         }
     }
@@ -269,7 +271,7 @@ public class ArtifactoryRepositoryImpl extends BaseMavenRepository {
             try {
                 OkHttpClient.Builder builder = new OkHttpClient.Builder();
                 OkHttpClient client = builder.build();
-                Request request = new Request.Builder().url(url).get().build();
+                Request request = new Request.Builder().addHeader("Authorization", Credentials.basic(username, password)).url(url).get().build();
                 final Response response = client.newCall(request).execute();
                 if (response.isSuccessful()) {
                     try (final ResponseBody body = HttpHelper.body(response)) {
@@ -308,7 +310,7 @@ public class ArtifactoryRepositoryImpl extends BaseMavenRepository {
 
     @Override
     public InputStream getZipFileEntry(MavenArtifact artifact, String path) throws IOException {
-        return getFileContent(String.format(ARTIFACTORY_ZIP_ENTRY_URL, "releases", getUri(artifact.artifact), StringUtils.prependIfMissing(path, "/")));
+        return getFileContent(String.format(ARTIFACTORY_ZIP_ENTRY_URL, ARTIFACTORY_REPOSITORY, getUri(artifact.artifact), StringUtils.prependIfMissing(path, "/")));
     }
 
     @Override
@@ -319,7 +321,7 @@ public class ArtifactoryRepositoryImpl extends BaseMavenRepository {
         if (localFile.exists()) {
             return localFile;
         }
-        return getFile(String.format(ARTIFACTORY_FILE_URL, "releases", uri));
+        return getFile(String.format(ARTIFACTORY_FILE_URL, ARTIFACTORY_REPOSITORY, uri));
     }
 
     private static final File LOCAL_REPO = new File(new File(System.getProperty("user.home")), ".m2/repository");


### PR DESCRIPTION
While the ability to host private update sites is explicitly _not_ a goal of this tool, this still makes it easier to use it in such situations:

* Allow overriding the Artifactory URL, Artifactory API URL, and Maven repository name
* Authenticate for artifact download

Additionally, this change should make it easier to respond to Artifactory problems like https://groups.google.com/g/jenkinsci-dev/c/4sgBC1crUJw/m/jrRxMKhKAAAJ, as only a few environment variables need to be set, rather than the code needing to be changed. I tested this with a recent private security fix staging repo and got only those fixes as part of the output, just by specifying `ARTIFACTORY_REPOSITORY`.