### PR TITLE
Suspend jersey2-api 2.39-1 from distribution

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -830,3 +830,6 @@ keycloak = https://github.com/jenkins-infra/update-center2/pull/678
 
 # abusive
 ascii-magician
+
+# https://github.com/jenkinsci/gitlab-plugin/issues/1419
+jersey2-api@2.39-1


### PR DESCRIPTION
This seems to be causing users a lot of pain in https://github.com/jenkinsci/gitlab-plugin/issues/1419, so let's revert the upgrade in https://github.com/jenkinsci/jersey2-api-plugin/pull/60 and suspend the problematic version from distribution.