### PR TITLE
Ignore h2-api@10.v8dd81336a_ede

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -833,3 +833,6 @@ ascii-magician
 
 # https://github.com/jenkinsci/gitlab-plugin/issues/1419
 jersey2-api@2.39-1
+
+# https://github.com/jenkinsci/h2-api-plugin/pull/9
+h2-api@10.v8dd81336a_ede


### PR DESCRIPTION
See https://github.com/jenkinsci/h2-api-plugin/pull/9

Is it possible to fix this? Given it's been pushed to the maven repository?
i.e. renovate / dependabot might just keep offering the new version?