### PR TITLE
Suspend all BMC/Compuware plugins

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -838,15 +838,15 @@ jersey2-api@2.39-1
 h2-api@10.v8dd81336a_ede
 
 # Received a complaint from BMC Software Inc about copyrighted code
-bmc-cfa-plugin
-bmc-change-manager-imstm
-bmc-rpd
-compuware-common-configuration
-compuware-ispw-operations
-compuware-scm-downloader
-compuware-strobe-measurement
-compuware-topaz-for-enterprise-data
-compuware-topaz-for-total-test
-compuware-topaz-utilities
-compuware-xpediter-code-coverage
-compuware-zadviser-api
+bmc-cfa-plugin = https://github.com/jenkins-infra/update-center2/pull/692
+bmc-change-manager-imstm = https://github.com/jenkins-infra/update-center2/pull/692
+bmc-rpd = https://github.com/jenkins-infra/update-center2/pull/692
+compuware-common-configuration = https://github.com/jenkins-infra/update-center2/pull/692
+compuware-ispw-operations = https://github.com/jenkins-infra/update-center2/pull/692
+compuware-scm-downloader = https://github.com/jenkins-infra/update-center2/pull/692
+compuware-strobe-measurement = https://github.com/jenkins-infra/update-center2/pull/692
+compuware-topaz-for-enterprise-data = https://github.com/jenkins-infra/update-center2/pull/692
+compuware-topaz-for-total-test = https://github.com/jenkins-infra/update-center2/pull/692
+compuware-topaz-utilities = https://github.com/jenkins-infra/update-center2/pull/692
+compuware-xpediter-code-coverage = https://github.com/jenkins-infra/update-center2/pull/692
+compuware-zadviser-api = https://github.com/jenkins-infra/update-center2/pull/692

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -836,3 +836,17 @@ jersey2-api@2.39-1
 
 # https://github.com/jenkinsci/h2-api-plugin/pull/9
 h2-api@10.v8dd81336a_ede
+
+# Received a complaint from BMC Software Inc about copyrighted code
+bmc-cfa-plugin
+bmc-change-manager-imstm
+bmc-rpd
+compuware-common-configuration
+compuware-ispw-operations
+compuware-scm-downloader
+compuware-strobe-measurement
+compuware-topaz-for-enterprise-data
+compuware-topaz-for-total-test
+compuware-topaz-utilities
+compuware-xpediter-code-coverage
+compuware-zadviser-api

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -838,7 +838,7 @@ jersey2-api@2.39-1
 h2-api@10.v8dd81336a_ede
 
 # Received a complaint from BMC Software Inc about copyrighted code
-bmc-cfa-plugin = https://github.com/jenkins-infra/update-center2/pull/692
+bmc-cfa = https://github.com/jenkins-infra/update-center2/pull/692
 bmc-change-manager-imstm = https://github.com/jenkins-infra/update-center2/pull/692
 bmc-rpd = https://github.com/jenkins-infra/update-center2/pull/692
 compuware-common-configuration = https://github.com/jenkins-infra/update-center2/pull/692

--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -6,7 +6,6 @@ ace-editor = https://github.com/jenkins-infra/update-center2/pull/681
 async-http-client = https://github.com/jenkins-infra/update-center2/pull/650
 BlameSubversion = https://github.com/jenkinsci/jenkins/pull/5320
 blueocean-executor-info = https://issues.jenkins.io/browse/JENKINS-56773
-bmc-rpd = https://github.com/jenkins-infra/update-center2/pull/597
 cloverphp = https://github.com/jenkinsci/jenkins/pull/5320
 cmvc = https://github.com/jenkinsci/jenkins/pull/5320
 coding-webhook = https://github.com/jenkinsci/coding-webhook-plugin/commit/20e1449513628ad24476b47331ea7bd6a2e82583


### PR DESCRIPTION
We got a complaint via GitHub Trust & Safety about code copyrighted by BMC Software Inc in one of our plugin repos, specifically https://github.com/jenkinsci/compuware-common-configuration-plugin/blob/85e15ffc9a2987453f61a1f41f91d7fe109d5636/src/test/java/com/compuware/jenkins/common/configuration/HostConnectionTest.java#L56 and https://github.com/jenkinsci/compuware-common-configuration-plugin/blob/85e15ffc9a2987453f61a1f41f91d7fe109d5636/src/test/java/com/compuware/jenkins/common/configuration/HostConnectionTest.java#L256 (yes, really).

Out of an abundance of caution I recommend we suspend all of their plugins' distribution.