### PR TITLE
Restore BMC plugins except releases with non-free licenses

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -837,19 +837,12 @@ jersey2-api@2.39-1
 # https://github.com/jenkinsci/h2-api-plugin/pull/9
 h2-api@10.v8dd81336a_ede
 
-# Received a complaint from BMC Software Inc about copyrighted code
-bmc-cfa = https://github.com/jenkins-infra/update-center2/pull/692
-bmc-change-manager-imstm = https://github.com/jenkins-infra/update-center2/pull/692
-bmc-rpd = https://github.com/jenkins-infra/update-center2/pull/692
-compuware-common-configuration = https://github.com/jenkins-infra/update-center2/pull/692
-compuware-ispw-operations = https://github.com/jenkins-infra/update-center2/pull/692
-compuware-scm-downloader = https://github.com/jenkins-infra/update-center2/pull/692
-compuware-strobe-measurement = https://github.com/jenkins-infra/update-center2/pull/692
-compuware-topaz-for-enterprise-data = https://github.com/jenkins-infra/update-center2/pull/692
-compuware-topaz-for-total-test = https://github.com/jenkins-infra/update-center2/pull/692
-compuware-topaz-utilities = https://github.com/jenkins-infra/update-center2/pull/692
-compuware-xpediter-code-coverage = https://github.com/jenkins-infra/update-center2/pull/692
-compuware-zadviser-api = https://github.com/jenkins-infra/update-center2/pull/692
+# Using a non-free license
+compuware-ispw-operations@1.0.12
+compuware-ispw-operations@2.0.0
+compuware-ispw-operations@2.1.0
+compuware-scm-downloader@2.0.15
+compuware-scm-downloader@2.0.16
 
 # https://jenkins.io/security/advisory/2023-03-21/
 mashup-portlets-plugin = https://www.jenkins.io/security/plugins/#suspensions


### PR DESCRIPTION
Mostly undo #692.

Related to https://github.com/jenkins-infra/helpdesk/issues/3461.