### PR TITLE
Discontinuing the Delphix plugin

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -73,6 +73,7 @@ cppunit = https://wiki.jenkins-ci.org/display/JENKINS/CppUnit+Plugin
 create-fingerprint-plugin        # renamed to create-fingerprint
 datadog-build-reporter           # renamed to datadog
 delphix-plugin                   # renamed to delphix
+delphix                          # discontinued
 description-column               # renamed to description-column-plugin
 discobit-autoconfig = https://github.com/jenkins-infra/update-center2/pull/587
 # removal requested by teilo, superceded by dockerhub-notification

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -73,6 +73,7 @@ cppunit = https://wiki.jenkins-ci.org/display/JENKINS/CppUnit+Plugin
 create-fingerprint-plugin        # renamed to create-fingerprint
 datadog-build-reporter           # renamed to datadog
 delphix-plugin                   # renamed to delphix
+# temporarily discontinued
 delphix = https://github.com/jenkins-infra/update-center2/pull/695
 description-column               # renamed to description-column-plugin
 discobit-autoconfig = https://github.com/jenkins-infra/update-center2/pull/587

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -73,7 +73,7 @@ cppunit = https://wiki.jenkins-ci.org/display/JENKINS/CppUnit+Plugin
 create-fingerprint-plugin        # renamed to create-fingerprint
 datadog-build-reporter           # renamed to datadog
 delphix-plugin                   # renamed to delphix
-delphix                          # discontinued
+delphix = https://github.com/jenkins-infra/update-center2/pull/695
 description-column               # renamed to description-column-plugin
 discobit-autoconfig = https://github.com/jenkins-infra/update-center2/pull/587
 # removal requested by teilo, superceded by dockerhub-notification


### PR DESCRIPTION
The Delphix plugin is out of date and requires significant attention. Our goal is to temporarily discontinue its distribution until it's rewritten to our higher standards. 

It's my understanding that this page will become unavailable on merge: https://plugins.jenkins.io/delphix/