### PR TITLE
sort according to VersionNumber comparator

### DIFF
--- a/src/main/java/io/jenkins/update_center/json/PluginVersions.java
+++ b/src/main/java/io/jenkins/update_center/json/PluginVersions.java
@@ -20,8 +20,7 @@ public class PluginVersions {
     public Map<String, PluginVersionsEntry> releases = new LinkedHashMap<>();
 
     PluginVersions(Map<VersionNumber, HPI> artifacts) {
-        // TODO this is suboptimal sorting (we'd rather sort by VersionNumber, not its string representation) but imitates existing behavior
-        for (VersionNumber versionNumber : artifacts.keySet().stream().sorted(Comparator.comparing(VersionNumber::toString)).collect(Collectors.toList())) {
+        for (VersionNumber versionNumber : artifacts.keySet().stream().sorted().collect(Collectors.toList())) {
             try {
                 if (releases.put(versionNumber.toString(), new PluginVersionsEntry(artifacts.get(versionNumber))) != null) {
                     throw new IllegalStateException("Duplicate key");


### PR DESCRIPTION
The file [plugin-versions.json](https://updates.jenkins.io/current/plugin-versions.json) is the base for sorting the releases of a plugin on the plugins page at https://plugins.jenkins.io 
The sorting with string causes wrong ordering in some cases as described in https://github.com/jenkins-infra/plugin-site/issues/1336

By sorting with the Comparator of VersionNumber we get the same sorting as in other places.