### PR TITLE
Restore mergebase-sca distribution

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -763,9 +763,6 @@ workflow-api@1162.va_1e49062a_00e
 # https://issues.jenkins.io/browse/JENKINS-68727
 workflow-durable-task-step@1144.vd77b_57189936
 
-# Block mergebase-sca because its version numbers cause trouble with this tool: https://repo.jenkins-ci.org/artifactory/releases/com/mergebase/mergebase-sca/
-mergebase-sca
-
 # https://issues.jenkins.io/browse/JENKINS-69164
 katalon@1.0.31
 katalon@1.0.30


### PR DESCRIPTION
Version numbers are fixed, and #673 makes suspension of the originally offending version unnecessary.

Reverts #621.