### PR TITLE
Adds adoption label when plugin has no declared maintainers

### DIFF
--- a/src/main/java/io/jenkins/update_center/HPI.java
+++ b/src/main/java/io/jenkins/update_center/HPI.java
@@ -604,6 +604,10 @@ public class HPI extends MavenArtifact {
             Set<String> labels = new TreeSet<>(Arrays.asList(getLabelsFromFile()));
             labels.addAll(gitHubLabels);
 
+            if (MaintainersSource.getInstance().getMaintainers(this.artifact).isEmpty()) {
+                labels.add("adopt-this-plugin");
+            }
+
             this.labels = new ArrayList<>(labels);
         }
         return this.labels;


### PR DESCRIPTION
This is to propose a long term solution for https://github.com/jenkins-infra/helpdesk/issues/3580.

The idea is to have the update-center automatically adds the `adopt-this-plugin` label on plugins where no maintainers are declared.