### PR TITLE
add credentials to the allowed topics

### DIFF
--- a/resources/allowed-github-topics.properties
+++ b/resources/allowed-github-topics.properties
@@ -24,6 +24,7 @@ cmp
 codebuild
 confluence
 configuration-as-code
+credentials
 database
 deployment
 devops


### PR DESCRIPTION
many plugins provide credential types or are credential stores.   if they are labeled as such we should have an easy way to discover them.

as per https://www.jenkins.io/doc/developer/publishing/documentation/#labeling-plugins submitting a PR to add `credentials` to the allow list of labels.

Not sure where the plugin page gets the text labels to search specific labels from in order to change that too :-/