### PR TITLE
Revert #678 to reinstate keycloak plugin.

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -826,9 +826,6 @@ config-rotator = https://www.jenkins.io/security/plugins/#suspensions
 
 bearychat = https://github.com/jenkinsci/bearychat-plugin/blob/master/README.markdown
 
-# requested by maintainer
-keycloak = https://github.com/jenkins-infra/update-center2/pull/678
-
 # abusive
 ascii-magician
 


### PR DESCRIPTION
I have adopted the plugin so it now as an active maintainer and version 2.3.1 was released that fixes security vulnerabilities SECURITY-2987 and SECURITY-2986 . 