### PR TITLE
Unpublish `headspin` plugin

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -848,4 +848,4 @@ mashup-portlets-plugin = https://www.jenkins.io/security/plugins/#suspensions
 remote-jobs-view-plugin = https://www.jenkins.io/security/plugins/#suspensions
 
 # No more supported
-headspin
+headspin = https://github.com/jenkinsci/headspin-plugin#readme

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -105,6 +105,7 @@ googlecode = https://wiki.jenkins-ci.org/display/JENKINS/Google+Code+Plugin
 groovy-events-listener-plugin-master # unintentional fork of groovy-events-listener-plugin
 # service discontinued
 hall-jenkins = https://wiki.jenkins-ci.org/display/JENKINS/Hall+Plugin
+headspin = https://github.com/jenkinsci/headspin-plugin#readme
 hello-world                      # people shouldn't actually *publish* the sample project!
 HiddenParameter                  # renamed to hidden-parameter
 hipchat-plugin                   # renamed to hipchat
@@ -846,6 +847,3 @@ compuware-scm-downloader@2.0.16
 # https://jenkins.io/security/advisory/2023-03-21/
 mashup-portlets-plugin = https://www.jenkins.io/security/plugins/#suspensions
 remote-jobs-view-plugin = https://www.jenkins.io/security/plugins/#suspensions
-
-# No more supported
-headspin = https://github.com/jenkinsci/headspin-plugin#readme

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -846,3 +846,6 @@ compuware-scm-downloader@2.0.16
 # https://jenkins.io/security/advisory/2023-03-21/
 mashup-portlets-plugin = https://www.jenkins.io/security/plugins/#suspensions
 remote-jobs-view-plugin = https://www.jenkins.io/security/plugins/#suspensions
+
+# No more supported
+headspin


### PR DESCRIPTION
I would like to unpublish `headspin` plugin(https://plugins.jenkins.io/headspin).
