### PR TITLE
Update spotbugs to allow compiling on Java 20 and newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>4.5.3.0</version>
+        <version>4.7.3.4</version>
         <configuration><excludeFilterFile>${project.basedir}/spotbugs-excludes.xml</excludeFilterFile></configuration>
       </plugin>
     </plugins>
@@ -219,7 +219,7 @@
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
-      <version>4.7.1</version>
+      <version>4.7.3</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
While working on https://github.com/jenkins-infra/update-center2/pull/712, I ran into
>      [java]     java.lang.IllegalArgumentException: Unsupported class file major version 64
The change proposed updates the SpotBugs components bundling newer versions of ASM, to allow compiling the update center on Java 20 and beyond.