### PR TITLE
Suspend blackduck-detect plugin 8.0.0 due to multiple serious unresolved issues

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -847,3 +847,9 @@ compuware-scm-downloader@2.0.16
 # https://jenkins.io/security/advisory/2023-03-21/
 mashup-portlets-plugin = https://www.jenkins.io/security/plugins/#suspensions
 remote-jobs-view-plugin = https://www.jenkins.io/security/plugins/#suspensions
+
+# Suspend blackduck-detect 8.0.0 plugin due to multiple serious unresolved issues
+# https://issues.jenkins.io/browse/JENKINS-71480 - 8.0.0 crashes startup of Jenkins 2.410 and later (June 2023)
+# https://issues.jenkins.io/browse/JENKINS-70671 - 8.0.0 includes far too many dependencies (including Guava 23, jackson 2.10, etc.) (Apr 2023)
+# https://issues.jenkins.io/browse/JENKINS-71023 - 8.0.0 bundles pull-parser.jar by mistake (Feb 2023)
+blackduck-detect@8.0.0


### PR DESCRIPTION
## Suspend blackduck-detect plugin 8.0.0

The Synopsys Detect plugin 8.0.0 release that was delivered in Jan 2023 has several issues that are unresolved.  Those issues are severe enough to justify suspension of delivery of that release of the plugin.

* 8.0.0 crashes startup of Jenkins 2.410 and later (June 2023)
  https://issues.jenkins.io/browse/JENKINS-71480

* 8.0.0 includes far too many dependencies (including Guava 23, jackson 2.10, etc.) (Apr 2023)
  https://issues.jenkins.io/browse/JENKINS-70671

* 8.0.0 bundles pull-parser.jar by mistake (Feb 2023)
  https://issues.jenkins.io/browse/JENKINS-71023

The blackduck-detect plugin 7.0.0 does not crash Jenkins 2.410 and seems unlikely to have the other issues either.

CC: @sig-cpotts, @jppetrakis, @dmamidisynopsys, @DanaMaxfield