### PR TITLE
Remove invalid sidebar-link releases

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -847,3 +847,8 @@ compuware-scm-downloader@2.0.16
 # https://jenkins.io/security/advisory/2023-03-21/
 mashup-portlets-plugin = https://www.jenkins.io/security/plugins/#suspensions
 remote-jobs-view-plugin = https://www.jenkins.io/security/plugins/#suspensions
+
+# Sidebar link
+# artifacts released only for testing
+sidebar-link@2.2.3_94c81e99ec
+sidebar-link@2.2.3_3769d72d


### PR DESCRIPTION
Artifacts were released only for testing fix https://github.com/jenkinsci/sidebar-link-plugin/pull/60 and should not be listed in https://plugins.jenkins.io/sidebar-link/releases/ as new valid release is published already.

New artifact is not listed as the most recent version so that's why it is not available at update center.