### PR TITLE
Suspend specific versions `synopsys-polaris` due to OSI license violation

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -854,7 +854,6 @@ sidebar-link@2.2.3_94c81e99ec
 sidebar-link@2.2.3_3769d72d
 
 # Using a non-free license
-synopsys-polaris = https://github.com/jenkinsci/synopsys-polaris-plugin/commit/7a0327cf352ace3a922aea9e3239958644fad706
 synopsys-polaris@1.2.0
 synopsys-polaris@1.3.0
 synopsys-polaris@1.3.1

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -852,3 +852,11 @@ remote-jobs-view-plugin = https://www.jenkins.io/security/plugins/#suspensions
 # artifacts released only for testing
 sidebar-link@2.2.3_94c81e99ec
 sidebar-link@2.2.3_3769d72d
+
+# Using a non-free license
+synopsys-polaris = https://github.com/jenkinsci/synopsys-polaris-plugin/commit/7a0327cf352ace3a922aea9e3239958644fad706
+synopsys-polaris@1.2.0
+synopsys-polaris@1.3.0
+synopsys-polaris@1.3.1
+synopsys-polaris@1.3.2
+synopsys-polaris@1.3.3


### PR DESCRIPTION
https://github.com/jenkinsci/synopsys-polaris-plugin/commit/7a0327cf352ace3a922aea9e3239958644fad706 changed the license from Apache 2.0 to a non-free license.

By the [Jenkins hosting guidelines](https://www.jenkins.io/doc/developer/publishing/preparation/#license), all plugins have to be licensed under an [OSI-approved](https://opensource.org/licenses/) license.

To restore distribution, revert the license changes made in https://github.com/jenkinsci/synopsys-polaris-plugin/commit/7a0327cf352ace3a922aea9e3239958644fad706.
Versions released under a non-free license remain suspended.

cc @DanaMaxfield @sig-saraf @sig-sshreyas @blackduck-serv-builder