### PR TITLE
Remove warning for SECURITY-3013

### DIFF
--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -15800,7 +15800,7 @@
     "versions": [
       {
         "lastVersion": "387.v938a_ecb_f7fe9",
-        "pattern": ".*"
+        "pattern": "([1-5]|358|370|387|389)(|[.-].+)"
       }
     ]
   },


### PR DESCRIPTION
The security issue was resolved in release 398.v3dfa_cb_223984 of the lucene-search plugin.