### PR TITLE
SECURITY-2709 Remove warning from visualexpert

### DIFF
--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -14924,8 +14924,8 @@
     "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2709",
     "versions": [
       {
-        "lastVersion": "1.3",
-        "pattern": ".*"
+        "lastVersion": "2.0",
+        "pattern": "(1|2[.]0)(|[.-].+)"
       }
     ]
   },


### PR DESCRIPTION
[SECURITY-2709](https://issues.jenkins.io/browse/SECURITY-2709)
This was corrected by https://github.com/jenkinsci/visualexpert-plugin/commit/25eda3057ce2dd5274b8c3c26a92257eeedaddbb and was released in v2.1

I tested the fix locally.