### PR TITLE
Re-releasing the Delphix Plugin

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -861,17 +861,17 @@ synopsys-polaris@1.3.3
 
 # Removing old Delphix Plugin releases
 # https://github.com/jenkins-infra/update-center2/pull/725
-delphix-plugin@1.0.0
-delphix-plugin@1.0.1
-delphix-plugin@1.0.2
-delphix-plugin@1.0.3
-delphix-plugin@1.0.4
-delphix-plugin@1.0.5
-delphix-plugin@1.0.6
-delphix-plugin@1.0.7
-delphix-plugin@1.0.8
-delphix-plugin@2.0.0
-delphix-plugin@2.0.1
-delphix-plugin@2.0.2
-delphix-plugin@2.0.3
-delphix-plugin@2.0.4
+delphix@1.0.0
+delphix@1.0.1
+delphix@1.0.2
+delphix@1.0.3
+delphix@1.0.4
+delphix@1.0.5
+delphix@1.0.6
+delphix@1.0.7
+delphix@1.0.8
+delphix@2.0.0
+delphix@2.0.1
+delphix@2.0.2
+delphix@2.0.3
+delphix@2.0.4

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -73,6 +73,7 @@ cppunit = https://wiki.jenkins-ci.org/display/JENKINS/CppUnit+Plugin
 create-fingerprint-plugin        # renamed to create-fingerprint
 datadog-build-reporter           # renamed to datadog
 delphix-plugin                   # renamed to delphix
+delphix                          # discontinued
 description-column               # renamed to description-column-plugin
 discobit-autoconfig = https://github.com/jenkins-infra/update-center2/pull/587
 # removal requested by teilo, superceded by dockerhub-notification

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -858,3 +858,20 @@ synopsys-polaris@1.3.0
 synopsys-polaris@1.3.1
 synopsys-polaris@1.3.2
 synopsys-polaris@1.3.3
+
+# Removing old Delphix Plugin releases
+# https://github.com/jenkins-infra/update-center2/pull/725
+delphix-plugin@1.0.0
+delphix-plugin@1.0.1
+delphix-plugin@1.0.2
+delphix-plugin@1.0.3
+delphix-plugin@1.0.4
+delphix-plugin@1.0.5
+delphix-plugin@1.0.6
+delphix-plugin@1.0.7
+delphix-plugin@1.0.8
+delphix-plugin@2.0.0
+delphix-plugin@2.0.1
+delphix-plugin@2.0.2
+delphix-plugin@2.0.3
+delphix-plugin@2.0.4

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -73,6 +73,7 @@ cppunit = https://wiki.jenkins-ci.org/display/JENKINS/CppUnit+Plugin
 create-fingerprint-plugin        # renamed to create-fingerprint
 datadog-build-reporter           # renamed to datadog
 delphix-plugin                   # renamed to delphix
+# temporarily discontinued
 delphix = https://github.com/jenkins-infra/update-center2/pull/695
 description-column               # renamed to description-column-plugin
 discobit-autoconfig = https://github.com/jenkins-infra/update-center2/pull/587

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -73,7 +73,7 @@ cppunit = https://wiki.jenkins-ci.org/display/JENKINS/CppUnit+Plugin
 create-fingerprint-plugin        # renamed to create-fingerprint
 datadog-build-reporter           # renamed to datadog
 delphix-plugin                   # renamed to delphix
-delphix                          # discontinued
+delphix = https://github.com/jenkins-infra/update-center2/pull/695
 description-column               # renamed to description-column-plugin
 discobit-autoconfig = https://github.com/jenkins-infra/update-center2/pull/587
 # removal requested by teilo, superceded by dockerhub-notification

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -74,8 +74,6 @@ cppunit = https://wiki.jenkins-ci.org/display/JENKINS/CppUnit+Plugin
 create-fingerprint-plugin        # renamed to create-fingerprint
 datadog-build-reporter           # renamed to datadog
 delphix-plugin                   # renamed to delphix
-# temporarily discontinued
-delphix = https://github.com/jenkins-infra/update-center2/pull/695
 description-column               # renamed to description-column-plugin
 discobit-autoconfig = https://github.com/jenkins-infra/update-center2/pull/587
 # removal requested by teilo, superceded by dockerhub-notification


### PR DESCRIPTION
We plan to push/release an updated version of our Delphix plugin v3.0.0 tomorrow. 
This will replace the existing (but currently hidden) Delphix Plugin. 

This PR is meant to revert the change I made back in March. https://github.com/jenkins-infra/update-center2/pull/695

Ideally, we merge this PR around the same time [the PR here is merged. ](https://github.com/jenkinsci/delphix-plugin)