### PR TITLE
SECURITY-1877 Remove warning from opsgenie-plugin

### DIFF
--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -12788,8 +12788,8 @@
     "url": "https://www.jenkins.io/security/advisory/2022-06-30/#SECURITY-1877",
     "versions": [
       {
-        "lastVersion": "1.9",
-        "pattern": ".*"
+        "lastVersion": "1.10",
+        "pattern": "(1[.][0-9]|1[.]10)(|[.-].*)"
       }
     ]
   },


### PR DESCRIPTION
The vulnerability has been fixed in this [PR](https://github.com/jenkinsci/opsgenie-plugin/pull/8).
You can check the latest plugin from [here](https://updates.jenkins.io/download/plugins/opsgenie/). e.g. `1.10`