### PR TITLE
Suspend Azure Dev Spaces plugin, service discontinued

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -875,3 +875,9 @@ delphix@2.0.1
 delphix@2.0.2
 delphix@2.0.3
 delphix@2.0.4
+
+# service discontinued
+# Azure Dev Spaces retired May 15, 2021 per https://azure.microsoft.com/en-us/updates/azure-dev-spaces-retired-on-may-15-2021/
+# https://learn.microsoft.com/en-us/previous-versions/azure/dev-spaces/ points to "Bridge to Kubernetes" as the replacement
+# https://issues.jenkins.io/browse/JENKINS-71776 asks to suspend azure-dev-spaces becuse the service is no longer available.
+azure-dev-spaces

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -23,6 +23,8 @@ aws-java-sdk-sts      = https://github.com/jenkinsci/aws-java-sdk-plugin/pull/54
 aws-lambda-jenkins-plugin        # renamed to aws-lambda
 aws-lambda-plugin                # renamed to aws-lambda
 aws-yum-paramater                # renamed to package-parameter
+# service discontinued: https://azure.microsoft.com/en-us/updates/azure-dev-spaces-retired-on-may-15-2021/
+azure-dev-spaces = https://issues.jenkins.io/browse/JENKINS-71776
 # deprecated -- https://github.com/jenkinsci/azure-iot-edge-plugin/blob/master/Readme.md
 azure-iot-edge = https://github.com/jenkinsci/azure-iot-edge-plugin/blob/master/Readme.md
 bart = https://github.com/jenkins-infra/update-center2/pull/658
@@ -875,9 +877,3 @@ delphix@2.0.1
 delphix@2.0.2
 delphix@2.0.3
 delphix@2.0.4
-
-# service discontinued
-# Azure Dev Spaces retired May 15, 2021 per https://azure.microsoft.com/en-us/updates/azure-dev-spaces-retired-on-may-15-2021/
-# https://learn.microsoft.com/en-us/previous-versions/azure/dev-spaces/ points to "Bridge to Kubernetes" as the replacement
-# https://issues.jenkins.io/browse/JENKINS-71776 asks to suspend azure-dev-spaces becuse the service is no longer available.
-azure-dev-spaces


### PR DESCRIPTION
## Suspend Azure Dev Spaces plugin, service discontinued

[Azure updates June 14, 2021](https://azure.microsoft.com/en-us/updates/azure-dev-spaces-retired-on-may-15-2021/) announces the retirement of Azure Dev Spaces May 15, 2021.

The [Microsoft learn site](https://learn.microsoft.com/en-us/previous-versions/azure/dev-spaces/) points to "Bridge to Kubernetes" as the replacement.

[JENKINS-71776](https://issues.jenkins.io/browse/JENKINS-71776) asks to suspend azure-dev-spaces becuse the service is no longer available.
