### PR TITLE
SECURITY-3117 Remove warning from sumologic-publisher

### DIFF
--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -16440,8 +16440,8 @@
     "url": "https://www.jenkins.io/security/advisory/2023-07-12/#SECURITY-3117",
     "versions": [
       {
-        "lastVersion": "2.2.1",
-        "pattern": ".*"
+        "lastVersion": "2.2.3",
+        "pattern": "(1|2[.][01]|2[.]2[.][013])(|[.-].+)"
       }
     ]
   },


### PR DESCRIPTION
This was corrected by https://github.com/jenkinsci/sumologic-publisher-plugin/commit/cdb7432f4a634af7e1333374626f06aa4a5de9dd and was released in v2.2.4

I tested the PR locally