### PR TITLE
Deprecate Green Balls

### DIFF
--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -15,6 +15,7 @@ emma = https://github.com/jenkinsci/jenkins/pull/5320
 extreme-feedback = https://www.jenkins.io/blog/2021/11/09/guava-upgrade/
 google-cloud-health-check = https://www.jenkins.io/blog/2021/11/09/guava-upgrade/
 harvest = https://github.com/jenkinsci/jenkins/pull/5320
+greenballs = https://github.com/jenkins-infra/update-center2/pull/735
 handlebars = https://github.com/jenkins-infra/update-center2/pull/677
 javatest-report = https://github.com/jenkinsci/jenkins/pull/5320
 maven-repo-cleaner = https://github.com/jenkinsci/jenkins/pull/6323


### PR DESCRIPTION
- Jenkins UI no longer shows balls
- Current passing build status is already green
- This plugin doesn't load anymore on Java 17 with a reflection error

https://giphy.com/gifs/star-trek-qH7J4EXzSCmBy