### PR TITLE
SECURITY-3122 Remove warning from test-results-aggregator

### DIFF
--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -16466,8 +16466,8 @@
     "url": "https://www.jenkins.io/security/advisory/2023-07-12/#SECURITY-3122",
     "versions": [
       {
-        "lastVersion": "1.2.13",
-        "pattern": ".*"
+        "lastVersion": "1.2.15",
+        "pattern": "(1[.][01]|1[.]2[.][0-9]|1[.]2[.]1[0-5])(|[.-].+)"
       }
     ]
   },


### PR DESCRIPTION
This was corrected by https://github.com/jenkinsci/test-results-aggregator-plugin/commit/3de0301dd1e19529b1edd4dd2e6507901f67b679 and was released in v1.2.16.

I tested the PR locally before it get merged