### PR TITLE
Decommission version 3.0.1 and 3.0.2 of Delphix plugin

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -877,3 +877,5 @@ delphix@2.0.1
 delphix@2.0.2
 delphix@2.0.3
 delphix@2.0.4
+delphix@3.0.1
+delphix@3.0.2


### PR DESCRIPTION
We intend to remove Delphix v3.0.1 and v3.0.2 due to security vulnerabilities identified in them that were addressed with v3.0.3. We do not want any customers to download these versions and expose themselves to the risks.