### PR TITLE
Suspend redhat-codeready-dependency-analysis

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -197,6 +197,7 @@ pretest-commit = https://wiki.jenkins-ci.org/display/JENKINS/Pretest+Commit+Plug
 PUCM = https://wiki.jenkins-ci.org/display/JENKINS/pucm+plugin
 rally-bookkeeper                 # removal requested by Mike Rogers: will be Rally plugin 2.0
 rally-update-plugin-1            # renamed to rally-plugin(!)
+redhat-codeready-dependency-analysis = https://plugins.jenkins.io/redhat-dependency-analytics/ # Renamed to redhat-dependency-analytics
 release-multi-test               # junk: contains only the HelloWorldBuilder sample
 release-test                     # junk: contains only the HelloWorldBuilder sample
 Relution                         # renamed to relution-publisher


### PR DESCRIPTION
In https://github.com/jenkins-infra/repository-permissions-updater/issues/3503, the plugin was submitted and hosted without unpublishing the existing one.