### PR TITLE
Remove wiki override for `github-scm-trait-notification-context`

### DIFF
--- a/resources/wiki-overrides.properties
+++ b/resources/wiki-overrides.properties
@@ -55,7 +55,6 @@ xpdev=https://wiki.jenkins-ci.org/display/JENKINS/XP-Dev+Plugin
 # wiki doesn't actually have any content
 working-hours=https://github.com/jenkinsci/working-hours-plugin
 
-github-scm-trait-notification-context=https://wiki.jenkins.io/display/JENKINS/Github+Custom+Notification+Context+SCM+Behaviour+Plugin
 ca-apm=https://wiki.jenkins.io/display/JENKINS/CA+APM+Plugin+1.x
 comments-remover=https://wiki.jenkins.io/display/JENKINS/XComment.io+-+Comments+Remover+Plugin
 pipeline-model-declarative-agent=https://github.com/jenkinsci/pipeline-model-definition-plugin/blob/master/pipeline-model-declarative-agent/README.md


### PR DESCRIPTION
This PR removes the wiki override in order to use the GitHub README as plugin description on plugins.jenkins.io instead of the content of https://wiki.jenkins.io/display/JENKINS/Github+Custom+Notification+Context+SCM+Behaviour+Plugin

Ref: https://github.com/jenkins-infra/helpdesk/issues/3770