### PR TITLE
Remove wiki override for `SonarQube`

### DIFF
--- a/resources/wiki-overrides.properties
+++ b/resources/wiki-overrides.properties
@@ -41,8 +41,6 @@ prereq-buildstep=http://wiki.jenkins-ci.org/display/JENKINS/Prerequisite+build+s
 project-health-report=https://wiki.jenkins-ci.org/display/JENKINS/Project+Health+Report+Plugin
 puppet=https://wiki.jenkins-ci.org/display/JENKINS/Puppet+Plugin
 ruby-runtime=https://wiki.jenkins-ci.org/display/JENKINS/Ruby+Runtime+Plugin
-# Macro leads to 404, sources are actually located at https://github.com/SonarSource/jenkins-sonar-plugin
-sonar=https://wiki.jenkins-ci.org/display/JENKINS/SonarQube+plugin
 started-by-envvar=https://wiki.jenkins-ci.org/display/JENKINS/Started-By+Environment+Variable+Plugin
 StashBranchParameter=https://wiki.jenkins-ci.org/display/JENKINS/StashBranchParameter
 # Macro leads to 404. Seems like the sources are under https://github.com/davidparsson/svn-workspace-cleaner-plugin (i.e. not forked)


### PR DESCRIPTION
This PR removes the wiki override in order to use https://github.com/jenkinsci/sonarqube-plugin/blob/master/README.md as plugin description on plugins.jenkins.io instead of the content of https://wiki.jenkins-ci.org/display/JENKINS/SonarQube+plugin

Ref: https://github.com/jenkins-infra/helpdesk/issues/3777