### PR TITLE
Also sync content into Azure File Share and R2 buckets

### DIFF
--- a/site/publish.sh
+++ b/site/publish.sh
@@ -40,7 +40,7 @@ ssh ${RSYNC_USER}@${UPDATES_SITE} "cat > /tmp/update-center2-rerecent-releases.j
 ssh ${RSYNC_USER}@${UPDATES_SITE} "/srv/releases/sync-recent-releases.sh /tmp/update-center2-rerecent-releases.json"
 
 ## 'www2' folder processing
-chmod -R a+r./ www2
+chmod -R a+r ./www2
 
 # TIME sync, used by mirrorbits to know the last update date to take in account
 date +%s > ./www2/TIME

--- a/site/publish.sh
+++ b/site/publish.sh
@@ -119,10 +119,14 @@ parallel --halt-on-error now,fail=1 parallelfunction ::: "${tasks[@]}"
 # Wait for all deferred tasks
 echo '============================ all done ============================'
 
-echo '== Triggering a mirror scan on mirrorbits...'
-# Kubernetes namespace of mirrorbits
-mirrorbits_namespace="updates-jenkins-io"
+# Trigger a mirror scan on mirrorbits if the flag is set
+if [[ $OPT_IN_SYNC_FS_R2 == "optin" ]]
+then
+    echo '== Triggering a mirror scan on mirrorbits...'
+    # Kubernetes namespace of mirrorbits
+    mirrorbits_namespace="updates-jenkins-io"
 
-# Requires a valid kubernetes credential file at $KUBECONFIG or $HOME/.kube/config by default
-pod_name="$(kubectl --namespace=${mirrorbits_namespace} --no-headers=true get pod --output=name | grep mirrorbits-lite | head -n1)"
-kubectl --namespace=${mirrorbits_namespace} --container=mirrorbits-lite exec "${pod_name}" -- mirrorbits scan -all -enable -timeout=120
+    # Requires a valid kubernetes credential file at $KUBECONFIG or $HOME/.kube/config by default
+    pod_name="$(kubectl --namespace=${mirrorbits_namespace} --no-headers=true get pod --output=name | grep mirrorbits-lite | head -n1)"
+    kubectl --namespace=${mirrorbits_namespace} --container=mirrorbits-lite exec "${pod_name}" -- mirrorbits scan -all -enable -timeout=120
+fi

--- a/site/publish.sh
+++ b/site/publish.sh
@@ -7,19 +7,9 @@
 UPDATES_SITE="updates.jenkins.io"
 RSYNC_USER="www-data"
 
-# For syncing R2 buckets with aws-cli configured through environment variables (from Jenkins credentials)
+# For syncing R2 buckets aws-cli is configured through environment variables (from Jenkins credentials)
 # https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
 export AWS_DEFAULT_REGION="auto"
-UPDATES_R2_BUCKET="westeurope-updates-jenkins-io"
-UPDATES_R2_ENDPOINT="https://8d1838a43923148c5cee18ccc356a594.r2.cloudflarestorage.com"
-
-# For syncing Azure File Share
-UPDATES_FILE_SHARE_URL_AND_PATH="https://updatesjenkinsio.file.core.windows.net/updates-jenkins-io/"
-
-# For triggering a mirror scan on mirrorbits
-MIRRORBITS_POD_NAME_PREFIX="mirrorbits-lite"
-MIRRORBITS_CONTAINER_NAME="mirrorbits-lite"
-MIRRORBITS_NAMESPACE="updates-jenkins-io"
 
 ## Install jq, required by generate.sh script
 wget --no-verbose -O jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 || { echo "Failed to download jq" >&2 ; exit 1; }
@@ -71,20 +61,25 @@ function parallelfunction() {
 
     azsync*)
         # Sync Azure File Share content using www3 to avoid symlinks
-        time azcopy sync ./www3/ "${UPDATES_FILE_SHARE_URL_AND_PATH}?${UPDATES_FILE_SHARE_QUERY_STRING}" \
+        time azcopy sync ./www3/ "https://updatesjenkinsio.file.core.windows.net/updates-jenkins-io/?${UPDATES_FILE_SHARE_QUERY_STRING}" \
             --recursive=true \
             --delete-destination=true
         ;;
 
     s3sync*)
+        # Retrieve the R2 bucket and the R2 endpoint from the task name passed as argument, minus "s3sync" prefix
+        updates_r2_bucket_and_endpoint="${1#s3sync}"
+        r2_bucket=${updates_r2_bucket_and_endpoint%|*}
+        r2_endpoint=${updates_r2_bucket_and_endpoint#*|}
+
         # Sync CloudFlare R2 buckets content excluding 'updates' folder from www3 sync (without symlinks)
         # as this folder is populated by https://github.com/jenkins-infra/crawler/blob/master/Jenkinsfile
-        time aws s3 sync ./www3/ s3://"${UPDATES_R2_BUCKET}"/ \
+        time aws s3 sync ./www3/ s3://"${r2_bucket}"/ \
             --no-progress \
             --no-follow-symlinks \
             --size-only \
             --exclude '.htaccess' \
-            --endpoint-url "${UPDATES_R2_ENDPOINT}"
+            --endpoint-url "${r2_endpoint}"
         ;;
 
     *)
@@ -97,35 +92,37 @@ function parallelfunction() {
 # Export local variables used in parallelfunction
 export UPDATES_SITE
 export RSYNC_USER
-export UPDATES_R2_BUCKET
-export UPDATES_R2_ENDPOINT
-export UPDATES_FILE_SHARE_URL_AND_PATH
 
 # Export function to use it with parallel
 export -f parallelfunction
 
-echo '----------------------- Launch synchronisation(s) -----------------------'
-if [[ $OPT_IN_SYNC_FS_R2 == 'optin' ]]
-then
-    # Sync updates.jenkins.io and azure.updates.jenkins.io
-    parallel --halt-on-error now,fail=1 parallelfunction ::: rsync azsync s3sync
-else
-    # Sync only updates.jenkins.io
-    parallel --halt-on-error now,fail=1 parallelfunction ::: rsync
+# Sync only updates.jenkins.io by default
+tasks=("rsync")
 
-    # ## If we prefer to avoid parallel when not opt-in, we can replace the previous instruction by the following one:
-    # # push generated index to the production server
-    # rsync --archive --checksum --verbose --compress \
-    #     --exclude=/updates `# populated by https://github.com/jenkins-infra/crawler` \
-    #     --delete `# delete old sites` \
-    #     --stats `# add verbose statistics` \
-    #     ./www2/ ${RSYNC_USER}@${UPDATES_SITE}:/var/www/${UPDATES_SITE}
+# Sync updates.jenkins.io and azure.updates.jenkins.io File Share and R2 bucket(s) if the flag is set
+if [[ $OPT_IN_SYNC_FS_R2 == "optin" ]]
+then
+    # Add File Share sync to the tasks
+    tasks+=("azsync")
+
+    # Add each R2 bucket sync to the tasks
+    updates_r2_bucket_and_endpoint_pairs=("westeurope-updates-jenkins-io|https://8d1838a43923148c5cee18ccc356a594.r2.cloudflarestorage.com")
+    for r2_bucket_and_endpoint_pair in "${updates_r2_bucket_and_endpoint_pairs[@]}"
+    do
+        tasks+=("s3sync${r2_bucket_and_endpoint_pair}")
+    done
 fi
+
+echo '----------------------- Launch synchronisation(s) -----------------------'
+parallel --halt-on-error now,fail=1 parallelfunction ::: "${tasks[@]}"
 
 # Wait for all deferred tasks
 echo '============================ all done ============================'
 
 echo '== Triggering a mirror scan on mirrorbits...'
+# Kubernetes namespace of mirrorbits
+mirrorbits_namespace="updates-jenkins-io"
+
 # Requires a valid kubernetes credential file at $KUBECONFIG or $HOME/.kube/config by default
-pod_name="$(kubectl --namespace=${MIRRORBITS_NAMESPACE} --no-headers=true get pod --output=name | grep "${MIRRORBITS_POD_NAME_PREFIX}" | head -n1)"
-kubectl --namespace=${MIRRORBITS_NAMESPACE} --container="${MIRRORBITS_CONTAINER_NAME}" exec "${pod_name}" -- mirrorbits scan -all -enable -timeout=120
+pod_name="$(kubectl --namespace=${mirrorbits_namespace} --no-headers=true get pod --output=name | grep mirrorbits-lite | head -n1)"
+kubectl --namespace=${mirrorbits_namespace} --container=mirrorbits-lite exec "${pod_name}" -- mirrorbits scan -all -enable -timeout=120

--- a/site/publish.sh
+++ b/site/publish.sh
@@ -32,20 +32,6 @@ ssh ${RSYNC_USER}@${UPDATES_SITE} "/srv/releases/sync-recent-releases.sh /tmp/up
 ## 'www2' folder processing
 chmod -R a+r ./www2
 
-# TIME sync, used by mirrorbits to know the last update date to take in account
-date +%s > ./www2/TIME
-
-## No need to remove the symlinks as the `azcopy sync` for symlinks is not yet supported and we use `--no-follow-symlinks` for `aws s3 sync`
-# Perform a copy with dereference symlink (object storage do not support symlinks)
-# copy & transform simlinks into referent file/dir
-rsync --archive --checksum --verbose --compress \
-            --copy-links `# derefence symlinks` \
-            --safe-links `# ignore symlinks outside of copied tree` \
-            --stats `# add verbose statistics` \
-            --exclude='updates' `# populated by https://github.com/jenkins-infra/crawler` \
-            --delete `# delete old sites` \
-            www2/ www3/
-
 function parallelfunction() {
     echo "=== parallelfunction: $1"
 
@@ -102,6 +88,20 @@ tasks=("rsync")
 # Sync updates.jenkins.io and azure.updates.jenkins.io File Share and R2 bucket(s) if the flag is set
 if [[ $OPT_IN_SYNC_FS_R2 == "optin" ]]
 then
+    # TIME sync, used by mirrorbits to know the last update date to take in account
+    date +%s > ./www2/TIME
+
+    ## No need to remove the symlinks as the `azcopy sync` for symlinks is not yet supported and we use `--no-follow-symlinks` for `aws s3 sync`
+    # Perform a copy with dereference symlink (object storage do not support symlinks)
+    # copy & transform simlinks into referent file/dir
+    rsync --archive --checksum --verbose --compress \
+                --copy-links `# derefence symlinks` \
+                --safe-links `# ignore symlinks outside of copied tree` \
+                --stats `# add verbose statistics` \
+                --exclude='updates' `# populated by https://github.com/jenkins-infra/crawler` \
+                --delete `# delete old sites` \
+                www2/ www3/
+
     # Add File Share sync to the tasks
     tasks+=("azsync")
 

--- a/site/publish.sh
+++ b/site/publish.sh
@@ -8,6 +8,7 @@ UPDATES_R2_ENDPOINT="https://8d1838a43923148c5cee18ccc356a594.r2.cloudflarestora
 if [[ -z "$ROOT_FOLDER" ]]; then
     ROOT_FOLDER="/home/jenkins/lemeurherve/pr-745" # TODO: remove after debug
 fi
+export AWS_DEFAULT_REGION=auto
 
 # parallel added within the permanent trusted agent here : https://github.com/jenkins-infra/jenkins-infra/blob/production/dist/profile/manifests/buildagent.pp
 command -v parallel >/dev/null 2>&1 || { echo "ERROR: parralel command not found. Exiting."; exit 1; }
@@ -33,18 +34,22 @@ export PATH=.:$PATH
 # # 'updates' come from tool installer generator, so leave that alone, but otherwise
 # # delete old sites
 chmod -R a+r "${ROOT_FOLDER}"/www2
-# # rsync -acvz www2/ --exclude=/updates --delete ${RSYNC_USER}@${UPDATES_SITE}:/var/www/${UPDATES_SITE}
+# TIME sync, used by mirrorbits to know the last update date to take in account
+date +%s > "${ROOT_FOLDER}"/www2/TIME
 
-# ### TODO: cleanup original commands above when https://github.com/jenkins-infra/helpdesk/issues/2649 is ready for production
+## Commented out: original rsync command to PKG VM (should be in the parallelized step below)
+# rsync -acvz www2/ --exclude=/updates --delete ${RSYNC_USER}@${UPDATES_SITE}:/var/www/${UPDATES_SITE}
 
-####   no need to remove the symlinks as the `azcopy sync`for symlinks is not yet supported and we use `--no-follow-symlinks` for `aws s3 sync``
+#### No need to remove the symlinks as the `azcopy sync` for symlinks is not yet supported and we use `--no-follow-symlinks` for `aws s3 sync``
 # Perform a copy with dereference symlink (object storage do not support symlinks)
 # copy & transform simlinks into referent file/dir
 time rsync  -acvz \
             --copy-links `# derefence symlinks` \
             --safe-links `# ignore symlinks outside of copied tree` \
             --stats `# add verbose statistics` \
-            "${ROOT_FOLDER}"/www2/ --exclude=updates/ --delete "${ROOT_FOLDER}"/www3/
+            --exclude='updates' \
+            --delete \
+            "${ROOT_FOLDER}"/www2/ "${ROOT_FOLDER}"/www3/
 ## "${ROOT_FOLDER}"/www3/ doesn't have symlinks already
 ## "${ROOT_FOLDER}"/www2/ still have symlinks
 ### Below: parallelise
@@ -58,17 +63,23 @@ function parallelfunction() {
     case $1 in
     rsync*)
         # keep exclude as from www2 with symlinks
-        time rsync -acz "${ROOT_FOLDER}"/www2/ --exclude=/updates --delete --stats ${RSYNC_USER}@${UPDATES_SITE}:/tmp/lemeurherve/pr-745/www/${UPDATES_SITE}
+        time rsync -acz "${ROOT_FOLDER}"/www2/ --exclude='updates' --delete --stats ${RSYNC_USER}@${UPDATES_SITE}:/tmp/lemeurherve/pr-745/www/${UPDATES_SITE}
         ;;
 
     azsync*)
         # Sync Azure File Share content (using www3 to avoid symlinks)
-        time azcopy sync "${ROOT_FOLDER}"/www3/ "${UPDATES_FILE_SHARE_URL}" --recursive=true --delete-destination=true
+        time azcopy sync "${ROOT_FOLDER}"/www3/ "https://updatesjenkinsio.file.core.windows.net/updates-jenkins-io/?${UPDATES_FILE_SHARE_QUERY_STRING}" --recursive=true --delete-destination=true
         ;;
 
     s3sync*)
+        ## Note: AWS CLI is configured through environment variables (from Jenkins credentials) - https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
         # Sync CloudFlare R2 buckets content using the updates-jenkins-io profile, excluding 'updates' folder which comes from tool installer generator (using www3 to avoid symlinks)
-        time aws s3 sync "${ROOT_FOLDER}"/www3/ s3://"${UPDATES_R2_BUCKETS}"/ --profile updates-jenkins-io --no-progress --no-follow-symlinks --size-only --exclude '.htaccess' --endpoint-url "${UPDATES_R2_ENDPOINT}"
+        time aws s3 sync "${ROOT_FOLDER}"/www3/ s3://"${UPDATES_R2_BUCKETS}"/ \
+            --no-progress \
+            --no-follow-symlinks \
+            --size-only \
+            --exclude '.htaccess' \
+            --endpoint-url "${UPDATES_R2_ENDPOINT}"
         ;;
 
     *)
@@ -84,20 +95,16 @@ export RSYNC_USER
 export UPDATES_R2_BUCKETS
 export UPDATES_R2_ENDPOINT
 export ROOT_FOLDER
+export UPDATES_FILE_SHARE_QUERY_STRING
 
 ## export function to use with parallel
 export -f parallelfunction
 parallel --halt-on-error now,fail=1 parallelfunction ::: rsync azsync s3sync
 
-
 # wait for all deferred task
 echo '===============================    all done   ============================'
 
-## TODO: test if needed rclone both rsync VM and R2 bucket(s) replacing these 2 calls
-
-# Debug
-
-# # /TIME sync, used by mirrorbits to know the last update date to take in account
-# date +%s > ./www2/TIME
-# aws s3 cp ./www2/TIME s3://"${UPDATES_R2_BUCKETS}"/ --profile updates-jenkins-io --endpoint-url "${UPDATES_R2_ENDPOINT}"
-# azcopy cp ./www2/TIME "${UPDATES_FILE_SHARE_URL}" --overwrite=true
+## Trigger a mirror scan on mirrorbits
+# Requires a valid kubernetes credential file at $KUBECONFIG or $HOME/.kube/config by default
+pod_name="$(kubectl --namespace=updates-jenkins-io --no-headers=true get pod --output=name | grep mirrorbits-lite | head -n1)"
+kubectl --namespace=updates-jenkins-io exec "${pod_name}" --container=mirrorbits-lite -- mirrorbits scan -all -enable -timeout=120

--- a/site/publish.sh
+++ b/site/publish.sh
@@ -46,8 +46,11 @@ function parallelfunction() {
         ;;
 
     azsync*)
+        # Script stored in /usr/local/bin used to generate a signed file share URL with a short-lived SAS token
+        # Source: https://github.com/jenkins-infra/pipeline-library/blob/master/resources/get-fileshare-signed-url.sh
+        fileShareUrl=$(get-fileshare-signed-url.sh)
         # Sync Azure File Share content using www3 to avoid symlinks
-        time azcopy sync ./www3/ "https://updatesjenkinsio.file.core.windows.net/updates-jenkins-io/?${UPDATES_FILE_SHARE_QUERY_STRING}" \
+        time azcopy sync ./www3/ "${fileShareUrl}" \
             --recursive=true \
             --exclude-path="updates" `# populated by https://github.com/jenkins-infra/crawler` \
             --delete-destination=true
@@ -79,6 +82,12 @@ function parallelfunction() {
 # Export local variables used in parallelfunction
 export UPDATES_SITE
 export RSYNC_USER
+
+# Export variables used in parallelfunction/azsync/get-fileshare-signed-url.sh
+export STORAGE_FILESHARE=updates-jenkins-io
+export STORAGE_NAME=updatesjenkinsio
+export STORAGE_DURATION_IN_MINUTE=5 # duration of the short-lived SAS token
+export STORAGE_PERMISSIONS=dlrw
 
 # Export function to use it with parallel
 export -f parallelfunction

--- a/site/publish.sh
+++ b/site/publish.sh
@@ -3,24 +3,68 @@
 # Used later for rsyncing updates
 UPDATES_SITE="updates.jenkins.io"
 RSYNC_USER="www-data"
+UPDATES_R2_BUCKETS="westeurope-updates-jenkins-io"
+UPDATES_R2_ENDPOINT="https://8d1838a43923148c5cee18ccc356a594.r2.cloudflarestorage.com"
+if [[ -z "$ROOT_FOLDER" ]]; then
+    ROOT_FOLDER="/home/jenkins/lemeurherve/pr-745" # TODO: remove after debug
+fi
+
+echo "ROOT_FOLDER: ${ROOT_FOLDER}"
 
 wget --no-verbose -O jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 || { echo "Failed to download jq" >&2 ; exit 1; }
 chmod +x jq || { echo "Failed to make jq executable" >&2 ; exit 1; }
 
 export PATH=.:$PATH
 
-"$( dirname "$0" )/generate.sh" ./www2 ./download
+# "$( dirname "$0" )/generate.sh" "${ROOT_FOLDER}"/www2 ./download
 
 # push plugins to mirrors.jenkins-ci.org
-chmod -R a+r download
-rsync -avz --size-only download/plugins/ ${RSYNC_USER}@${UPDATES_SITE}:/srv/releases/jenkins/plugins
+# chmod -R a+r download
+# rsync -avz --size-only download/plugins/ ${RSYNC_USER}@${UPDATES_SITE}:/srv/releases/jenkins/plugins
 
-# Invoke a minimal mirrorsync to mirrorbits which will use the 'recent-releases.json' file as input
-ssh ${RSYNC_USER}@${UPDATES_SITE} "cat > /tmp/update-center2-rerecent-releases.json" < www2/experimental/recent-releases.json
-ssh ${RSYNC_USER}@${UPDATES_SITE} "/srv/releases/sync-recent-releases.sh /tmp/update-center2-rerecent-releases.json"
+# # Invoke a minimal mirrorsync to mirrorbits which will use the 'recent-releases.json' file as input
+# ssh ${RSYNC_USER}@${UPDATES_SITE} "cat > /tmp/update-center2-rerecent-releases.json" < www2/experimental/recent-releases.json
+# ssh ${RSYNC_USER}@${UPDATES_SITE} "/srv/releases/sync-recent-releases.sh /tmp/update-center2-rerecent-releases.json"
 
-# push generated index to the production servers
-# 'updates' come from tool installer generator, so leave that alone, but otherwise
-# delete old sites
-chmod -R a+r www2
-rsync -acvz www2/ --exclude=/updates --delete ${RSYNC_USER}@${UPDATES_SITE}:/var/www/${UPDATES_SITE}
+# # push generated index to the production servers
+# # 'updates' come from tool installer generator, so leave that alone, but otherwise
+# # delete old sites
+chmod -R a+r "${ROOT_FOLDER}"/www2
+# # rsync -acvz www2/ --exclude=/updates --delete ${RSYNC_USER}@${UPDATES_SITE}:/var/www/${UPDATES_SITE}
+
+# ### TODO: cleanup original commands above when https://github.com/jenkins-infra/helpdesk/issues/2649 is ready for production
+
+# Original-like rsync to pkg VM for testing and timing purposes
+time rsync -acvz "${ROOT_FOLDER}"/www2/ --exclude=/updates --delete --stats ${RSYNC_USER}@${UPDATES_SITE}:/tmp/lemeurherve/pr-745/www/${UPDATES_SITE}
+
+### Above ^: not to be modified
+
+### Below: parallelise
+
+# copy & transform simlinks into referent file/dir
+# time rsync -acvz --copy-links --safe-links --stats "${ROOT_FOLDER}"/www2/ --exclude=/updates --delete "${ROOT_FOLDER}"/www3/
+time rsync -acvz --no-links --stats "${ROOT_FOLDER}"/www2/ --exclude=/updates --delete "${ROOT_FOLDER}"/www3/
+
+ls -l "${ROOT_FOLDER}"/www3/
+ls -l "${ROOT_FOLDER}"/www3/current
+
+# Sync Azure File Share content
+time azcopy sync "${ROOT_FOLDER}"/www3/ "${UPDATES_FILE_SHARE_URL}" --recursive=true --delete-destination=true --exclude-path="updates"
+
+# Debug
+echo "= azcopy sync done."
+
+# Sync CloudFlare R2 buckets content using the updates-jenkins-io profile, excluding 'updates' folder which comes from tool installer generator
+time aws s3 sync "${ROOT_FOLDER}"/www3/ s3://"${UPDATES_R2_BUCKETS}"/ --profile updates-jenkins-io --no-progress --size-only --no-follow-symlinks --exclude="updates/*" --endpoint-url "${UPDATES_R2_ENDPOINT}"
+# aws s3 cp "${ROOT_FOLDER}"/www2/ s3://"${UPDATES_R2_BUCKETS}"/ --profile updates-jenkins-io --no-progress --no-follow-symlinks --exclude="updates/*" --endpoint-url "${UPDATES_R2_ENDPOINT}"
+
+
+## TODO: test if needed rclone both rsync VM and R2 bucket(s) replacing these 2 calls
+
+# Debug
+echo "= aws sync done."
+
+# # /TIME sync, used by mirrorbits to know the last update date to take in account
+# date +%s > ./www2/TIME
+# aws s3 cp ./www2/TIME s3://"${UPDATES_R2_BUCKETS}"/ --profile updates-jenkins-io --endpoint-url "${UPDATES_R2_ENDPOINT}"
+# azcopy cp ./www2/TIME "${UPDATES_FILE_SHARE_URL}" --overwrite=true

--- a/site/publish.sh
+++ b/site/publish.sh
@@ -131,6 +131,6 @@ then
     mirrorbits_namespace='updates-jenkins-io'
 
     # Requires a valid kubernetes credential file at $KUBECONFIG or $HOME/.kube/config by default
-    pod_name=$(kubectl --namespace="${mirrorbits_namespace}" --no-headers=true get pod --output=name | grep mirrorbits-lite | head -n1)
-    kubectl --namespace="${mirrorbits_namespace}" --container=mirrorbits-lite exec "${pod_name}" -- mirrorbits scan -all -enable -timeout=120
+    pod_name=$(kubectl --namespace="${mirrorbits_namespace}" --no-headers=true get pod --output=name | grep mirrorbits | head -n1)
+    kubectl --namespace="${mirrorbits_namespace}" --container=mirrorbits exec "${pod_name}" -- mirrorbits scan -all -enable -timeout=120
 fi

--- a/site/publish.sh
+++ b/site/publish.sh
@@ -49,6 +49,7 @@ function parallelfunction() {
         # Sync Azure File Share content using www3 to avoid symlinks
         time azcopy sync ./www3/ "https://updatesjenkinsio.file.core.windows.net/updates-jenkins-io/?${UPDATES_FILE_SHARE_QUERY_STRING}" \
             --recursive=true \
+            --exclude-path="updates" `# populated by https://github.com/jenkins-infra/crawler` \
             --delete-destination=true
         ;;
 

--- a/site/publish.sh
+++ b/site/publish.sh
@@ -9,6 +9,9 @@ if [[ -z "$ROOT_FOLDER" ]]; then
     ROOT_FOLDER="/home/jenkins/lemeurherve/pr-745" # TODO: remove after debug
 fi
 
+# parallel added within the permanent trusted agent here : https://github.com/jenkins-infra/jenkins-infra/blob/production/dist/profile/manifests/buildagent.pp
+command -v parallel >/dev/null 2>&1 || { echo "ERROR: parralel command not found. Exiting."; exit 1; }
+
 echo "ROOT_FOLDER: ${ROOT_FOLDER}"
 
 wget --no-verbose -O jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 || { echo "Failed to download jq" >&2 ; exit 1; }
@@ -34,35 +37,65 @@ chmod -R a+r "${ROOT_FOLDER}"/www2
 
 # ### TODO: cleanup original commands above when https://github.com/jenkins-infra/helpdesk/issues/2649 is ready for production
 
-# Original-like rsync to pkg VM for testing and timing purposes
-time rsync -acvz "${ROOT_FOLDER}"/www2/ --exclude=/updates --delete --stats ${RSYNC_USER}@${UPDATES_SITE}:/tmp/lemeurherve/pr-745/www/${UPDATES_SITE}
-
-### Above ^: not to be modified
-
-### Below: parallelise
-
+####   no need to remove the symlinks as the `azcopy sync`for symlinks is not yet supported and we use `--no-follow-symlinks` for `aws s3 sync``
+# Perform a copy with dereference symlink (object storage do not support symlinks)
 # copy & transform simlinks into referent file/dir
-# time rsync -acvz --copy-links --safe-links --stats "${ROOT_FOLDER}"/www2/ --exclude=/updates --delete "${ROOT_FOLDER}"/www3/
-time rsync -acvz --no-links --stats "${ROOT_FOLDER}"/www2/ --exclude=/updates --delete "${ROOT_FOLDER}"/www3/
+time rsync  -acvz \
+            --copy-links `# derefence symlinks` \
+            --safe-links `# ignore symlinks outside of copied tree` \
+            --stats `# add verbose statistics` \
+            "${ROOT_FOLDER}"/www2/ --exclude=updates/ --delete "${ROOT_FOLDER}"/www3/
+## "${ROOT_FOLDER}"/www3/ doesn't have symlinks already
+## "${ROOT_FOLDER}"/www2/ still have symlinks
+### Below: parallelise
+echo '--------------------------- Launch Parallelization -----------------------'
 
-ls -l "${ROOT_FOLDER}"/www3/
-ls -l "${ROOT_FOLDER}"/www3/current
 
-# Sync Azure File Share content
-time azcopy sync "${ROOT_FOLDER}"/www3/ "${UPDATES_FILE_SHARE_URL}" --recursive=true --delete-destination=true --exclude-path="updates"
+## define function
+function parallelfunction() {
+    echo "=== parallelfunction: $1"
 
-# Debug
-echo "= azcopy sync done."
+    case $1 in
+    rsync*)
+        # keep exclude as from www2 with symlinks
+        time rsync -acz "${ROOT_FOLDER}"/www2/ --exclude=/updates --delete --stats ${RSYNC_USER}@${UPDATES_SITE}:/tmp/lemeurherve/pr-745/www/${UPDATES_SITE}
+        ;;
 
-# Sync CloudFlare R2 buckets content using the updates-jenkins-io profile, excluding 'updates' folder which comes from tool installer generator
-time aws s3 sync "${ROOT_FOLDER}"/www3/ s3://"${UPDATES_R2_BUCKETS}"/ --profile updates-jenkins-io --no-progress --size-only --no-follow-symlinks --exclude="updates/*" --endpoint-url "${UPDATES_R2_ENDPOINT}"
-# aws s3 cp "${ROOT_FOLDER}"/www2/ s3://"${UPDATES_R2_BUCKETS}"/ --profile updates-jenkins-io --no-progress --no-follow-symlinks --exclude="updates/*" --endpoint-url "${UPDATES_R2_ENDPOINT}"
+    azsync*)
+        # Sync Azure File Share content (using www3 to avoid symlinks)
+        time azcopy sync "${ROOT_FOLDER}"/www3/ "${UPDATES_FILE_SHARE_URL}" --recursive=true --delete-destination=true
+        ;;
 
+    s3sync*)
+        # Sync CloudFlare R2 buckets content using the updates-jenkins-io profile, excluding 'updates' folder which comes from tool installer generator (using www3 to avoid symlinks)
+        time aws s3 sync "${ROOT_FOLDER}"/www3/ s3://"${UPDATES_R2_BUCKETS}"/ --profile updates-jenkins-io --no-progress --no-follow-symlinks --size-only --exclude '.htaccess' --endpoint-url "${UPDATES_R2_ENDPOINT}"
+        ;;
+
+    *)
+        echo -n "unknown"
+        ;;
+    esac
+
+}
+
+## need to export variables used within the functions above
+export UPDATES_SITE
+export RSYNC_USER
+export UPDATES_R2_BUCKETS
+export UPDATES_R2_ENDPOINT
+export ROOT_FOLDER
+
+## export function to use with parallel
+export -f parallelfunction
+parallel --halt-on-error now,fail=1 parallelfunction ::: rsync azsync s3sync
+
+
+# wait for all deferred task
+echo '===============================    all done   ============================'
 
 ## TODO: test if needed rclone both rsync VM and R2 bucket(s) replacing these 2 calls
 
 # Debug
-echo "= aws sync done."
 
 # # /TIME sync, used by mirrorbits to know the last update date to take in account
 # date +%s > ./www2/TIME

--- a/site/publish.sh
+++ b/site/publish.sh
@@ -1,80 +1,85 @@
 #!/bin/bash -ex
 
+## Environment variables that could be configured at the job level:
+# - OPT_IN_SYNC_FS_R2: (optional) Set it to "optin" to also update azure.updates.jenkins.io Files Share and R2 buckets
+
 # Used later for rsyncing updates
 UPDATES_SITE="updates.jenkins.io"
 RSYNC_USER="www-data"
-UPDATES_R2_BUCKETS="westeurope-updates-jenkins-io"
+
+# For syncing R2 buckets with aws-cli configured through environment variables (from Jenkins credentials)
+# https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
+export AWS_DEFAULT_REGION="auto"
+UPDATES_R2_BUCKET="westeurope-updates-jenkins-io"
 UPDATES_R2_ENDPOINT="https://8d1838a43923148c5cee18ccc356a594.r2.cloudflarestorage.com"
-if [[ -z "$ROOT_FOLDER" ]]; then
-    ROOT_FOLDER="/home/jenkins/lemeurherve/pr-745" # TODO: remove after debug
-fi
-export AWS_DEFAULT_REGION=auto
 
-# parallel added within the permanent trusted agent here : https://github.com/jenkins-infra/jenkins-infra/blob/production/dist/profile/manifests/buildagent.pp
-command -v parallel >/dev/null 2>&1 || { echo "ERROR: parralel command not found. Exiting."; exit 1; }
+# For syncing Azure File Share
+UPDATES_FILE_SHARE_URL_AND_PATH="https://updatesjenkinsio.file.core.windows.net/updates-jenkins-io/"
 
-echo "ROOT_FOLDER: ${ROOT_FOLDER}"
+# For triggering a mirror scan on mirrorbits
+MIRRORBITS_POD_NAME_PREFIX="mirrorbits-lite"
+MIRRORBITS_CONTAINER_NAME="mirrorbits-lite"
+MIRRORBITS_NAMESPACE="updates-jenkins-io"
 
+## Install jq, required by generate.sh script
 wget --no-verbose -O jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 || { echo "Failed to download jq" >&2 ; exit 1; }
 chmod +x jq || { echo "Failed to make jq executable" >&2 ; exit 1; }
 
 export PATH=.:$PATH
 
-# "$( dirname "$0" )/generate.sh" "${ROOT_FOLDER}"/www2 ./download
+## Generate the content of 'www2' and 'download' folders
+"$( dirname "$0" )/generate.sh" ./www2 ./download
 
+## 'download' folder processing
 # push plugins to mirrors.jenkins-ci.org
-# chmod -R a+r download
-# rsync -avz --size-only download/plugins/ ${RSYNC_USER}@${UPDATES_SITE}:/srv/releases/jenkins/plugins
+chmod -R a+r ./download
+rsync -avz --size-only download/plugins/ ${RSYNC_USER}@${UPDATES_SITE}:/srv/releases/jenkins/plugins
 
-# # Invoke a minimal mirrorsync to mirrorbits which will use the 'recent-releases.json' file as input
-# ssh ${RSYNC_USER}@${UPDATES_SITE} "cat > /tmp/update-center2-rerecent-releases.json" < www2/experimental/recent-releases.json
-# ssh ${RSYNC_USER}@${UPDATES_SITE} "/srv/releases/sync-recent-releases.sh /tmp/update-center2-rerecent-releases.json"
+# Invoke a minimal mirrorsync to mirrorbits which will use the 'recent-releases.json' file as input
+ssh ${RSYNC_USER}@${UPDATES_SITE} "cat > /tmp/update-center2-rerecent-releases.json" < www2/experimental/recent-releases.json
+ssh ${RSYNC_USER}@${UPDATES_SITE} "/srv/releases/sync-recent-releases.sh /tmp/update-center2-rerecent-releases.json"
 
-# # push generated index to the production servers
-# # 'updates' come from tool installer generator, so leave that alone, but otherwise
-# # delete old sites
-chmod -R a+r "${ROOT_FOLDER}"/www2
+## 'www2' folder processing
+chmod -R a+r./ www2
+
 # TIME sync, used by mirrorbits to know the last update date to take in account
-date +%s > "${ROOT_FOLDER}"/www2/TIME
+date +%s > ./www2/TIME
 
-## Commented out: original rsync command to PKG VM (should be in the parallelized step below)
-# rsync -acvz www2/ --exclude=/updates --delete ${RSYNC_USER}@${UPDATES_SITE}:/var/www/${UPDATES_SITE}
-
-#### No need to remove the symlinks as the `azcopy sync` for symlinks is not yet supported and we use `--no-follow-symlinks` for `aws s3 sync``
+## No need to remove the symlinks as the `azcopy sync` for symlinks is not yet supported and we use `--no-follow-symlinks` for `aws s3 sync`
 # Perform a copy with dereference symlink (object storage do not support symlinks)
 # copy & transform simlinks into referent file/dir
-time rsync  -acvz \
+rsync --archive --checksum --verbose --compress \
             --copy-links `# derefence symlinks` \
             --safe-links `# ignore symlinks outside of copied tree` \
             --stats `# add verbose statistics` \
-            --exclude='updates' \
-            --delete \
-            "${ROOT_FOLDER}"/www2/ "${ROOT_FOLDER}"/www3/
-## "${ROOT_FOLDER}"/www3/ doesn't have symlinks already
-## "${ROOT_FOLDER}"/www2/ still have symlinks
-### Below: parallelise
-echo '--------------------------- Launch Parallelization -----------------------'
+            --exclude='updates' `# populated by https://github.com/jenkins-infra/crawler` \
+            --delete `# delete old sites` \
+            www2/ www3/
 
-
-## define function
 function parallelfunction() {
     echo "=== parallelfunction: $1"
 
     case $1 in
     rsync*)
-        # keep exclude as from www2 with symlinks
-        time rsync -acz "${ROOT_FOLDER}"/www2/ --exclude='updates' --delete --stats ${RSYNC_USER}@${UPDATES_SITE}:/tmp/lemeurherve/pr-745/www/${UPDATES_SITE}
+        # Push generated index to the production server
+        time rsync --archive --checksum --verbose --compress \
+            --exclude=/updates `# populated by https://github.com/jenkins-infra/crawler` \
+            --delete `# delete old sites` \
+            --stats `# add verbose statistics` \
+            www2/ ${RSYNC_USER}@${UPDATES_SITE}:/var/www/${UPDATES_SITE}
         ;;
 
     azsync*)
-        # Sync Azure File Share content (using www3 to avoid symlinks)
-        time azcopy sync "${ROOT_FOLDER}"/www3/ "https://updatesjenkinsio.file.core.windows.net/updates-jenkins-io/?${UPDATES_FILE_SHARE_QUERY_STRING}" --recursive=true --delete-destination=true
+        # Sync Azure File Share content using www3 to avoid symlinks
+        time azcopy sync ./www3/ "${UPDATES_FILE_SHARE_URL_AND_PATH}?${UPDATES_FILE_SHARE_QUERY_STRING}" \
+            --recursive=true \
+            --delete-destination=true
         ;;
 
     s3sync*)
-        ## Note: AWS CLI is configured through environment variables (from Jenkins credentials) - https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
-        # Sync CloudFlare R2 buckets content using the updates-jenkins-io profile, excluding 'updates' folder which comes from tool installer generator (using www3 to avoid symlinks)
-        time aws s3 sync "${ROOT_FOLDER}"/www3/ s3://"${UPDATES_R2_BUCKETS}"/ \
+        # Sync CloudFlare R2 buckets content excluding 'updates' folder from www3 sync (without symlinks)
+        # as this folder is populated by https://github.com/jenkins-infra/crawler/blob/master/Jenkinsfile
+        time aws s3 sync ./www3/ s3://"${UPDATES_R2_BUCKET}"/ \
             --no-progress \
             --no-follow-symlinks \
             --size-only \
@@ -83,28 +88,44 @@ function parallelfunction() {
         ;;
 
     *)
-        echo -n "unknown"
+        echo -n "Warning: unknown parameter"
         ;;
-    esac
 
+    esac
 }
 
-## need to export variables used within the functions above
+# Export local variables used in parallelfunction
 export UPDATES_SITE
 export RSYNC_USER
-export UPDATES_R2_BUCKETS
+export UPDATES_R2_BUCKET
 export UPDATES_R2_ENDPOINT
-export ROOT_FOLDER
-export UPDATES_FILE_SHARE_QUERY_STRING
+export UPDATES_FILE_SHARE_URL_AND_PATH
 
-## export function to use with parallel
+# Export function to use it with parallel
 export -f parallelfunction
-parallel --halt-on-error now,fail=1 parallelfunction ::: rsync azsync s3sync
 
-# wait for all deferred task
-echo '===============================    all done   ============================'
+echo '----------------------- Launch synchronisation(s) -----------------------'
+if [[ $OPT_IN_SYNC_FS_R2 == 'optin' ]]
+then
+    # Sync updates.jenkins.io and azure.updates.jenkins.io
+    parallel --halt-on-error now,fail=1 parallelfunction ::: rsync azsync s3sync
+else
+    # Sync only updates.jenkins.io
+    parallel --halt-on-error now,fail=1 parallelfunction ::: rsync
 
-## Trigger a mirror scan on mirrorbits
+    # ## If we prefer to avoid parallel when not opt-in, we can replace the previous instruction by the following one:
+    # # push generated index to the production server
+    # rsync --archive --checksum --verbose --compress \
+    #     --exclude=/updates `# populated by https://github.com/jenkins-infra/crawler` \
+    #     --delete `# delete old sites` \
+    #     --stats `# add verbose statistics` \
+    #     ./www2/ ${RSYNC_USER}@${UPDATES_SITE}:/var/www/${UPDATES_SITE}
+fi
+
+# Wait for all deferred tasks
+echo '============================ all done ============================'
+
+echo '== Triggering a mirror scan on mirrorbits...'
 # Requires a valid kubernetes credential file at $KUBECONFIG or $HOME/.kube/config by default
-pod_name="$(kubectl --namespace=updates-jenkins-io --no-headers=true get pod --output=name | grep mirrorbits-lite | head -n1)"
-kubectl --namespace=updates-jenkins-io exec "${pod_name}" --container=mirrorbits-lite -- mirrorbits scan -all -enable -timeout=120
+pod_name="$(kubectl --namespace=${MIRRORBITS_NAMESPACE} --no-headers=true get pod --output=name | grep "${MIRRORBITS_POD_NAME_PREFIX}" | head -n1)"
+kubectl --namespace=${MIRRORBITS_NAMESPACE} --container="${MIRRORBITS_CONTAINER_NAME}" exec "${pod_name}" -- mirrorbits scan -all -enable -timeout=120


### PR DESCRIPTION
This PR allows synchronizing the content of updates.jenkins.io to the new Azure File Share and CloudFlare R2 buckets I've put in place for the migration of this service from the current VM to an high availability service on publick8s.

This migration will allow us to reduce our AWS cost by a third, thanks to the free outbound bandwidth of CloudFlare R2.

It will also allow us to benefit from a distributed service thanks to mirrorbits, and (later) the use of a bucket in each of the 6 regions offered by CloudFlare for its buckets: https://developers.cloudflare.com/r2/reference/data-location/#available-hints.

For this sync I'm using the `aws-cli` and `azcopy` tools now installed on trusted agent since https://github.com/jenkins-infra/jenkins-infra/pull/3099

For `aws-cli`, it's using a non default `updates-jenkins-io` profile, stored in `/home/jenkins/.aws` on the agent.

For `azcopy`, it's using an account SAS token, stored manually as global credentials on trusted.ci.jenkins.io.
We're not reusing blobxfer, which authenticates with a global storage account access key, less secure than the SAS token which is restricted to a specific file share, and later only on the agent IP address. (IP restriction disabled for now, will be restored later with the workaround mentioned in https://github.com/jenkins-infra/azure/pull/496)

Test job, using a copy of the content of updates.jenkins.io instead of running generate.sh script as we don't have access in this test to the 400Go cache folder:
https://trusted.ci.jenkins.io:1443/job/update_center_test_lemeurherve_helpdesk2649/job/test-update-center-pr-745/

If this sync works as expected, the previous one in the script targeting the current VM will be removed, as the flag mechanism used to optionally sync azure.updates.jenkins.io.

Ref: https://github.com/jenkins-infra/helpdesk/issues/2649