### PR TITLE
Use public URLs for suspension reasoning

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -128,7 +128,7 @@ javanet-uploader = https://wiki.jenkins-ci.org/display/JENKINS/java.net+uploader
 jbehave-hudson-plugin            # renamed to jbehave-jenkins-plugin
 jenkins-leiningen                # renamed to leiningen-plugin :'(
 # deleted by maintainers
-jenkins-tracker = https://issues.jenkins.io/browse/INFRA-1531
+jenkins-tracker = https://github.com/jenkins-infra/helpdesk/issues/1262
 jenkinswalldisplay-pom           # renamed to jenkinswalldisplay
 # unmaintained
 jenkow-activiti-designer = https://wiki.jenkins-ci.org/display/JENKINS/Jenkow+Activiti+Designer
@@ -212,7 +212,7 @@ schedule-failed-builds = https://wiki.jenkins-ci.org/display/JENKINS/Retry+Faile
 # deprecated
 scis-ad = https://github.com/jenkins-infra/update-center2/commit/5f3f5ae66ea0e819c27d6d1fed9fdb00781f636c
 # renamed shortly after publication for https://github.com/jenkins-infra/repository-permissions-updater/pull/459#issuecomment-334702817
-scm-branch-pr-filter = https://issues.jenkins.io/browse/INFRA-1358
+scm-branch-pr-filter = https://github.com/jenkins-infra/helpdesk/issues/1106
 script-realm-extended            # fork of a plugin and has since been subsumed -- https://wiki.jenkins-ci.org/display/JENKINS/Script+Security+Realm+Extended
 # plugin obsolete, replaced by Gradle-based invocation; depublishing as requested by 'silk' in SECURITY-1521
 SCTMExecutor = https://github.com/jenkins-infra/update-center2/pull/324
@@ -659,27 +659,27 @@ nerrvana
 persona = https://www.jenkins.io/security/plugins/#suspensions
 
 # Non-open dependency, see INFRA-2751
-tfs = https://issues.jenkins.io/browse/INFRA-2751
+tfs = https://github.com/jenkins-infra/helpdesk/issues/2319
 
 # INFRA-2487 -- suspend analysis-core and all plugins with a non-optional dependency on it
-analysis-collector = https://issues.jenkins.io/browse/INFRA-2487
-analysis-core = https://issues.jenkins.io/browse/INFRA-2487
-android-lint = https://issues.jenkins.io/browse/INFRA-2487
-ccm = https://issues.jenkins.io/browse/INFRA-2487
-CFLint = https://issues.jenkins.io/browse/INFRA-2487
-checkstyle = https://issues.jenkins.io/browse/INFRA-2487
-ci-game = https://issues.jenkins.io/browse/INFRA-2487
-codeclimate-plugin = https://issues.jenkins.io/browse/INFRA-2487
-codescanner = https://issues.jenkins.io/browse/INFRA-2487
-cpptest = https://issues.jenkins.io/browse/INFRA-2487
-DotCi-Plugins-Starter-Pack = https://issues.jenkins.io/browse/INFRA-2487
-dry = https://issues.jenkins.io/browse/INFRA-2487
-findbugs = https://issues.jenkins.io/browse/INFRA-2487
-php = https://issues.jenkins.io/browse/INFRA-2487
-pmd = https://issues.jenkins.io/browse/INFRA-2487
-swamp = https://issues.jenkins.io/browse/INFRA-2487
-tasks = https://issues.jenkins.io/browse/INFRA-2487
-warnings = https://issues.jenkins.io/browse/INFRA-2487
+analysis-collector = https://github.com/jenkins-infra/helpdesk/issues/2089
+analysis-core = https://github.com/jenkins-infra/helpdesk/issues/2089
+android-lint = https://github.com/jenkins-infra/helpdesk/issues/2089
+ccm = https://github.com/jenkins-infra/helpdesk/issues/2089
+CFLint = https://github.com/jenkins-infra/helpdesk/issues/2089
+checkstyle = https://github.com/jenkins-infra/helpdesk/issues/2089
+ci-game = https://github.com/jenkins-infra/helpdesk/issues/2089
+codeclimate-plugin = https://github.com/jenkins-infra/helpdesk/issues/2089
+codescanner = https://github.com/jenkins-infra/helpdesk/issues/2089
+cpptest = https://github.com/jenkins-infra/helpdesk/issues/2089
+DotCi-Plugins-Starter-Pack = https://github.com/jenkins-infra/helpdesk/issues/2089
+dry = https://github.com/jenkins-infra/helpdesk/issues/2089
+findbugs = https://github.com/jenkins-infra/helpdesk/issues/2089
+php = https://github.com/jenkins-infra/helpdesk/issues/2089
+pmd = https://github.com/jenkins-infra/helpdesk/issues/2089
+swamp = https://github.com/jenkins-infra/helpdesk/issues/2089
+tasks = https://github.com/jenkins-infra/helpdesk/issues/2089
+warnings = https://github.com/jenkins-infra/helpdesk/issues/2089
 # Functionality merged into warnings-ng to support INFRA-2487
 brakeman = https://github.com/jenkinsci/brakeman-plugin/issues/23
 


### PR DESCRIPTION
The INFRA- tickets were moved to GitHub, trying to access them leads to Jira login page.