### PR TITLE
[SECURITY-1025] Remove warning from batch-task

### DIFF
--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -10557,8 +10557,8 @@
     "url": "https://www.jenkins.io/security/advisory/2022-01-12/#SECURITY-1025",
     "versions": [
       {
-        "lastVersion": "1.19",
-        "pattern": ".*"
+        "lastVersion": "1.398.v550a_8e8ca_e5f",
+        "pattern": "(1[.][0-9]|1[.]1[0-9])(|[.-].+)"
       }
     ]
   },

--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -10557,8 +10557,8 @@
     "url": "https://www.jenkins.io/security/advisory/2022-01-12/#SECURITY-1025",
     "versions": [
       {
-        "lastVersion": "1.398.v550a_8e8ca_e5f",
-        "pattern": "(1[.][0-9]|1[.]1[0-9])(|[.-].+)"
+        "lastVersion": "1.19",
+        "pattern": "(1[.]1[5-9])(|[.-].+)"
       }
     ]
   },


### PR DESCRIPTION
The issue https://issues.jenkins.io/browse/SECURITY-1025

The release
* https://github.com/jenkinsci/batch-task-plugin/releases/tag/1.398.v550a_8e8ca_e5f
* https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/batch-task/1.398.v550a_8e8ca_e5f/