### PR TITLE
[JENKINS-72353] Ban build-pipeline-plugin 2.0.0

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -887,3 +887,8 @@ batch-task@1.16               # SECURITY-1025
 batch-task@1.17               # SECURITY-1025
 batch-task@1.18               # SECURITY-1025
 batch-task@1.19               # SECURITY-1025
+
+# Remove build-pipeline-plugin that incorrectly bundles Jenkins test harness
+# https://issues.jenkins.io/browse/JENKINS-72353 for the bug report
+# https://github.com/jenkinsci/build-pipeline-plugin/pull/131 for the fix
+build-pipeline-plugin@2.0.0


### PR DESCRIPTION
## Ban build-pipeline-plugin 2.0.0

[JENKINS-72353](https://issues.jenkins.io/browse/JENKINS-72353) reports that build pipeline plugin 2.0.0 generates stack traces into the Jenkins log because it incorrectly bundles the Jenkins test harness as a compile time dependency.

[PR 131](https://github.com/jenkinsci/build-pipeline-plugin/pull/131) fixes the dependency.

I'm not entirely sure that this is a severe enough error to ban the plugin version from distribution, especially since I am hopeful that @dalvizu will deliver a 2.0.1 release very quickly.

I'm proposing this ban in case there is a delay in delivering the 2.0.1 release or in case the repeated stack traces are severe enough to justify banning the plugin.

@daniel-beck can you offer guidance on this type of issue?  Should this be enough to ban the specific plugin release?
