### PR TITLE
Deprecate scp plugin

### DIFF
--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -25,6 +25,7 @@ openshift-deployer = https://www.jenkins.io/blog/2021/11/09/guava-upgrade/
 performance-signature-dynatrace = https://github.com/jenkins-infra/update-center2/pull/531
 relution-publisher = https://www.jenkins.io/blog/2021/11/09/guava-upgrade/
 scm-httpclient = https://www.jenkins.io/blog/2021/11/09/guava-upgrade/
+scp = https://github.com/jenkinsci/scp-plugin/blob/master/README.md
 sicci_for_xcode = https://github.com/jenkinsci/jenkins/pull/5560
 slave-prerequisites = https://github.com/jenkinsci/jenkins/pull/5526
 synergy = https://github.com/jenkinsci/jenkins/pull/5320


### PR DESCRIPTION
## Deprecate scp plugin

This plugin is deprecated due to open security vulnerabilities and readily available replacements provided with currently supported operating systems.

There are two open security vulnerabilities.  The plain text credentials storage security vulnerability was published in October 2017.  The CSRF vulnerability and missing permission check security vulnerability was published in February 2022.

The `scp` command is available on all the operating systems that Jenkins supports.  Unix variants include `scp` with the OpenSSH commands.  Windows includes `scp` with their port of OpenSSH.  The `withCredentials` Pipeline step supports ssh private keys so that users can more safely call `sh` steps that perform `scp` operations.

The plugin was last released in January 2011.  The last commit with any change to the plugin source code was in January 2014.

The last successful build on ci.jenkins.io was in September 2020.  The plugin does not build currently.

The following pull requests have been merged:

* [x] https://github.com/jenkins-infra/repository-permissions-updater/pull/3668
  Request to adopt the plugin so that the deprecation reason can be included in the plugin repository
* [x] https://github.com/jenkinsci/scp-plugin/pull/23
  README description of the reasons the plugin is deprecated
