### PR TITLE
Suspend distribution of Crowd2 plugin

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -402,6 +402,7 @@ uno-choice@1.5.3              # While we serve pre-2.7 update sites; depends on 
 # depends on scripttrigger
 xtrigger = https://www.jenkins.io/security/plugins/#suspensions
 
+
 # These plugins implement Groovy scripting in an unsafe way, but are currently unreleased -- so suspend preemptively
 groovy-choice-parameter
 groovy-script-scheduler


### PR DESCRIPTION
## Suspend distribution of Crowd2 plugin

https://github.com/jenkins-infra/helpdesk/issues/3854 explains that the Crowd2 integration plugin uses a dependency that is not open source licensed.

The Crowd2 integration library is Atlassian licensed as described in https://github.com/jenkins-infra/helpdesk/issues/3842#issuecomment-1847559631

The Atlassian license is not an open source license.  Refer to https://www.atlassian.com/legal/software-license-agreement for the details of the license.

https://www.jenkins.io/project/governance/#license says that the Jenkins project requires plugins that it distributes to be open source, including their dependencies.  When a closed source dependency is detected in a plugin, we suspend distribution of that plugin.  If maintainers update the plugin to remove the closed source dependency, distribution can begin for the new release that removes the closed source dependency.

Fixes https://github.com/jenkins-infra/helpdesk/issues/3854
