### PR TITLE
Suspend distribution of Confluence publisher plugin

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -895,3 +895,6 @@ batch-task@1.19               # SECURITY-1025
 #   https://github.com/jenkins-infra/helpdesk/issues/3842#issuecomment-1847399101
 #   https://github.com/jenkins-infra/helpdesk/issues/3842#issuecomment-1847559631
 crowd2 = https://github.com/jenkins-infra/helpdesk/issues/3854
+
+# Non-open source dependency
+confluence-publisher = https://github.com/jenkins-infra/helpdesk/issues/3856


### PR DESCRIPTION
## Suspend distribution of Confluence publisher plugin

https://github.com/jenkins-infra/helpdesk/issues/3856 explains that the Confluence publisher plugin uses a dependency that is not open source licensed.

The Confluence publisher libraries are Atlassian licensed including:

* com.atlassian.confluence:confluence-java-api:7.14.0
* com.atlassian.confluence:confluence-rest-client:7.14.0
* com.atlassian.confluence:confluence-rest-serialization:7.14.0
* com.atlassian.confluence:confluence-rest-api:7.14.0

The Atlassian license is not an open source license.  Refer to https://www.atlassian.com/legal/software-license-agreement for the details of the license.

https://www.jenkins.io/project/governance/#license says that the Jenkins project requires plugins that it distributes to be open source, including their dependencies.  When a closed source dependency is detected in a plugin, we suspend distribution of that plugin.  If maintainers update the plugin to remove the closed source dependency, distribution can begin for the new release that removes the closed source dependency.

Fixes https://github.com/jenkins-infra/helpdesk/issues/3856
