### PR TITLE
Removal of database-drizzle

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -74,7 +74,7 @@ copyarchiver = https://wiki.jenkins-ci.org/display/JENKINS/CopyArchiver+Plugin
 # Incompatible with Hudson 1.355+ and superseded by xUnit Plugin
 cppunit = https://wiki.jenkins-ci.org/display/JENKINS/CppUnit+Plugin
 create-fingerprint-plugin        # renamed to create-fingerprint
-database-drizzle                 # service discontinued
+database-drizzle = https://github.com/jenkins-infra/update-center2/pull/757
 datadog-build-reporter           # renamed to datadog
 delphix-plugin                   # renamed to delphix
 description-column               # renamed to description-column-plugin

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -74,6 +74,7 @@ copyarchiver = https://wiki.jenkins-ci.org/display/JENKINS/CopyArchiver+Plugin
 # Incompatible with Hudson 1.355+ and superseded by xUnit Plugin
 cppunit = https://wiki.jenkins-ci.org/display/JENKINS/CppUnit+Plugin
 create-fingerprint-plugin        # renamed to create-fingerprint
+database-drizzle                 # service discontinued
 datadog-build-reporter           # renamed to datadog
 delphix-plugin                   # renamed to delphix
 description-column               # renamed to description-column-plugin


### PR DESCRIPTION
Database is discontinued since more than 10 years.

https://dbdb.io/db/drizzle

I don't see any point to keep it on the list of database plugins.

https://github.com/jenkinsci/database-drizzle-plugin

I can also submit an helpdesk ticket to archive the repo