### PR TITLE
Deprecate `plasticscm-mergebot` in artifact-ignores.properties

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -190,6 +190,8 @@ PerfPublisher                    # latest releases use "perfpublisher"
 pipeline-classpath = https://www.jenkins.io/security/plugins/#suspensions
 # Removed by author
 pipeline-editor = https://github.com/jenkinsci/pipeline-editor-plugin
+# Functionality ported to https://github.com/jenkinsci/plasticscm-plugin
+plasticscm-mergebot = https://github.com/jenkinsci/plasticscm-mergebot-plugin/pull/6
 # renamed to poll-mailbox-trigger-plugin
 poll-mailbox-trigger = https://github.com/jenkins-infra/update-center2/pull/42
 # discontinued PoC, use Pretested Integration Plugin instead


### PR DESCRIPTION
This PR removes `plasticscm-mergebot` (https://github.com/jenkinsci/plasticscm-mergebot-plugin) from the update center. The plugin is now deprecated https://github.com/jenkinsci/plasticscm-mergebot-plugin/pull/6 and its functionality is merged into https://github.com/jenkinsci/plasticscm-plugin.