### PR TITLE
[SECURITY-2716] Update warning range as the fix went into 0.0.8

### DIFF
--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -12620,7 +12620,7 @@
     "versions": [
       {
         "lastVersion": "0.0.7",
-        "pattern": ".*"
+        "pattern": "(0[.]0[.][0-7])"
       }
     ]
   },


### PR DESCRIPTION
Try to remove warning.

https://issues.jenkins.io/browse/JENKINS-69980