### PR TITLE
Delete/Ignore version 24.1 of the hpaat plugin

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -287,6 +287,7 @@ google-compute-engine@3.1.0                      # Github issue #85 - Regression
 build-name-setter-plugin@2.0.0           # breaks builds when using with build-user-vars-plugin https://github.com/jenkinsci/build-name-setter-plugin/issues/39
 hp-application-automation-tools-plugin@6.0.1-beta  	 # unexpected release version - latest release is 5.9
 ibm-application-security@1.2.7    # Bug that breaks existing jobs from previous versions
+hp-application-automation-tools-plugin@24.1  	 # unexpected release version - latest release is 23.4
 
 # rogue releases with unknown source
 ez-templates@1.0.0


### PR DESCRIPTION
Hello!

We accidentally released the [24.1 version](https://repo.jenkins-ci.org/ui/repos/tree/General/releases/org/jenkins-ci/plugins/hp-application-automation-tools-plugin/24.1/hp-application-automation-tools-plugin-24.1.jar?clearFilter=true) of the [plugin](https://plugins.jenkins.io/hp-application-automation-tools-plugin) too early, while trying to do a dry run.

We would like this version to be removed or at least not to be available for use.
On the 12th of march we will need to release the same version of the plugin -- 24.1. Can this be done, since here it will be ignored? Or we will have to make the release with a new version?

Thank you!
