### PR TITLE
Suspend 3.0.x and 3.1.x delphix plugin versions

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -882,6 +882,15 @@ delphix@2.0.2
 delphix@2.0.3
 delphix@2.0.4
 
+# Non-open source dependency
+# https://github.com/jenkins-infra/helpdesk/issues/3989
+delphix@3.0.0
+delphix@3.0.1
+delphix@3.0.2
+delphix@3.0.3
+delphix@3.1.0
+delphix@3.1.1
+
 # Dependency nexus-platform-api has a proprietary license, helpdesk#3742
 nexus-jenkins-plugin = https://github.com/jenkins-infra/helpdesk/issues/3742
 


### PR DESCRIPTION
https://github.com/jenkins-infra/helpdesk/issues/3989 describes the situation.  The license of the relevant library was changed for the version that is included in the delphix plugin 3.2.0.
