### PR TITLE
hotfix(publish) change the SSH/rsync user for connecting to the `pkg` VM (`updates.jenkins.io` and `pkg.origin.jenkins.io`)

### DIFF
--- a/site/publish.sh
+++ b/site/publish.sh
@@ -5,7 +5,7 @@
 
 # Used later for rsyncing updates
 UPDATES_SITE="updates.jenkins.io"
-RSYNC_USER="www-data"
+RSYNC_USER="mirrorbrain"
 
 # For syncing R2 buckets aws-cli is configured through environment variables (from Jenkins credentials)
 # https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html


### PR DESCRIPTION
This PR changes the SSH/Rsync user for `pkg.origin.jenkins.io` (`updates.jenkins.io`) to ensure we can only let `www-data` to read-only files (through group membership) on both `/srv/release/jenkins/**` and `/var/www/**`.

Note: the permanent agent of trusted.ci where this script runs is already setup to log-in as `mirrorbrain` user:

```
jenkins@agent:~$ ssh mirrorbrain@updates.jenkins.io echo Hello
Hello
```

Once this PR is merged, a manual operation to set up permissions properly is required.