### PR TITLE
chore: skip azcopy version check

### DIFF
--- a/site/publish.sh
+++ b/site/publish.sh
@@ -52,6 +52,7 @@ function parallelfunction() {
         fileShareUrl=$(get-fileshare-signed-url.sh)
         # Sync Azure File Share content using www3 to avoid symlinks
         time azcopy sync ./www3/ "${fileShareUrl}" \
+            --skip-version-check `# Do not check for new azcopy versions (we have updatecli for this)` \
             --recursive=true \
             --exclude-path="updates" `# populated by https://github.com/jenkins-infra/crawler` \
             --delete-destination=true


### PR DESCRIPTION
This PR skips azcopy version check which we don't care about as its version is tracked by updatecli.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414