### PR TITLE
SECURITY-3190 Remove warning from TAP

### DIFF
--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -17056,8 +17056,8 @@
     "url": "https://www.jenkins.io/security/advisory/2023-09-06/#SECURITY-3190",
     "versions": [
       {
-        "lastVersion": "2.3",
-        "pattern": ".*"
+        "lastVersion": "2.4.1",
+        "pattern": "(1|2[.][0-3]|2[.]4[.][01])(|[.-].+)"
       }
     ]
   },


### PR DESCRIPTION
This was corrected by https://github.com/jenkinsci/tap-plugin/pull/37 and was released in v2.4.2