### PR TITLE
Suspend obsolete plugins

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -225,7 +225,7 @@ security-no-captcha              # Functionality integrated in Jenkins 1.416 -- 
 serenitec                        # gbossert asked to remove this plugin
 # superseded by envinject
 setenv = https://wiki.jenkins-ci.org/display/JENKINS/Setenv+Plugin
-sladiator-notifier
+sladiator-notifier = https://github.com/jenkins-infra/update-center2/pull/775
 skytap-cloud-plugin              # renamed to skytap
 sms-notification                 # renamed to sms
 # superseded by sonargraph-integration --

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -92,6 +92,7 @@ evergreen                        # not supposed to be installed manually. We use
 external-scheduler = https://github.com/jenkins-infra/update-center2/pull/257
 fabric-beta-publisher = https://github.com/jenkinsci/fabric-beta-publisher-plugin#deprecation-notice
 first-plugin                     # INFRA-1108: Unintended release as part of a plugin tutorial workshop
+flexteam = https://github.com/jenkins-infra/update-center2/pull/775
 foofoo                           # junk: contains only the HelloWorldBuilder sample
 foreman-node-sharing             # Reimplemented as https://github.com/jenkinsci/node-sharing-plugin/
 # superseded by Gerrit Trigger Plugin

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -77,6 +77,7 @@ create-fingerprint-plugin        # renamed to create-fingerprint
 database-drizzle = https://github.com/jenkins-infra/update-center2/pull/757
 datadog-build-reporter           # renamed to datadog
 delphix-plugin                   # renamed to delphix
+delta-cloud = https://github.com/jenkins-infra/update-center2/pull/775
 description-column               # renamed to description-column-plugin
 discobit-autoconfig = https://github.com/jenkins-infra/update-center2/pull/587
 # removal requested by teilo, superceded by dockerhub-notification

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -225,6 +225,7 @@ security-no-captcha              # Functionality integrated in Jenkins 1.416 -- 
 serenitec                        # gbossert asked to remove this plugin
 # superseded by envinject
 setenv = https://wiki.jenkins-ci.org/display/JENKINS/Setenv+Plugin
+sladiator-notifier
 skytap-cloud-plugin              # renamed to skytap
 sms-notification                 # renamed to sms
 # superseded by sonargraph-integration --


### PR DESCRIPTION
* SLAdiator: Website of the service is dead, [last website snapshot](https://web.archive.org/web/20170331010759/https://sladiator.com/) 2017 [last tweet](https://twitter.com/sladiator) in 2013
* Flexteam: has no functionality, consists of [only one empty source file](https://github.com/jenkinsci/flexteam-plugin/blob/master/src/main/java/org/jvnet/hudson/plugins/flexteam/SidebarAction.java)
* Delta Cloud -- service retired in 2015 https://deltacloud.apache.org/