### PR TITLE
chore(publish.sh) set up `httpd` fallback redirection to mirrors [new UC]

### DIFF
--- a/site/publish.sh
+++ b/site/publish.sh
@@ -117,6 +117,12 @@ then
         --exclude='updates' `# Exclude ALL 'updates' directories, not only the root /updates (because symlink dereferencing create additional directories` \
         ./www2/ ./www3/
 
+    # Append the httpd -> mirrorbits redirection as fallback (end of htaccess file) for www3 only
+    mirrorbits_hostname='mirrors.updates.jenkins.io'
+    echo '' >> ./www3/.htaccess
+    echo "## Fallback: if not rules match then redirect to ${mirrorbits_hostname}" >> ./www3/.htaccess
+    echo "RewriteRule ^.* https://${mirrorbits_hostname}%{REQUEST_URI}? [NC,L,R=307]" >> ./www3/.htaccess
+
     # Add File Share sync to the tasks
     tasks+=('azsync')
 


### PR DESCRIPTION
This PR ensures that the infra custom redirection described in https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2075467628 is appended **only** for the new Update Center's  (Azure + mirrorbits) `.htaccess` (`www3`).

The "current" (AWS + `pkg` VM) Update Center must not have this change (`www2`).
