### PR TITLE
feat(publish.sh): use dedicated source folder for httpd service including only .htaccess files

### DIFF
--- a/site/publish.sh
+++ b/site/publish.sh
@@ -6,7 +6,7 @@
 # - [mandatory] UPDATE_CENTER_FILESHARES_ENV_FILES (directory path): directory containing environment files to be sources for each sync. destination.
 #     Each task named XX expects a file named 'env-XX' in this directory to be sourced by the script to retrieve settings for the task.
 RUN_STAGES="${RUN_STAGES:-generate-site|sync-plugins|sync-uc}"
-SYNC_UC_TASKS="${SYNC_UC_TASKS:-rsync-updates.jenkins.io|azsync-content|s3sync-westeurope|s3sync-eastamerica}"
+SYNC_UC_TASKS="${SYNC_UC_TASKS:-rsync-updates.jenkins.io|azsync-content|azsync-redirections|s3sync-westeurope|s3sync-eastamerica}"
 
 # Split strings to arrays for feature flags setup
 run_stages=()


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/2649

Blocked by https://github.com/jenkins-infra/pipeline-library/pull/854

This PR allows using a dedicated volume for httpd service:
- separated `www-content` & `www-redirections` sources created with a filtered rsync copy from `www2`
- including only the .htaccess files to avoid serving any file from it
- on its own `updates-jenkins-io-httpd` file share, in the same storage account as `updates-jenkins-io` file share used for mirrorbits service
- cherry-picked commit from #776 to allow patching only content in `www-redirections`
  - we might need to patch all .htaccess and not only the one at the root, TBD
- mirrorbits and R2 buckets use `www-content` which doesn't contain any .htaccess file as they don't need/can't use/shouldn't have access to them

It will requires some job config changes: new file share service principal credentials on trusted, and adapt some variable names of the existing one.

Will prepare something to try out in our dedicated test folder https://trusted.ci.jenkins.io:1443/job/update_center_test_lemeurherve_helpdesk2649/, I'll let you know before doing anything on trusted.ci.jenkins.io

WIP in draft to share what I'm working on, not for immediate review.