### PR TITLE
Remove datadog@7.0.0 plugin from distribution due to regression

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -291,6 +291,7 @@ build-name-setter-plugin@2.0.0           # breaks builds when using with build-u
 hp-application-automation-tools-plugin@6.0.1-beta  	 # unexpected release version - latest release is 5.9
 ibm-application-security@1.2.7    # Bug that breaks existing jobs from previous versions
 hp-application-automation-tools-plugin@24.1  	 # unexpected release version - latest release is 23.4
+datadog@7.0.0                                    # regression: https://github.com/jenkins-infra/helpdesk/issues/4080
 
 # rogue releases with unknown source
 ez-templates@1.0.0


### PR DESCRIPTION
The 7.0.0 release of the [Datadog plugin](https://github.com/jenkinsci/datadog-plugin) introduced a [major regression](https://github.com/jenkinsci/datadog-plugin/issues/423) and needs to be removed from the Update Center's output