### PR TITLE
deprecating perfecto plugin

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -184,9 +184,10 @@ paaslane                         # renamed to paaslane-estimate
 # renamed to extended-security-settings
 paranoia = https://github.com/jenkins-infra/update-center2/pull/291
 pathignore-plugin                # renamed to pathignore
-# plugin obsolete, replaced by https://plugins.jenkins.io/perfecto/
+# plugin obsolete
 perfectomobile = https://developers.perfectomobile.com/display/PD/Legacy+%7C+Jenkins+plugin
 perfectomobile-jenkins           # renamed to perfectomobile
+perfecto = https://help.perfecto.io/perfecto-help/content/perfecto/integrations/jenkins_plugin.htm#
 PerfPublisher                    # latest releases use "perfpublisher"
 # https://jenkins.io/security/advisory/2017-03-20
 pipeline-classpath = https://www.jenkins.io/security/plugins/#suspensions


### PR DESCRIPTION
More info: https://help.perfecto.io/perfecto-help/content/perfecto/integrations/jenkins_plugin.htm#

Important: As of May 24, 2024, the Perfecto Jenkins plugin will be deprecated. Current plugin installations will continue to work, but going forward, Perfecto will no longer provide bug fixes and maintenance services for this plugin. As an alternative, you can create a Jenkins pipeline with Perfecto Connect. To learn more, see [Jenkins plugin](https://help.perfecto.io/perfecto-help/content/perfecto/integrations/jenkins_plugin.htm#) > Step-by-step instructions > 4 | Work with Advanced usage scenarios > Create a Perfecto Connect pipeline.