### PR TITLE
Last Version was missing

### DIFF
--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -4139,6 +4139,7 @@
     "url": "https://jenkins.io/security/advisory/2019-04-03/#SECURITY-832",
     "versions": [
       {
+        "lastVersion": "1.13",
         "pattern": "1(|[.-].+)"
       }
     ]


### PR DESCRIPTION
This vulnerability was fixed with v2.0 a long time ago, but when updating warnings, we forgot to add the latest affected version.