### PR TITLE
fix(publish/new UC httpd) use a `RedirectMatch` instead of `RewriteRule` for Apache2 redirection fallback

### DIFF
--- a/site/publish.sh
+++ b/site/publish.sh
@@ -157,7 +157,6 @@ then
     {
         echo ''
         echo "## Fallback: if not rules match then redirect to ${mirrorbits_hostname}"
-        echo "RewriteRule ^.* https://${mirrorbits_hostname}%{REQUEST_URI}? [NC,L,R=307]"
         echo 'RedirectMatch 307 (.*)$ https://'"${mirrorbits_hostname}"'$1'
     } >> ./www-redirections/.htaccess
 

--- a/site/publish.sh
+++ b/site/publish.sh
@@ -158,6 +158,7 @@ then
         echo ''
         echo "## Fallback: if not rules match then redirect to ${mirrorbits_hostname}"
         echo "RewriteRule ^.* https://${mirrorbits_hostname}%{REQUEST_URI}? [NC,L,R=307]"
+        echo 'RedirectMatch 307 (.*)$ https://'"${mirrorbits_hostname}"'$1'
     } >> ./www-redirections/.htaccess
 
     echo '----------------------- Launch synchronisation(s) -----------------------'


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2248481608

This PR is scoped to the new Update Center and fixes the fallback redirection in its httpd component.

The goal of this fallback redirection is to catch any request not meeting the other rewrite rules and redirections and to trigger a redirect to the mirror system (as the file are not served by Apache but by a mirror in the new UC).

Rationale: the Apache `RedirectMatch` directives are processed after all the `RewriteRule`. As such, we want to be sure the fallback has the least priority.

Tested locally with the script from https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2252877808

**Before**

```shell
./.tmp/uc-test.sh http://test.updates.jenkins.io:8080 
= Testing UC behavior on host http://test.updates.jenkins.io:8080...
=> The original URL http://test.updates.jenkins.io:8080/latest/zos-connector.hpi...
... redirects to http://test.updates.jenkins.io:8080/download/plugins/zos-connector/3.281.vb_03b_09a_7ec78/zos-connector.hpi
... returns HTTP/404 if following redirections

=> The original URL http://test.updates.jenkins.io:8080/download/plugins/zos-connector/3.257.v41e144167971/zos-connector.hpi...
... redirects to https://mirrors.updates.jenkins.io/download/plugins/zos-connector/3.257.v41e144167971/zos-connector.hpi
... returns HTTP/404 if following redirections

=> The original URL http://test.updates.jenkins.io:8080/update-center.json?id=default&version=2.426.3...
... redirects to http://test.updates.jenkins.io:8080/dynamic-stable-2.426.3/update-center.json
... returns HTTP/200 if following redirections

=> The original URL http://test.updates.jenkins.io:8080/update-center.json...
... redirects to http://test.updates.jenkins.io:8080/current/update-center.json
... returns HTTP/200 if following redirections

=> The original URL http://test.updates.jenkins.io:8080/current/update-center.json...
... redirects to https://mirrors.updates.jenkins.io/current/update-center.json
... returns HTTP/200 if following redirections
```

**After**

```shell
./.tmp/uc-test.sh http://test.updates.jenkins.io:8080
= Testing UC behavior on host http://test.updates.jenkins.io:8080...
=> The original URL http://test.updates.jenkins.io:8080/latest/zos-connector.hpi...
... redirects to http://test.updates.jenkins.io:8080/download/plugins/zos-connector/3.281.vb_03b_09a_7ec78/zos-connector.hpi
... returns HTTP/200 if following redirections

=> The original URL http://test.updates.jenkins.io:8080/download/plugins/zos-connector/3.257.v41e144167971/zos-connector.hpi...
... redirects to https://get.jenkins.io/plugins/zos-connector/3.257.v41e144167971/zos-connector.hpi
... returns HTTP/200 if following redirections

=> The original URL http://test.updates.jenkins.io:8080/update-center.json?id=default&version=2.426.3...
... redirects to http://test.updates.jenkins.io:8080/dynamic-stable-2.426.3/update-center.json
... returns HTTP/200 if following redirections

=> The original URL http://test.updates.jenkins.io:8080/update-center.json...
... redirects to http://test.updates.jenkins.io:8080/current/update-center.json
... returns HTTP/200 if following redirections

=> The original URL http://test.updates.jenkins.io:8080/current/update-center.json...
... redirects to https://mirrors.updates.jenkins.io/current/update-center.json
... returns HTTP/200 if following redirections
```