### PR TITLE
Suspend windows-slaves and multi-slave-config plugins

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -164,6 +164,9 @@ mber                             # service discontinued -- https://wiki.jenkins.
 # superseded by Relution Publisher
 mcap-eas-plugin = https://github.com/mwaylabs/jenkins-mcap-eas-plugin
 mogotest                         # deprecated: mogotest service no longer exists
+# Windows DCOM as used by this plugin is blocked by Microsoft security from CVE-2021-26414
+# Depends on the windows-slaves plugin that is also suspended
+multi-slave-config = https://github.com/jenkins-infra/helpdesk/issues/4221#issuecomment-2277844595
 # service discontinued
 mypeople = https://wiki.jenkins-ci.org/display/JENKINS/MyPeople+Plugin
 # service discontinued
@@ -258,6 +261,8 @@ vagrant-plugin                    # renamed to vagrant, herpderp
 vessel = https://groups.google.com/d/msg/jenkinsci-dev/L34eAMMWA5o/-AxtRdGsAAAJ
 weibo4jenkins                    # renamed to weibo
 whitesource = https://docs.mend.io/bundle/unified_agent/page/jenkins_plugin.html
+# Windows DCOM as used by this plugin is blocked by Microsoft security from CVE-2021-26414
+windows-slaves = https://github.com/jenkinsci/windows-slaves-plugin?tab=readme-ov-file#notice-of-deprecation
 wsnotifier                       # renamed to websocket
 # renamed to xltestview-plugin
 xltest-plugin = https://github.com/jenkinsci/xltestview-plugin/commit/ea034f9929b520e63b9ce15aed9bdb62354146cf


### PR DESCRIPTION
## Suspend windows-slaves and multi-slave-config plugins

We suspend distribution of plugins that depend on a service that no longer exists or is end of life like:

* https://github.com/jenkins-infra/update-center2/pull/732
* https://github.com/jenkins-infra/update-center2/pull/708
* https://github.com/jenkins-infra/update-center2/pull/676
* https://github.com/jenkins-infra/update-center2/pull/587

This is a similar case to services that are end of life.  Windows is not end of life, but the services required for this plugin have been end of life since at least March 2023. The plugin was deprecated as noted in [README](https://github.com/jenkinsci/windows-slaves-plugin?tab=readme-ov-file#notice-of-deprecation) almost two years ago in [November 2022](https://github.com/jenkinsci/windows-slaves-plugin/commit/cdafd13807267b535b13bbb25d9cc72376aa4594).

The [plugin installation statistics](https://stats.jenkins.io/pluginversions/windows-slaves.html) show that there are still almost 80,000 installations of the plugin, but only 22% of those installations are on 2.426.3 or newer.  Most installations of the plugin are not upgrading their Jenkins controller version.

Users with the plugin already installed will not be affected by distribution being suspended.  Users with configuration as code definitions that include the plugin will need to remove it from their configuration as code definition.  They will receive an error message when they attempt to download the plugin version.

Implied dependencies on the plugin were removed from [Jenkins 2.386](https://www.jenkins.io/changelog/2.386/) (10 Jan 2023)

* https://github.com/jenkinsci/jenkins/pull/7568

The plugin was removed from the setup wizard in [Jenkins 2.379](https://www.jenkins.io/changelog/2.379/) (22 Nov 2022)

* https://github.com/jenkinsci/jenkins/pull/7414

Fixes https://github.com/jenkins-infra/helpdesk/issues/4221

The multi-slave-config plugin has additional reasons why its distribution should be suspended.  It uses Prototype.js and so is not usable with current Jenkins releases.  It uses the YahooUI JavaScript library and so will not be usable with upcoming Jenkins versions that will remove the YahooUI JavaScript library.  It does not have an active maintainer and was last released 10 years ago.  It has [less than 1000 installations](https://stats.jenkins.io/pluginversions/multi-slave-config-plugin.html).