### PR TITLE
chore(publish.sh) ensure mirror pod retrieval only check Running pods

### DIFF
--- a/site/publish.sh
+++ b/site/publish.sh
@@ -172,6 +172,6 @@ then
     mirrorbits_namespace='updates-jenkins-io'
 
     # Requires a valid kubernetes credential file at $KUBECONFIG or $HOME/.kube/config by default
-    pod_name="$(kubectl --namespace="${mirrorbits_namespace}" --no-headers=true get pod --output=name | grep mirrorbits | head -n1)"
+    pod_name="$(kubectl --namespace="${mirrorbits_namespace}" --no-headers=true get pod --output=name --field-selector=status.phase==Running | grep mirrorbits | head -n1)"
     kubectl --namespace="${mirrorbits_namespace}" --container=mirrorbits exec "${pod_name}" -- mirrorbits scan -all -enable -timeout=120
 fi


### PR DESCRIPTION
This is a minor PR on the `publish` script related to https://github.com/jenkins-infra/helpdesk/issues/2649

The goal is to avoid errors during the trusted.ci publication while a new release of the helm chart `updates-jenkins-io` is deploying.

I had the issue twice which made the update-center job failing twice: it should not have failed as there were running pods during the rollout.


Should not need any tests on the UC itself; just merge it and I'll check the next builds. For the sake of saefty, here are the commands tested with a local connection to the production cluster:

```shell
$ mirrorbits_namespace='updates-jenkins-io'

$ kubectl --namespace="${mirrorbits_namespace}" --no-headers=true get pod --output=name
pod/updates-jenkins-io-httpd-ffd6998bf-hrggk
pod/updates-jenkins-io-httpd-ffd6998bf-p8hjb
pod/updates-jenkins-io-mirrorbits-5b9fd8f6d4-qhzkh
pod/updates-jenkins-io-mirrorbits-5b9fd8f6d4-tgtwb
pod/updates-jenkins-io-rsyncd-6b7465ff45-j6xtf

$ kubectl --namespace="${mirrorbits_namespace}" --no-headers=true get pod --output=name --field-selector=status.phase==Running
pod/updates-jenkins-io-httpd-ffd6998bf-hrggk
pod/updates-jenkins-io-httpd-ffd6998bf-p8hjb
pod/updates-jenkins-io-mirrorbits-5b9fd8f6d4-qhzkh
pod/updates-jenkins-io-mirrorbits-5b9fd8f6d4-tgtwb
pod/updates-jenkins-io-rsyncd-6b7465ff45-j6xtf

$ kubectl --namespace="${mirrorbits_namespace}" --no-headers=true get pod --output=name | grep mirrorbits | head -n1          
pod/updates-jenkins-io-mirrorbits-5b9fd8f6d4-qhzkh

$ kubectl --namespace="${mirrorbits_namespace}" --no-headers=true get pod --output=name --field-selector=status.phase==Running | grep mirrorbits | head -n1
pod/updates-jenkins-io-mirrorbits-5b9fd8f6d4-qhzkh
```

