### PR TITLE
hotfix(publish) avoid publication failures by using the VM specific hostname

### DIFF
--- a/site/publish.sh
+++ b/site/publish.sh
@@ -30,7 +30,7 @@ fi
 
 if [[ "${run_stages[*]}" =~ 'sync-plugins' ]]
 then
-    UPDATES_SITE="updates.jenkins.io"
+    UPDATES_SITE="aws.updates.jenkins.io"
     RSYNC_USER="mirrorbrain"
 
     ## $download_dir folder processing


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2344340606

The new UC system (in azure) uses the ZIP credential with proper hostname/etc. for rsync (and others).
But the script still specifies (and need) to update the current UC system (in AWS).