### PR TITLE
cleanup(publish) remove deprecated azcopy sync redirection (replaced by "redirections-secured")

### DIFF
--- a/site/publish.sh
+++ b/site/publish.sh
@@ -6,8 +6,7 @@
 # - [mandatory] UPDATE_CENTER_FILESHARES_ENV_FILES (directory path): directory containing environment files to be sources for each sync. destination.
 #     Each task named XX expects a file named 'env-XX' in this directory to be sourced by the script to retrieve settings for the task.
 RUN_STAGES="${RUN_STAGES:-generate-site|sync-plugins|sync-uc}"
-# TODO: remove 'azsync-redirections' task once fully migrated to `azsync-redirections-(*)secured` tasks
-SYNC_UC_TASKS="${SYNC_UC_TASKS:-rsync-updates.jenkins.io|azsync-content|azsync-redirections|azsync-redirections-unsecured|azsync-redirections-secured|s3sync-westeurope|s3sync-eastamerica}"
+SYNC_UC_TASKS="${SYNC_UC_TASKS:-rsync-updates.jenkins.io|azsync-content|azsync-redirections-unsecured|azsync-redirections-secured|s3sync-westeurope|s3sync-eastamerica}"
 MIRRORBITS_HOST="${MIRRORBITS_HOST:-updates.jio-cli.trusted.ci.jenkins.io}"
 
 # Split strings to arrays for feature flags setup
@@ -141,7 +140,7 @@ then
 
     ## No need to remove the symlinks as the `azcopy sync` for symlinks is not yet supported and we use `--no-follow-symlinks` for `aws s3 sync`
     # Perform a copy with dereference symlink (object storage do not support symlinks)
-    rm -rf ./www-content/ ./www-redirections/ "${httpd_secured_dir}" "${httpd_unsecured_dir}" # Cleanup
+    rm -rf ./www-content/ "${httpd_secured_dir}" "${httpd_unsecured_dir}" # Cleanup
 
     # Prepare www-content, a copy of the $www2_dir dedicated to mirrorbits service, excluding every .htaccess files
     rsync --archive --verbose \
@@ -182,9 +181,6 @@ then
         # shellcheck disable=SC2016 # The $1 expansion is for RedirectMatch pattern, not shell
         echo 'RedirectMatch 307 (.*)$ http://'"${mirrorbits_hostname}"'$1'
     } >> "${httpd_unsecured_dir}"/.htaccess
-
-    # TODO: remove this line once fully migrated to `azsync-redirections-(*)secured` tasks
-    cp -r "${httpd_secured_dir}" ./www-redirections/
 
     echo '----------------------- Launch synchronisation(s) -----------------------'
     parallel --halt-on-error now,fail=1 parallelfunction ::: "${sync_uc_tasks[@]}"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2364054995

Since https://github.com/jenkins-infra/kubernetes-management/pull/5736, this file share is not used anymore