### PR TITLE
Suspend `shared-library-version-override`

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -914,3 +914,5 @@ crowd2 = https://github.com/jenkins-infra/helpdesk/issues/3854
 
 # Non-open source dependency
 confluence-publisher = https://github.com/jenkins-infra/helpdesk/issues/3856
+
+shared-library-version-override = https://github.com/jenkins-infra/update-center2/pull/802


### PR DESCRIPTION
https://github.com/jenkinsci/shared-library-version-override-plugin/blob/786074c9fce7adeaefcdf6b869304be19464c07b/src/main/java/io/jenkins/plugins/shared_library_version_override/FolderConfigurations.java#L78-L80 is unsafe. Since this plugin was first released only today, I propose we're suspend this plugin. Once this issue is resolved, we can restore distribution.

CC @c3p0-maif as maintainer
