### PR TITLE
chore(publish) trigger mirror scans of both instances

### DIFF
--- a/site/publish.sh
+++ b/site/publish.sh
@@ -189,7 +189,11 @@ then
     echo '============================ all parallel sync tasks done ============================'
 
     # Trigger a mirror scan on mirrorbits once all synchronized copies are finished
-    echo '== Triggering a mirror scan on mirrorbits...'
+    echo '== Triggering mirrors scans...'
     # MIRRORBITS_CLI_PASSWORD is a sensitive values (comes from encrypted credentials)
-    echo "${MIRRORBITS_CLI_PASSWORD}" | mirrorbits -h "${MIRRORBITS_HOST}" -a scan -all -enable -timeout=120
+    # 3390 is the port of the "secured" instance (HTTPS) while 3391 of the "unsecured" (HTTP) instance. It's the only difference.
+    for mirrorbits_cli_port in 3390 3391
+    do
+        echo "${MIRRORBITS_CLI_PASSWORD}" | mirrorbits -h "${MIRRORBITS_HOST}" -p "${mirrorbits_cli_port}" -a scan -all -enable -timeout=120
+    done
 fi


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2364054995

This PR adds a mirrors scan of the secondary mirrorbits instance to ensure everything is up to date and coherent once the publication finished.

The prerequisite https://github.com/jenkins-infra/kubernetes-management/pull/5756 has been deployed with success:

```shell
# From the agent
$ mirrorbits -h updates.jio-cli.trusted.ci.jenkins.io -p 3390 list
Please set the server password with the -P option.

$ mirrorbits -h updates.jio-cli.trusted.ci.jenkins.io -p 3391 list
Please set the server password with the -P option.
```

=> the 2 services are exposed and set up!


----

Note about the performances: I chose not to parallelize as first step. Optimization will have to come later.
The reason is that the switch to S3 copy with full checksum instead of size in https://github.com/jenkins-infra/update-center2/pull/797 did an an impact on the execution time which led us to increase the frequency from 5 to 10 min.

=> We'll have to work on optimization later, as such no need to try to be fancy for now.
