### PR TITLE
Republish `shared-library-version-override`

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -914,5 +914,3 @@ crowd2 = https://github.com/jenkins-infra/helpdesk/issues/3854
 
 # Non-open source dependency
 confluence-publisher = https://github.com/jenkins-infra/helpdesk/issues/3856
-
-shared-library-version-override = https://github.com/jenkins-infra/update-center2/pull/802


### PR DESCRIPTION
@c3p0-maif @daniel-beck 

Can you confirmed it's fixed by https://github.com/jenkinsci/shared-library-version-override-plugin/pull/7 on https://github.com/jenkinsci/shared-library-version-override-plugin/releases/tag/19.v3a_c975738d4a_