### PR TITLE
Revert "Suspend `shared-library-version-override`"

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -914,5 +914,3 @@ crowd2 = https://github.com/jenkins-infra/helpdesk/issues/3854
 
 # Non-open source dependency
 confluence-publisher = https://github.com/jenkins-infra/helpdesk/issues/3856
-
-shared-library-version-override = https://github.com/jenkins-infra/update-center2/pull/802

--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -1,5 +1,18 @@
 [
   {
+    "id": "SECURITY-3466",
+    "type": "plugin",
+    "name": "shared-library-version-override",
+    "message": "Script security sandbox bypass",
+    "url": "https://github.com/jenkins-infra/update-center2/pull/802",
+    "versions": [
+      {
+        "lastVersion": "17.v786074c9fce7 ",
+        "pattern": "(1[17])(|[.-].+)"
+      }
+    ]
+  },
+  {
     "id": "SECURITY-208",
     "type": "plugin",
     "name": "google-login",


### PR DESCRIPTION
Reverts jenkins-infra/update-center2#802

I am no longer able to reproduce the earlier problem in 19.v3a_c975738d4a_, so restoring distribution.