### PR TITLE
Deprecate and suspend `synopsys-sigma` plugin

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -914,3 +914,6 @@ crowd2 = https://github.com/jenkins-infra/helpdesk/issues/3854
 
 # Non-open source dependency
 confluence-publisher = https://github.com/jenkins-infra/helpdesk/issues/3856
+
+# Removing old plugin releases, replaced by black-duck-sigma
+synopsys-sigma = https://github.com/jenkinsci/synopsys-sigma-plugin/blob/master/README.md


### PR DESCRIPTION
Being replaced with a rebranded version that is now hosted at https://github.com/jenkinsci/black-duck-sigma-plugin