### PR TITLE
fix(site/htaccess) only use Apache `mod_rewrite` by replacing `RedirectMatch` by `RewriteRule` directives

### DIFF
--- a/site/generate-htaccess.sh
+++ b/site/generate-htaccess.sh
@@ -129,10 +129,10 @@ DirectoryIndex index.html
 # download/* directories contain virtual URL spaces for redirecting download traffic to mirrors.
 
 # 'latest' need special handling here since they're not getting mirrored properly to get.jenkins.io
-RedirectMatch 302 /download/war/latest/jenkins[.]war$ https://updates.jenkins.io/latest/jenkins.war
-RedirectMatch 302 /download/plugins/(.*)/latest/(.+)[.]hpi$ https://updates.jenkins.io/latest/\$2.hpi
+RewriteRule ^download/war/latest/jenkins[.]war$ https://updates.jenkins.io/latest/jenkins.war [NC,L,R=302]
+RewriteRule ^download/plugins/(.*)/latest/(.+)[.]hpi$ https://updates.jenkins.io/latest/\$2.hpi [NC,L,R=302]
 
-RedirectMatch 302 /download/war/([0-9]+[.][0-9]+[.][0-9]+/jenkins)[.]war$ https://get.jenkins.io/war-stable/\$1.war
-RedirectMatch 302 /download/war/(.+)[.]war$ https://get.jenkins.io/war/\$1.war
-RedirectMatch 302 /download/plugins/(.+)[.]hpi$ https://get.jenkins.io/plugins/\$1.hpi
+RewriteRule ^download/war/([0-9]+[.][0-9]+[.][0-9]+/jenkins)[.]war$ https://get.jenkins.io/war-stable/\$1.war [NC,L,R=302]
+RewriteRule ^download/war/(.+)[.]war$ https://get.jenkins.io/war/\$1.war [NC,L,R=302]
+RewriteRule ^download/plugins/(.+)[.]hpi$ https://get.jenkins.io/plugins/\$1.hpi [NC,L,R=302]
 EOF

--- a/site/test/test.sh
+++ b/site/test/test.sh
@@ -129,6 +129,11 @@ test_redirect "$TEST_BASE_URL/download/war/latest/jenkins.war" "https://updates.
 test_redirect "$TEST_BASE_URL/download/plugins/git/latest/git.hpi" "https://updates.jenkins.io/latest/git.hpi"
 test_redirect "$TEST_BASE_URL/download/plugins/lolwut/latest/git.hpi" "https://updates.jenkins.io/latest/git.hpi" # Fun side effect of the redirect rule
 
+# Check static redirections to get.jenkins.io website
+test_redirect "$TEST_BASE_URL/download/war/2.246/jenkins.war" "https://get.jenkins.io/war/2.246/jenkins.war"
+test_redirect "$TEST_BASE_URL/download/war/2.204.1/jenkins.war" "https://get.jenkins.io/war-stable/2.204.1/jenkins.war"
+test_redirect "$TEST_BASE_URL/download/plugins/git/5.6.0/git.hpi" "https://get.jenkins.io/plugins/git/5.6.0/git.hpi"
+
 # Ensure that ?uctest gets a tiny OK response
 OUTPUT="$( curl -I "$TEST_BASE_URL/update-center.json?uctest" 2>/dev/null )"
 assert 'HTTP/1.1 200 OK'   "$( echo "$OUTPUT" | dos2unix | grep -F 'HTTP/1.1' )"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2380569628 and https://github.com/jenkins-infra/helpdesk/issues/4311

After a discussion with @daniel-beck , we realized that some of the issues on the new update center could be solved using smart request distribution on Apache. 

The mix of `mod_rewrite` (`RewriteRule`) and `mod_alias` (`RedirectMatch` ) in the generated `htaccess` files makes the rules ordering hard to determine as Apache evaluates all rewrite rules and apply the module's own internal priority, and then evaluate the redirect matchings.

We were forced to use `RedirectMatch` in https://github.com/jenkins-infra/update-center2/pull/790 to ensure the new UC fallback to `mirrors.updates.jenkins.io` was working as expected without breaking existing redirections.

Using rewrite rules allows more powerful setup such as using internal variables, applying conditions, etc.

This PR:

- Add test case to cover all current `RedirectMatch` rules (and the test works obviously)
- Replaces the `RedirectMatch` rules by `RewriteRule` directives (with test still passing)
- Changing the new UC fallback rule to a `RewriteRule` which tests the absence of the file specified by the request in order to send to the mirrors. As such, if we copy any file (such as `uctest.json` or `/download/**/*.html`) in the Apache document roots, then we can control which files are served from Azure or from the mirrors.