### PR TITLE
chore(wrapper/publish) serve `uctest.json` and the HTML in the virtual tree `download/` from Apache instead of mirrors

### DIFF
--- a/site/publish.sh
+++ b/site/publish.sh
@@ -149,6 +149,8 @@ then
         --prune-empty-dirs `# Do not copy empty directories` \
         --exclude='updates/' `# Exclude ALL 'updates' directories, not only the root /updates (because symlink dereferencing create additional directories` \
         --exclude='.htaccess' `# Exclude every .htaccess files` \
+        --exclude="uctest.json" `# Service Applicative Healthcheck (empty JSON)` \
+        --exclude="download/***" `# Virtual Tree of the download service, redirected to get.jio, with only HTML version listings with relative links to UC itself` \
         "${www2_dir}"/ ./www-content/
 
     # Prepare www-redirections-*secured/ directories, from $www2_dir, dedicated to httpd services, including only (customized) .htaccess files
@@ -158,6 +160,8 @@ then
         --prune-empty-dirs `# Do not copy empty directories` \
         --include "*/" `# Includes all directories in the filtering` \
         --include=".htaccess" `# Includes all elements named '.htaccess' in the filtering - redirections logic` \
+        --include="uctest.json" `# Service Applicative Healthcheck (empty JSON)` \
+        --include="download/***" `# Virtual Tree of the download service, redirected to get.jio, with only HTML version listings with relative links to UC itself` \
         --exclude="*" `# Exclude all elements found in source and not matching pattern aboves (must be the last filter flag)` \
         "${www2_dir}"/ "${httpd_secured_dir}/"
 


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4311#issuecomment-2419583755 (second bullet).

~Closes 810 (as not needed anymore)~

This PR is a follow up of #812  for the new [Update Center](https://github.com/jenkins-infra/helpdesk/issues/2649) using Apache2 + Mirrorbits.

It updates the publication script to serve the following file from Apache instead of mirrors:

- `uctest.json` => solves the HTTP/404 on azure.updates.jenkins.io/whatever?uctest
- `download/**/*.html` (only these files are present: other are sent to get.jenkins.io` => should solve the broken links in these HTML pages

As #812 did add a condition on "the file must not exist in httpd documentroot" to redirect incoming requests to the UC mirrors, Apache will serve these files.

As discussed with @daniel-beck:

- These files will count in the (billed) outbound bandwidth as served by Apache, but the amount of traffic is really low so it does not even count
- These files won't benefit from the new "mirror proximity" feature. But we do not really care as it is a really low usage
- We won't need to define an absolute URL (constraining us for years to a scheme and an hostname: not really flexible)




