### PR TITLE
chore(wrappers/publish) new Azure UC: send all `.json.html` requests to mirrors

### DIFF
--- a/site/publish.sh
+++ b/site/publish.sh
@@ -155,9 +155,9 @@ then
         --exclude="download/***" `# Virtual Tree of the download service, redirected to get.jio, with only HTML version listings with relative links to UC itself` \
         --include='*/' `# Include all other directories` \
         --include='*.json' `# Only include JSON files` \
+        --include='*.json.html' `# Only include HTML-wrapped JSON files` \
         --exclude='*' `# Exclude all other files` \
         "${www2_dir}"/ "${content_dir}"/
-
 
     # Prepare www-redirections-*secured/ directories, same content as $www2_dir (to allow directory listing), dedicated to httpd services
     cp -r "${www2_dir}" "${httpd_secured_dir}"
@@ -170,12 +170,8 @@ then
         {
             echo ''
             echo "## Send JSON files to ${mirrorbits_hostname}, except uctest.json (healthcheck served by Apache)"
-            echo 'RewriteCond %{REQUEST_URI} ([.](json)|TIME)$'
+            echo 'RewriteCond %{REQUEST_URI} ([.](json|json.html)|TIME)$'
             echo 'RewriteCond %{REQUEST_URI} !/uctest.json$'
-            # shellcheck disable=SC2016 # The $1 expansion is for RedirectMatch pattern, not shell
-            echo 'RewriteRule ^(.*)$ %{REQUEST_SCHEME}://'"${mirrorbits_hostname}"'/$1 [NC,L,R=307]'
-            echo "## Send requests to crawler's html files to ${mirrorbits_hostname} (JSON already sent, but we still want directory listing)"
-            echo 'RewriteCond %{REQUEST_URI} ^/updates/(.*).json.html$'
             # shellcheck disable=SC2016 # The $1 expansion is for RedirectMatch pattern, not shell
             echo 'RewriteRule ^(.*)$ %{REQUEST_SCHEME}://'"${mirrorbits_hostname}"'/$1 [NC,L,R=307]'
         } >> "${httpd_dir}"/.htaccess


### PR DESCRIPTION
As per <>

we want https://azure.updates.jenkins.io/current/update-center.json.html redirected to https://mirrors.updates.jenkins.io/current/update-center.json.html (and then to a mirror close to the HTTP client's location).

This PR is a fixup of #816 with the following corrections:

- Simplify the 2 "additional" redirection rules (added to the new Azure Apache) into a single one to redirect ALL `.json.html` files to mirrors (not only `updates/` ones)
- And of course, copy these files to mirrors


Note: tested with the integrated test, same as #816 (not commited to avoid breaking the actual UC):


```diff
diff --git a/site/generate-htaccess.sh b/site/generate-htaccess.sh
index 42b48ea..628fe5c 100755
--- a/site/generate-htaccess.sh
+++ b/site/generate-htaccess.sh
@@ -135,4 +135,8 @@ RewriteRule ^download/plugins/(.*)/latest/(.+)[.]hpi$ https://updates.jenkins.io
 RewriteRule ^download/war/([0-9]+[.][0-9]+[.][0-9]+/jenkins)[.]war$ https://get.jenkins.io/war-stable/\$1.war [NC,L,R=302]
 RewriteRule ^download/war/(.+)[.]war$ https://get.jenkins.io/war/\$1.war [NC,L,R=302]
 RewriteRule ^download/plugins/(.+)[.]hpi$ https://get.jenkins.io/plugins/\$1.hpi [NC,L,R=302]
+
+RewriteCond %{REQUEST_URI} ([.](json|json.html)|TIME)$
+RewriteCond %{REQUEST_URI} !/uctest.json$
+RewriteRule ^(.*)$ %{REQUEST_SCHEME}://mirrors.updates.jenkins.io/\$1 [NC,L,R=307]
 EOF
diff --git a/site/test/Dockerfile b/site/test/Dockerfile
index 8d56ae8..d69c55b 100644
--- a/site/test/Dockerfile
+++ b/site/test/Dockerfile
@@ -6,4 +6,6 @@ COPY ./httpd.conf /usr/local/apache2/conf/httpd.conf
 COPY ./htaccess.tmp /usr/local/apache2/htdocs/.htaccess
 
 RUN echo "{}" > /usr/local/apache2/htdocs/uctest.json
+RUN mkdir -p /usr/local/apache2/htdocs/updates
+RUN rm -f /usr/local/apache2/htdocs/index.html
 RUN chmod a+r /usr/local/apache2/htdocs/.htaccess
diff --git a/site/test/test.sh b/site/test/test.sh
index ab7e561..ec0e777 100755
--- a/site/test/test.sh
+++ b/site/test/test.sh
@@ -29,7 +29,7 @@ function test_redirect () {
   local REQUEST_URL="$1"
   local DESTINATION="$2"
   echo "Requesting $REQUEST_URL (-> $DESTINATION)"
-  REDIRECT=$( curl -I "$REQUEST_URL" 2>/dev/null | fgrep 'Location:' | cut -d' ' -f2 | tr -d '[:space:]' ) || { echo "Failed to curl $REQUEST_URL" >&2 ; }
+  REDIRECT=$( curl -I "$REQUEST_URL" 2>/dev/null | grep -F 'Location:' | cut -d' ' -f2 | tr -d '[:space:]' ) || { echo "Failed to curl $REQUEST_URL" >&2 ; }
   if [ "$REDIRECT" != "$DESTINATION" ] ; then
     echo "Expected $DESTINATION but got $REDIRECT for $REQUEST_URL"
   fi
@@ -134,6 +134,23 @@ test_redirect "$TEST_BASE_URL/download/war/2.246/jenkins.war" "https://get.jenki
 test_redirect "$TEST_BASE_URL/download/war/2.204.1/jenkins.war" "https://get.jenkins.io/war-stable/2.204.1/jenkins.war"
 test_redirect "$TEST_BASE_URL/download/plugins/git/5.6.0/git.hpi" "https://get.jenkins.io/plugins/git/5.6.0/git.hpi"
 
+# Check redirection to mirrors
+test_redirect "$TEST_BASE_URL/current/update-center.json" "http://mirrors.updates.jenkins.io/current/update-center.json"
+test_redirect "$TEST_BASE_URL/current/update-center.json.html" "http://mirrors.updates.jenkins.io/current/update-center.json.html"
+test_redirect "$TEST_BASE_URL/dynamic-stable-2.204.1/update-center.json" "http://mirrors.updates.jenkins.io/dynamic-stable-2.204.1/update-center.json"
+test_redirect "$TEST_BASE_URL/dynamic-stable-2.240/update-center.json" "http://mirrors.updates.jenkins.io/dynamic-stable-2.240/update-center.json"
+test_redirect "$TEST_BASE_URL/TIME" "http://mirrors.updates.jenkins.io/TIME"
+test_redirect "$TEST_BASE_URL/updates/org.jenkins-ci.plugins.chromedriver.ChromeDriver.json" "http://mirrors.updates.jenkins.io/updates/org.jenkins-ci.plugins.chromedriver.ChromeDriver.json"
+test_redirect "$TEST_BASE_URL/updates/org.jenkins-ci.plugins.chromedriver.ChromeDriver.json.html" "http://mirrors.updates.jenkins.io/updates/org.jenkins-ci.plugins.chromedriver.ChromeDriver.json.html"
+
+# Ensure directory (listings) are answered with an HTTP/200 (created empty in the Dockerfile for this test)
+OUTPUT="$(curl -v "$TEST_BASE_URL/" -o /dev/null 2>&1)"
+assert '< HTTP/1.1 200 OK'   "$( echo "$OUTPUT" | dos2unix | grep -F '< HTTP/1.1' )"
+assert '< Content-Length: 251' "$( echo "$OUTPUT" | dos2unix | grep -F 'Content-Length: ' )"
+OUTPUT="$(curl -v "$TEST_BASE_URL/updates/" -o /dev/null 2>&1)"
+assert '< HTTP/1.1 200 OK'   "$( echo "$OUTPUT" | dos2unix | grep -F '< HTTP/1.1' )"
+assert '< Content-Length: 218' "$( echo "$OUTPUT" | dos2unix | grep -F 'Content-Length: ' )"
+
 # Ensure that ?uctest gets a tiny OK response
 OUTPUT="$( curl -I "$TEST_BASE_URL/update-center.json?uctest" 2>/dev/null )"
 assert 'HTTP/1.1 200 OK'   "$( echo "$OUTPUT" | dos2unix | grep -F 'HTTP/1.1' )"
```