### PR TITLE
Update artifact-ignores.properties

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -298,6 +298,7 @@ hp-application-automation-tools-plugin@6.0.1-beta  	 # unexpected release versio
 ibm-application-security@1.2.7    # Bug that breaks existing jobs from previous versions
 hp-application-automation-tools-plugin@24.1  	 # unexpected release version - latest release is 23.4
 datadog@7.0.0                                    # regression: https://github.com/jenkins-infra/helpdesk/issues/4080
+applitools-eyes@1.16.4             # accidentally released. not working.
 
 # rogue releases with unknown source
 ez-templates@1.0.0

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -298,7 +298,7 @@ hp-application-automation-tools-plugin@6.0.1-beta  	 # unexpected release versio
 ibm-application-security@1.2.7    # Bug that breaks existing jobs from previous versions
 hp-application-automation-tools-plugin@24.1  	 # unexpected release version - latest release is 23.4
 datadog@7.0.0                                    # regression: https://github.com/jenkins-infra/helpdesk/issues/4080
-applitools-eyes@1.16.4             # accidentally released. not working.
+applitools-eyes-plugin@1.16.4             # accidentally released. not working.
 
 # rogue releases with unknown source
 ez-templates@1.0.0


### PR DESCRIPTION
Hello!

I accidentally released version 1.16.4 of applitools-eyes, which doesn't work.

I'd like to block this specific version from being downloaded. In addition I'll re-release the last working version with a new version number.

Thanks.