### PR TITLE
chore(wrappers/publish) ensure Apache has access to symlinked folders

### DIFF
--- a/site/publish.sh
+++ b/site/publish.sh
@@ -159,23 +159,26 @@ then
         --exclude='*' `# Exclude all other files` \
         "${www2_dir}"/ "${content_dir}"/
 
-    # Prepare www-redirections-*secured/ directories, same content as $www2_dir (to allow directory listing), dedicated to httpd services
-    cp -r "${www2_dir}" "${httpd_secured_dir}"
-    cp -r "${www2_dir}" "${httpd_unsecured_dir}"
+    # Prepare www-redirections-*secured/ directories, same content as $www2_dir (to allow directory listing) but with dereferenced symlinks, dedicated to httpd services
+    rsync --archive --verbose \
+        --copy-links `# derefence symlinks` \
+        --safe-links `# ignore symlinks outside of copied tree` \
+        "${www2_dir}"/ "${httpd_secured_dir}/"
 
-    # Append the httpd -> mirrorbits redirection as fallback (end of htaccess file) for www-redirections (both secured and unsecured)
     mirrorbits_hostname='mirrors.updates.jenkins.io'
-    for httpd_dir in "${httpd_secured_dir}" "${httpd_unsecured_dir}"
-    do
-        {
-            echo ''
-            echo "## Send JSON files to ${mirrorbits_hostname}, except uctest.json (healthcheck served by Apache)"
-            echo 'RewriteCond %{REQUEST_URI} ([.](json|json.html)|TIME)$'
-            echo 'RewriteCond %{REQUEST_URI} !/uctest.json$'
-            # shellcheck disable=SC2016 # The $1 expansion is for RedirectMatch pattern, not shell
-            echo 'RewriteRule ^(.*)$ %{REQUEST_SCHEME}://'"${mirrorbits_hostname}"'/$1 [NC,L,R=307]'
-        } >> "${httpd_dir}"/.htaccess
-    done
+    {
+        # Append the httpd -> mirrorbits redirection as fallback (end of htaccess file) for www-redirections (both secured and unsecured)
+        echo ''
+        echo "## Send JSON files to ${mirrorbits_hostname}, except uctest.json (healthcheck served by Apache)"
+        echo 'RewriteCond %{REQUEST_URI} ([.](json|json.html)|TIME)$'
+        echo 'RewriteCond %{REQUEST_URI} !/uctest.json$'
+        # shellcheck disable=SC2016 # The $1 expansion is for RedirectMatch pattern, not shell
+        echo 'RewriteRule ^(.*)$ %{REQUEST_SCHEME}://'"${mirrorbits_hostname}"'/$1 [NC,L,R=307]'
+    } >> "${httpd_secured_dir}"/.htaccess
+
+    # Duplicate to a distinct dir (not required but allow custom HTTP customization if need be)
+    # TODO: remove when we force HTTPS
+    cp -r "${httpd_secured_dir}" "${httpd_unsecured_dir}"
 
     echo '----------------------- Launch synchronisation(s) -----------------------'
     parallel --halt-on-error now,fail=1 parallelfunction ::: "${sync_uc_tasks[@]}"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4375

This PR aims at fixing the issue:

- `azcopy sync` does not provide any symlink option
- We cannot use `azcopy copy` (which has symlinks options)

So we take advantage of `rsync` to do the "symlink dereferencing" for us.


Note: the impact in timing can be ignored as this task is in parallel of S3 which takes WAY more time