### PR TITLE
Revert "chore(wrappers/publish) ensure mirrorbits scans local files before scanning mirrors"

### DIFF
--- a/site/publish.sh
+++ b/site/publish.sh
@@ -192,7 +192,6 @@ then
     # 3390 is the port of the "secured" instance (HTTPS) while 3391 of the "unsecured" (HTTP) instance. It's the only difference.
     for mirrorbits_cli_port in 3390 3391
     do
-        echo "${MIRRORBITS_CLI_PASSWORD}" | mirrorbits -h "${MIRRORBITS_HOST}" -p "${mirrorbits_cli_port}" -a refresh -rehash
         echo "${MIRRORBITS_CLI_PASSWORD}" | mirrorbits -h "${MIRRORBITS_HOST}" -p "${mirrorbits_cli_port}" -a scan -all -enable -timeout=120
     done
 fi


### PR DESCRIPTION
Reverts jenkins-infra/update-center2#820

Because the rsync fails with:

```
symlink has no referent: "/home/jenkins/agent-workspace/workspace/update_center/www2/current/updates"
```