### PR TITLE
chore(wrappers/publish) ensure mirrorbits scans local files before scanning mirrors

### DIFF
--- a/site/publish.sh
+++ b/site/publish.sh
@@ -192,6 +192,7 @@ then
     # 3390 is the port of the "secured" instance (HTTPS) while 3391 of the "unsecured" (HTTP) instance. It's the only difference.
     for mirrorbits_cli_port in 3390 3391
     do
+        echo "${MIRRORBITS_CLI_PASSWORD}" | mirrorbits -h "${MIRRORBITS_HOST}" -p "${mirrorbits_cli_port}" -a refresh -rehash
         echo "${MIRRORBITS_CLI_PASSWORD}" | mirrorbits -h "${MIRRORBITS_HOST}" -p "${mirrorbits_cli_port}" -a scan -all -enable -timeout=120
     done
 fi


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649

This PR ensures that mirrorbits does not mark files with "Hash Mismatch" or "File size mismatch" during 8-9 minutes (until the next "mirrorbits Scan Repository" is performed).

It should avoid sending all traffic to the fallback during these (long) minutes.

the PR https://github.com/jenkins-infra/update-center2/pull/820 have been reverted by mistake