### PR TITLE
chore(wrappers/publish) add 3 new rsync targets on the new data service

### DIFF
--- a/site/publish.sh
+++ b/site/publish.sh
@@ -6,7 +6,7 @@
 # - [mandatory] UPDATE_CENTER_FILESHARES_ENV_FILES (directory path): directory containing environment files to be sources for each sync. destination.
 #     Each task named XX expects a file named 'env-XX' in this directory to be sourced by the script to retrieve settings for the task.
 RUN_STAGES="${RUN_STAGES:-generate-site|sync-plugins|sync-uc}"
-SYNC_UC_TASKS="${SYNC_UC_TASKS:-rsync-updates.jenkins.io|azsync-content|azsync-redirections-unsecured|azsync-redirections-secured|s3sync-westeurope|s3sync-eastamerica}"
+SYNC_UC_TASKS="${SYNC_UC_TASKS:-rsync-updates.jenkins.io|rsync-updates.jenkins.io-data-content|azsync-content|rsync-updates.jenkins.io-data-redirections-unsecured|azsync-redirections-unsecured|rsync-updates.jenkins.io-data-redirections-secured|azsync-redirections-secured|s3sync-westeurope|s3sync-eastamerica}"
 MIRRORBITS_HOST="${MIRRORBITS_HOST:-updates.jio-cli.trusted.ci.jenkins.io}"
 
 # Split strings to arrays for feature flags setup


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4402#issuecomment-2498467862

This PR adds 3 new rsync targets, which goal will be to replace the current `azcopy`  targets as soon as possible.
It will populate these elements in parallel of the existing ones to avoid disrupting the existing production (we'll switch to the new populated data later).

Checks:

- Credentials have been updated in trusted.ci.jenkins.io.
- Routing has been verified on the `agent-1` permanent agent

