### PR TITLE
chore(wrappers/publish) add 3 new rsync targets on the new data service

### DIFF
--- a/site/publish.sh
+++ b/site/publish.sh
@@ -6,7 +6,7 @@
 # - [mandatory] UPDATE_CENTER_FILESHARES_ENV_FILES (directory path): directory containing environment files to be sources for each sync. destination.
 #     Each task named XX expects a file named 'env-XX' in this directory to be sourced by the script to retrieve settings for the task.
 RUN_STAGES="${RUN_STAGES:-generate-site|sync-plugins|sync-uc}"
-SYNC_UC_TASKS="${SYNC_UC_TASKS:-rsync-updates.jenkins.io|azsync-content|azsync-redirections-unsecured|azsync-redirections-secured|s3sync-westeurope|s3sync-eastamerica}"
+SYNC_UC_TASKS="${SYNC_UC_TASKS:-rsync-updates.jenkins.io|rsync-updates.jenkins.io-data-content|azsync-content|rsync-updates.jenkins.io-data-redirections-unsecured|azsync-redirections-unsecured|rsync-updates.jenkins.io-data-redirections-secured|azsync-redirections-secured|s3sync-westeurope|s3sync-eastamerica}"
 MIRRORBITS_HOST="${MIRRORBITS_HOST:-updates.jio-cli.trusted.ci.jenkins.io}"
 
 # Split strings to arrays for feature flags setup


### PR DESCRIPTION
This PR is a retry of #825 which was reverted by #826 due to rsync errors on the service

We fixed (and tested in details) the new rsync now it's been using NFS instead of SMB for the shared volume: https://github.com/jenkins-infra/helpdesk/issues/4402