### PR TITLE
feat(publish): add archives.jenkins.io in the rsync process for update-center

### DIFF
--- a/site/publish.sh
+++ b/site/publish.sh
@@ -6,7 +6,7 @@
 # - [mandatory] UPDATE_CENTER_FILESHARES_ENV_FILES (directory path): directory containing environment files to be sources for each sync. destination.
 #     Each task named XX expects a file named 'env-XX' in this directory to be sourced by the script to retrieve settings for the task.
 RUN_STAGES="${RUN_STAGES:-generate-site|sync-plugins|sync-uc}"
-SYNC_UC_TASKS="${SYNC_UC_TASKS:-rsync-updates.jenkins.io|rsync-updates.jenkins.io-data-content|rsync-updates.jenkins.io-data-redirections-unsecured|rsync-updates.jenkins.io-data-redirections-secured|s3sync-westeurope|s3sync-eastamerica}"
+SYNC_UC_TASKS="${SYNC_UC_TASKS:-rsync-updates.jenkins.io|rsync-archives.jenkins.io|rsync-updates.jenkins.io-data-content|rsync-updates.jenkins.io-data-redirections-unsecured|rsync-updates.jenkins.io-data-redirections-secured|s3sync-westeurope|s3sync-eastamerica}"
 MIRRORBITS_HOST="${MIRRORBITS_HOST:-updates.jio-cli.trusted.ci.jenkins.io}"
 
 # Split strings to arrays for feature flags setup


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4401#issuecomment-2515106384
add archives.jenkins.io to the parallel steps for rsync in order to add it as a failback mirror

depends on https://github.com/jenkins-infra/charts-secrets/pull/34