### PR TITLE
Removal of protecode-sc plugin

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -919,4 +919,4 @@ confluence-publisher = https://github.com/jenkins-infra/helpdesk/issues/3856
 synopsys-sigma = https://github.com/jenkinsci/synopsys-sigma-plugin/blob/master/README.md
 
 # Project discontinued
-protecode-sc
+protecode-sc = https://github.com/jenkinsci/protecode-sc-plugin/blob/master/README.md

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -917,3 +917,6 @@ confluence-publisher = https://github.com/jenkins-infra/helpdesk/issues/3856
 
 # Removing old plugin releases, replaced by black-duck-sigma
 synopsys-sigma = https://github.com/jenkinsci/synopsys-sigma-plugin/blob/master/README.md
+
+# Project discontinued
+protecode-sc


### PR DESCRIPTION
protecode-sc plugin is no longer supported or developed at all and should be removed.