### PR TITLE
Generate `timestamp.txt`

### DIFF
--- a/site/generate.sh
+++ b/site/generate.sh
@@ -112,12 +112,12 @@ function sanity-check {
 # This supports updating Jenkins (core) once a year while getting offered compatible plugin updates.
 for version in "${WEEKLY_RELEASES[@]}" ; do
   # For mainline, advertising the latest core
-  generate --limit-plugin-core-dependency "$version" --write-latest-core --latest-links-directory "$WWW_ROOT_DIR/dynamic-$version/latest" --www-dir "$WWW_ROOT_DIR/dynamic-$version"
+  generate --limit-plugin-core-dependency "$version" --write-latest-core --write-timestamp --latest-links-directory "$WWW_ROOT_DIR/dynamic-$version/latest" --www-dir "$WWW_ROOT_DIR/dynamic-$version"
 done
 
 for version in "${STABLE_RELEASES[@]}" ; do
   # For LTS, advertising the latest LTS core
-  generate --limit-plugin-core-dependency "$version" --write-latest-core --latest-links-directory "$WWW_ROOT_DIR/dynamic-stable-$version/latest" --www-dir "$WWW_ROOT_DIR/dynamic-stable-$version" --only-stable-core
+  generate --limit-plugin-core-dependency "$version" --write-latest-core --write-timestamp --latest-links-directory "$WWW_ROOT_DIR/dynamic-stable-$version/latest" --www-dir "$WWW_ROOT_DIR/dynamic-stable-$version" --only-stable-core
 done
 
 # Experimental update center without version caps, including experimental releases.
@@ -129,7 +129,7 @@ generate --www-dir "$WWW_ROOT_DIR/experimental" --generate-recent-releases --wit
 # This generates -download after the experimental update site above to change the 'latest' symlinks to the latest released version.
 # This also generates --download-links-directory to only visibly show real releases on index.html pages.
 generate --generate-release-history --generate-recent-releases --generate-plugin-versions --generate-plugin-documentation-urls \
-    --write-latest-core --write-plugin-count \
+    --write-latest-core --write-timestamp --write-plugin-count \
     --www-dir "$WWW_ROOT_DIR/current" --download-links-directory "$WWW_ROOT_DIR/download" --downloads-directory "$DOWNLOAD_ROOT_DIR" --latest-links-directory "$WWW_ROOT_DIR/current/latest"
 
 # Actually run the update center build.

--- a/src/main/java/io/jenkins/update_center/MetadataWriter.java
+++ b/src/main/java/io/jenkins/update_center/MetadataWriter.java
@@ -1,6 +1,7 @@
 package io.jenkins.update_center;
 
 import hudson.util.VersionNumber;
+import io.jenkins.update_center.util.Timestamp;
 import org.apache.commons.io.IOUtils;
 import org.kohsuke.args4j.Option;
 
@@ -19,6 +20,7 @@ public class MetadataWriter {
     private static final Logger LOGGER = Logger.getLogger(MetadataWriter.class.getName());
     private static final String LATEST_CORE_FILENAME = "latestCore.txt";
     private static final String PLUGIN_COUNT_FILENAME = "pluginCount.txt";
+    private static final String TIMESTAMP_FILENAME = "timestamp.txt";
 
     @Option(name = "--write-plugin-count", usage = "Report the number of plugins published by the update site")
     public boolean generatePluginCount;
@@ -26,10 +28,13 @@ public class MetadataWriter {
     @Option(name = "--write-latest-core", usage = "Generate a text file with the core version offered by this update site")
     public boolean generateLatestCore;
 
+    @Option(name = "--write-timestamp", usage = "Generate a text file with the generation timestamp of this update site")
+    public boolean generateTimestamp;
+
     public void writeMetadataFiles(@Nonnull MavenRepository repository, @CheckForNull File outputDirectory) throws IOException {
         Objects.requireNonNull(repository, "repository");
 
-        if (!generateLatestCore && !generatePluginCount) {
+        if (!generateLatestCore && !generatePluginCount && !generateTimestamp) {
             LOGGER.log(Level.INFO, "Skipping generation of metadata files");
             return;
         }
@@ -56,6 +61,12 @@ public class MetadataWriter {
         if (generatePluginCount) {
             try (final FileOutputStream output = new FileOutputStream(new File(outputDirectory, PLUGIN_COUNT_FILENAME))) {
                 IOUtils.write(Integer.toString(repository.listJenkinsPlugins().size()), output, StandardCharsets.UTF_8);
+            }
+        }
+
+        if (generateTimestamp) {
+            try (final FileOutputStream output = new FileOutputStream(new File(outputDirectory, TIMESTAMP_FILENAME))) {
+                IOUtils.write(Timestamp.TIMESTAMP, output, StandardCharsets.UTF_8);
             }
         }
     }

--- a/src/main/java/io/jenkins/update_center/json/WithSignature.java
+++ b/src/main/java/io/jenkins/update_center/json/WithSignature.java
@@ -5,6 +5,7 @@ import com.alibaba.fastjson.annotation.JSONField;
 import com.alibaba.fastjson.serializer.SerializerFeature;
 import io.jenkins.update_center.Signer;
 
+import io.jenkins.update_center.util.Timestamp;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -14,16 +15,12 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.security.GeneralSecurityException;
-import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 
 /**
  * Support generation of JSON output with included checksum + signatures block for the same JSON output.
  */
 public abstract class WithSignature {
     private JsonSignature signature;
-    private final String generationTimestamp = DateTimeFormatter.ISO_DATE_TIME.format(Instant.now().atOffset(ZoneOffset.UTC).withNano(0));
 
     @JSONField
     public JsonSignature getSignature() {
@@ -37,7 +34,7 @@ public abstract class WithSignature {
      * @return a string with the current date and time in the format YYYY-MM-DD'T'HH:mm:ss'Z'
      */
     public String getGenerationTimestamp() {
-        return generationTimestamp;
+        return Timestamp.TIMESTAMP;
     }
 
     /**

--- a/src/main/java/io/jenkins/update_center/util/Timestamp.java
+++ b/src/main/java/io/jenkins/update_center/util/Timestamp.java
@@ -1,0 +1,9 @@
+package io.jenkins.update_center.util;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+public class Timestamp {
+    public static final String TIMESTAMP = DateTimeFormatter.ISO_DATE_TIME.format(Instant.now().atOffset(ZoneOffset.UTC).withNano(0));
+}


### PR DESCRIPTION
`Last-Modified` headers of the metadata files are no longer a reliable indicator of age, as these are different between the different hosts that respond to those requests since recent infra changes (archives/fallback vs. CF).

Downloading all of `update-center.actual.json` to get the timestamp from https://github.com/jenkins-infra/update-center2/pull/636 is impractical, and wasteful if done repeatedly in a short amount of time.

So this PR adds the new file `timestamp.txt` that has the same content as the value of `.generationTimestamp` in `update-center.actual.json` would be.