### PR TITLE
Update dependencies

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,8 +14,8 @@ node('linux') {
     stage('Generate') {
         withEnv([
                 "PATH+MVN=${tool 'mvn'}/bin",
-                "JAVA_HOME=${tool 'jdk8'}",
-                "PATH+JAVA=${tool 'jdk8'}/bin"
+                "JAVA_HOME=${tool 'jdk11'}",
+                "PATH+JAVA=${tool 'jdk11'}/bin"
         ]) {
             sh 'mvn -e clean verify'
         }

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <description>Generates update sites for updates.jenkins.io</description>
 
   <properties>
-    <java.level>11</java.level>
+    <maven.compiler.release>11</maven.compiler.release>
     <main.class>io.jenkins.update_center.Main</main.class>
     <spotbugs.failOnError>false</spotbugs.failOnError>
     <spotbugs.threshold>Low</spotbugs.threshold>
@@ -55,14 +55,10 @@
             <configuration>
               <rules>
                 <enforceBytecodeVersion>
-                  <maxJdkVersion>${java.level}</maxJdkVersion>
+                  <maxJdkVersion>${maven.compiler.release}</maxJdkVersion>
                   <ignoredScopes>
                     <ignoredScope>test</ignoredScope>
                   </ignoredScopes>
-                  <ignoreClasses>
-                    <ignoreClass>org/owasp/shim/ForJava9AndLater</ignoreClass>
-                    <ignoreClass>org/owasp/shim/Notice</ignoreClass>
-                  </ignoreClasses>
                 </enforceBytecodeVersion>
               </rules>
             </configuration>
@@ -88,7 +84,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>appassembler-maven-plugin</artifactId>
-        <version>1.1.1</version>
+        <version>2.1.0</version>
         <configuration>
           <programs>
             <program>
@@ -101,7 +97,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M5</version>
+        <version>3.5.2</version>
         <configuration>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
         </configuration>
@@ -170,8 +166,7 @@
     <dependency>
       <groupId>org.kohsuke.stapler</groupId>
       <artifactId>json-lib</artifactId>
-      <!-- newest Java 8 release -->
-      <version>2.4-jenkins-3</version>
+      <version>2.4-jenkins-8</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
@@ -191,19 +186,19 @@
     <dependency>
       <groupId>args4j</groupId>
       <artifactId>args4j</artifactId>
-      <!-- 2.33 is the last Java 8 release, 2.37 requires 11 -->
-      <version>2.33</version>
+      <version>2.37</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.lib</groupId>
       <artifactId>support-log-formatter</artifactId>
-      <!-- 1.2 requires Java 11 -->
-      <version>1.1</version>
+      <!-- 1.3 requires Java 17 -->
+      <version>1.2</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>version-number</artifactId>
-      <version>1.10</version>
+      <!-- 1.12 requires Java 17 -->
+      <version>1.11</version>
     </dependency>
     <dependency>
       <groupId>bouncycastle</groupId>
@@ -223,7 +218,7 @@
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
-      <version>4.9.0</version>
+      <!-- version from parent pom -->
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.70</version>
+    <version>1.128</version>
   </parent>
 
   <artifactId>update-center2</artifactId>
@@ -13,7 +13,7 @@
   <description>Generates update sites for updates.jenkins.io</description>
 
   <properties>
-    <java.level>8</java.level>
+    <java.level>11</java.level>
     <main.class>io.jenkins.update_center.Main</main.class>
     <spotbugs.failOnError>false</spotbugs.failOnError>
     <spotbugs.threshold>Low</spotbugs.threshold>
@@ -55,7 +55,7 @@
             <configuration>
               <rules>
                 <enforceBytecodeVersion>
-                  <maxJdkVersion>1.${java.level}</maxJdkVersion>
+                  <maxJdkVersion>${java.level}</maxJdkVersion>
                   <ignoredScopes>
                     <ignoredScope>test</ignoredScope>
                   </ignoredScopes>
@@ -68,25 +68,6 @@
             </configuration>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-            <id>check</id>
-            <phase>test</phase>
-          </execution>
-        </executions>
-        <configuration>
-          <signature>
-            <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java1${java.level}</artifactId>
-          </signature>
-        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
@@ -128,7 +109,7 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>4.7.3.4</version>
+        <version>4.8.6.6</version>
         <configuration><excludeFilterFile>${project.basedir}/spotbugs-excludes.xml</excludeFilterFile></configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,16 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-common</artifactId>
+        <version>1.9.25</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-jdk8</artifactId>
+        <version>1.9.25</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -169,7 +179,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp-urlconnection</artifactId>
-      <version>4.10.0</version>
+      <version>4.12.0</version>
     </dependency>
     <dependency>
       <groupId>jaxen</groupId>
@@ -241,19 +251,6 @@
       <version>1.18.3</version>
     </dependency>
 
-
-    <!-- for requireUpperBoundDeps -->
-    <dependency>
-      <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.7.10</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>3.0.2</version>
-    </dependency>
-
     <!-- test dependencies -->
     <dependency>
       <groupId>org.hamcrest</groupId>
@@ -270,7 +267,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
-      <version>4.10.0</version>
+      <version>4.12.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,10 @@
                   <ignoredScopes>
                     <ignoredScope>test</ignoredScope>
                   </ignoredScopes>
+                  <ignoreClasses>
+                    <ignoreClass>org/owasp/shim/ForJava9AndLater</ignoreClass>
+                    <ignoreClass>org/owasp/shim/Notice</ignoreClass>
+                  </ignoreClasses>
                 </enforceBytecodeVersion>
               </rules>
             </configuration>
@@ -130,6 +134,11 @@
     </plugins>
   </build>
 
+  <dependencyManagement>
+    <dependencies>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.jvnet.hudson</groupId>
@@ -139,6 +148,7 @@
     <dependency>
       <groupId>com.alibaba</groupId>
       <artifactId>fastjson</artifactId>
+      <!-- latest 1.x release, 2.x has compatibility mode per https://github.com/alibaba/fastjson2/wiki/fastjson_1_upgrade_cn but has a bit of dependency issues -->
       <version>1.2.83</version>
       <exclusions>
         <exclusion>
@@ -154,7 +164,7 @@
     <dependency>
       <groupId>org.dom4j</groupId>
       <artifactId>dom4j</artifactId>
-      <version>2.1.3</version>
+      <version>2.1.4</version>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
@@ -164,36 +174,39 @@
     <dependency>
       <groupId>jaxen</groupId>
       <artifactId>jaxen</artifactId>
-      <version>1.2.0</version>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.kohsuke.stapler</groupId>
       <artifactId>json-lib</artifactId>
+      <!-- newest Java 8 release -->
       <version>2.4-jenkins-3</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.11.0</version>
+      <version>2.18.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.12.0</version>
+      <version>3.17.0</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.15</version>
+      <version>1.17.2</version>
     </dependency>
     <dependency>
       <groupId>args4j</groupId>
       <artifactId>args4j</artifactId>
+      <!-- 2.33 is the last Java 8 release, 2.37 requires 11 -->
       <version>2.33</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.lib</groupId>
       <artifactId>support-log-formatter</artifactId>
+      <!-- 1.2 requires Java 11 -->
       <version>1.1</version>
     </dependency>
     <dependency>
@@ -209,23 +222,23 @@
     <dependency>
       <groupId>org.apache.ant</groupId>
       <artifactId>ant</artifactId>
-      <version>1.10.12</version>
+      <version>1.10.15</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
       <artifactId>owasp-java-html-sanitizer</artifactId>
-      <version>20220608.1</version>
+      <version>20240325.1</version>
     </dependency>
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
-      <version>4.7.3</version>
+      <version>4.9.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
-      <version>1.15.3</version>
+      <version>1.18.3</version>
     </dependency>
 
 
@@ -245,13 +258,7 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
-      <version>2.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>4.6.1</version>
+      <version>3.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/io/jenkins/update_center/HPI.java
+++ b/src/main/java/io/jenkins/update_center/HPI.java
@@ -24,7 +24,6 @@
 package io.jenkins.update_center;
 
 import com.alibaba.fastjson.annotation.JSONField;
-import com.google.common.annotations.VisibleForTesting;
 import hudson.util.VersionNumber;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -242,7 +241,6 @@ public class HPI extends MavenArtifact {
         return name;
     }
 
-    @VisibleForTesting
     static String simplifyPluginName(String name) {
         name = org.apache.commons.lang3.StringUtils.removeStart(name, "Jenkins ");
         name = org.apache.commons.lang3.StringUtils.removeStart(name, "Hudson ");
@@ -353,7 +351,6 @@ public class HPI extends MavenArtifact {
         return pluginUrl;
     }
 
-    @VisibleForTesting
     static String requireTopLevelUrl(String scmUrl) {
         if (scmUrl == null) {
             return null;
@@ -625,10 +622,8 @@ public class HPI extends MavenArtifact {
 
     // declared type is generic here because return value of com.google.common.base.Function::apply
     // (and hence PolicyFactory) is considered nullable, triggering SpotBugs warnings
-    @VisibleForTesting
     public static final Function<HtmlStreamEventReceiver, HtmlSanitizer.Policy> HTML_POLICY = Sanitizers.FORMATTING.and(Sanitizers.LINKS).and(new HtmlPolicyBuilder().allowElements("a").requireRelsOnLinks("noopener", "noreferrer").allowAttributes("target").matching(false, "_blank").onElements("a").toFactory());
 
-    @VisibleForTesting
     public static final HtmlStreamEventProcessor PRE_PROCESSOR = receiver -> new HtmlStreamEventReceiverWrapper(receiver) {
         @Override
         public void openTag(String elementName, List<String> attrs) {

--- a/src/main/java/io/jenkins/update_center/json/PlatformPluginsRoot.java
+++ b/src/main/java/io/jenkins/update_center/json/PlatformPluginsRoot.java
@@ -2,7 +2,7 @@ package io.jenkins.update_center.json;
 
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.annotation.JSONField;
-import com.google.common.io.Files;
+import java.nio.file.Files;
 import org.apache.commons.io.IOUtils;
 
 import java.io.File;
@@ -18,7 +18,7 @@ public class PlatformPluginsRoot extends WithSignature {
     public List<PlatformCategory> categories;
 
     public PlatformPluginsRoot(File referenceFile) throws IOException {
-        try (Reader r = Files.newReader(referenceFile, StandardCharsets.UTF_8)) {
+        try (Reader r = Files.newBufferedReader(referenceFile.toPath(), StandardCharsets.UTF_8)) {
             categories = Arrays.asList(JSON.parseObject(IOUtils.toString(r), PlatformCategory[].class));
         }
     }

--- a/src/main/java/io/jenkins/update_center/json/UpdateCenterRoot.java
+++ b/src/main/java/io/jenkins/update_center/json/UpdateCenterRoot.java
@@ -2,7 +2,6 @@ package io.jenkins.update_center.json;
 
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.annotation.JSONField;
-import com.google.common.base.Functions;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.jenkins.update_center.BaseMavenRepository;
 import io.jenkins.update_center.Deprecations;
@@ -18,6 +17,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -63,7 +63,7 @@ public class UpdateCenterRoot extends WithSignature {
         warnings = Arrays.asList(JSON.parseObject(warningsJsonText, UpdateCenterWarning[].class));
 
         // load deprecations
-        deprecations = new TreeMap<>(Deprecations.getDeprecatedPlugins().collect(Collectors.toMap(Functions.identity(), UpdateCenterRoot::deprecationForPlugin)));
+        deprecations = new TreeMap<>(Deprecations.getDeprecatedPlugins().collect(Collectors.toMap(Function.identity(), UpdateCenterRoot::deprecationForPlugin)));
 
         for (Plugin plugin : repo.listJenkinsPlugins()) {
             try {

--- a/src/test/java/io/jenkins/update_center/SanitizerTest.java
+++ b/src/test/java/io/jenkins/update_center/SanitizerTest.java
@@ -1,12 +1,16 @@
 package io.jenkins.update_center;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.owasp.html.HtmlSanitizer;
 import org.owasp.html.HtmlStreamRenderer;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class SanitizerTest {
     private static final Logger LOGGER = Logger.getLogger(SanitizerTest.class.getName());
@@ -16,16 +20,27 @@ public class SanitizerTest {
         assertSanitize("<strong>strong!</strong>", "<strong>strong!</strong>");
         assertSanitize("foo", "foo<img src=x onerror=alert(1)>");
         assertSanitize("this is the logo:", "this is the logo:<img src='https://www.jenkins.io/images/gsoc/jenkins-gsoc-transparent.png'>");
-        assertSanitize("this is the <a href=\"https://jenkins.io\" target=\"_blank\" rel=\"nofollow noopener noreferrer\">URL</a>", "this is the <a href=\"https://jenkins.io\" target=\"_blank\">URL</a>");
-        assertSanitize("this is the <a href=\"https://jenkins.io\" target=\"_blank\" rel=\"nofollow noopener noreferrer\">URL</a>", "this is the <a href=\"https://jenkins.io\">URL</a>");
-        assertSanitize("this is the <a href=\"https://jenkins.io\" target=\"_blank\" rel=\"nofollow noopener noreferrer\">URL</a>", "this is the <a href=\"https://jenkins.io\" target=\"foo\">URL</a>");
-        assertSanitize("this is the <a href=\"https://jenkins.io\" target=\"_blank\" rel=\"nofollow noopener noreferrer\">URL</a>", "this is the <a target=\"____\" href=\"https://jenkins.io\">URL</a>");
+        assertSanitize("this is the <a href=\"https://jenkins.io\" target=\"_blank\" rel=\"nofollow noreferrer noopener\">URL</a>", "this is the <a href=\"https://jenkins.io\" target=\"_blank\">URL</a>");
+        assertSanitize("this is the <a href=\"https://jenkins.io\" target=\"_blank\" rel=\"nofollow noreferrer noopener\">URL</a>", "this is the <a href=\"https://jenkins.io\">URL</a>");
+        assertSanitize("this is the <a href=\"https://jenkins.io\" target=\"_blank\" rel=\"nofollow noreferrer noopener\">URL</a>", "this is the <a href=\"https://jenkins.io\" target=\"foo\">URL</a>");
+        assertSanitize("this is the <a href=\"https://jenkins.io\" target=\"_blank\" rel=\"nofollow noreferrer noopener\">URL</a>", "this is the <a target=\"____\" href=\"https://jenkins.io\">URL</a>");
     }
 
     private void assertSanitize(String expected, String input) {
         StringBuilder b = new StringBuilder();
         HtmlStreamRenderer renderer = HtmlStreamRenderer.create(b, Throwable::printStackTrace, html -> LOGGER.log(Level.INFO, "Bad HTML: '" + html + "'"));
         HtmlSanitizer.sanitize(input, HPI.HTML_POLICY.apply(renderer), HPI.PRE_PROCESSOR);
-        Assert.assertEquals(expected, b.toString());
+        assertSanitizer336Workaround(expected, b.toString());
+    }
+
+    // Workaround for https://github.com/OWASP/java-html-sanitizer/issues/336
+    private void assertSanitizer336Workaround(String expected, String actual) {
+        if (expected.contains("rel")) {
+            assertThat(expected, allOf(containsString("nofollow"), containsString("noopener"), containsString("noreferrer")));
+            assertThat(actual, allOf(containsString("nofollow"), containsString("noopener"), containsString("noreferrer")));
+        }
+        expected = expected.replace("nofollow", "*").replace("noopener", "*").replace("noreferrer", "*");
+        actual = actual.replace("nofollow", "*").replace("noopener", "*").replace("noreferrer", "*");
+        assertThat(expected, is(actual));
     }
 }


### PR DESCRIPTION
Update parent POM, most dependencies, and increase Java version to 11.

FastJSON can be updated to 2.x, but that's a separate project (use of new APIs).

BC is being updated in https://github.com/jenkins-infra/update-center2/pull/785.

This introduces ~28 Spotbugs findings. The ones I quickly looked at were false positives or irrelevant, so cleaning those up is a project for another time.