### PR TITLE
Block unneeded AWS Java SDK 2 plugins

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -921,3 +921,12 @@ synopsys-sigma = https://github.com/jenkinsci/synopsys-sigma-plugin/blob/master/
 
 # Project discontinued
 protecode-sc = https://github.com/jenkinsci/protecode-sc-plugin/blob/master/README.md
+
+# Renamed to aws-java-sdk2-apigateway
+aws-java-sdk2-api-gateway
+
+# Renamed to aws-java-sdk2-cloudwatchlogs
+aws-java-sdk2-logs
+
+# Combined with aws-java-sdk2-core
+aws-java-sdk2-sts


### PR DESCRIPTION
These plugins were published during an earlier phase of development but have seen been renamed for consistency or combined for technical reasons.