### PR TITLE
Make `IssueTrackersSource` more resilient

### DIFF
--- a/src/main/java/io/jenkins/update_center/IssueTrackerSource.java
+++ b/src/main/java/io/jenkins/update_center/IssueTrackerSource.java
@@ -47,6 +47,7 @@ public class IssueTrackerSource {
             pluginToIssueTrackers = JSON.parseObject(jsonData, new TypeReferenceForHashMapFromStringToListOfIssueTracker().getType());
         } catch (RuntimeException | IOException ex) {
             LOGGER.log(Level.WARNING, ex.getMessage());
+            pluginToIssueTrackers = new HashMap<>();
         }
     }
 


### PR DESCRIPTION
https://github.com/jenkins-infra/update-center2/pull/840#issuecomment-2631201109 points out that the build fails if `reports.jenkins.io` cannot be reached. While the code was written to be more resilient, it wasn't done properly, this PR fixes that.