### PR TITLE
Update JVM from 11 to 21

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+--show-version

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,8 +14,8 @@ node('linux') {
     stage('Generate') {
         withEnv([
                 "PATH+MVN=${tool 'mvn'}/bin",
-                "JAVA_HOME=${tool 'jdk11'}",
-                "PATH+JAVA=${tool 'jdk11'}/bin"
+                "JAVA_HOME=${tool 'jdk21'}",
+                "PATH+JAVA=${tool 'jdk21'}/bin"
         ]) {
             sh 'mvn -e clean verify'
         }

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,6 @@
             <id>display-info</id>
             <phase>validate</phase>
             <goals>
-              <goal>display-info</goal>
               <goal>enforce</goal>
             </goals>
             <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <description>Generates update sites for updates.jenkins.io</description>
 
   <properties>
-    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.release>21</maven.compiler.release>
     <main.class>io.jenkins.update_center.Main</main.class>
     <spotbugs.failOnError>false</spotbugs.failOnError>
     <spotbugs.threshold>Low</spotbugs.threshold>
@@ -34,13 +34,6 @@
               <mainClass>${main.class}</mainClass>
             </manifest>
           </archive>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
This lets the project use Java 21. 
As the project deals a lot with String, this updates could help as the recent versions improved the memory management for that.

It opens us to bump support-log-formatter and version-number next (or let dependabot do it).

Once we have the build setup with this, we can go through the code and update API calls, removing deprecated onces, use. try-with-resources, records, and other few cleanups.