### PR TITLE
feat(publish.sh): adding CRC32 checksum algorithm paramter on the aws cli call to cloudflare R2

### DIFF
--- a/site/publish.sh
+++ b/site/publish.sh
@@ -92,6 +92,7 @@ then
             time aws s3 sync \
                 --no-progress \
                 --no-follow-symlinks \
+                --checksum-algorithm CRC32 \
                 --exclude '.htaccess' \
                 --endpoint-url "${BUCKET_ENDPOINT_URL}" \
                 "${fileshare_sync_source_abs}" "s3://${BUCKET_NAME}/"


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4500#issuecomment-2650386390

we need to provide that parameter for the call to go through on cloudflare R2 with the aws cli new version released here https://github.com/jenkins-infra/packer-images/pull/1723