### PR TITLE
Removing advisory for SECURITY-2774

### DIFF
--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -14997,19 +14997,6 @@
     ]
   },
   {
-    "id": "SECURITY-2774",
-    "type": "plugin",
-    "name": "jira-steps",
-    "message": "Keys stored in plain text",
-    "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2774",
-    "versions": [
-      {
-        "lastVersion": "2.0.165.v8846cf59f3db",
-        "pattern": ".*"
-      }
-    ]
-  },
-  {
     "id": "SECURITY-2778",
     "type": "plugin",
     "name": "rabbitmq-consumer",


### PR DESCRIPTION
Fix released in [jira-steps-plugin 2.0.180.vccfe35b_5910d](https://github.com/jenkinsci/jira-steps-plugin/releases/tag/2.0.180.vccfe35b_5910d) (see [jira-steps-plugin #190](https://github.com/jenkinsci/jira-steps-plugin/pull/190))