### PR TITLE
Removing advisory for SECURITY-2786

### DIFF
--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -15023,19 +15023,6 @@
     ]
   },
   {
-    "id": "SECURITY-2786",
-    "type": "plugin",
-    "name": "jira-steps",
-    "message": "CSRF vulnerability and missing permission checks",
-    "url": "https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2786",
-    "versions": [
-      {
-        "lastVersion": "2.0.165.v8846cf59f3db",
-        "pattern": ".*"
-      }
-    ]
-  },
-  {
     "id": "SECURITY-2787",
     "type": "plugin",
     "name": "view-cloner",


### PR DESCRIPTION
Fix released in [jira-steps-plugin 2.0.172.vc456eb_0cfa_4f](https://github.com/jenkinsci/jira-steps-plugin/releases/tag/2.0.172.vc456eb_0cfa_4f) (see [jira-steps-plugin #189](https://github.com/jenkinsci/jira-steps-plugin/pull/189))