### PR TITLE
Suspend `simplify-qa-connector`

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -930,3 +930,6 @@ aws-java-sdk2-logs
 
 # Combined with aws-java-sdk2-core
 aws-java-sdk2-sts
+
+# Sources were wiped
+simplify-qa-connector = https://github.com/jenkins-infra/update-center2/pull/849


### PR DESCRIPTION
No sources corresponding to this plugin's releases are still available in the repository at https://github.com/jenkinsci/simplify-qa-connector-plugin/

Looks like the maintainers simplified a little too much :trollface: 