### PR TITLE
Suspend `valid-network`

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -257,6 +257,7 @@ upload-artifacts-to-nexus        # renamed, see https://issues.jenkins-ci.org/br
 # Superseded by URLTrigger Plugin
 url-change-trigger = https://wiki.jenkins-ci.org/display/JENKINS/URL+Change+Trigger
 vagrant-plugin                    # renamed to vagrant, herpderp
+valid-network                     # plugin never worked due to reference to src/main/resources in code
 # service discontinued --- https://wiki.jenkins-ci.org/display/JENKINS/Vessel+plugin https://groups.google.com/d/msg/jenkinsci-dev/L34eAMMWA5o/-AxtRdGsAAAJ
 vessel = https://groups.google.com/d/msg/jenkinsci-dev/L34eAMMWA5o/-AxtRdGsAAAJ
 weibo4jenkins                    # renamed to weibo


### PR DESCRIPTION
https://github.com/jenkinsci/valid-network-plugin/blob/c55a07578b5c7f35733fe42415f4288d3d5cc3da/src/main/java/io/jenkins/plugins/CliExecutor.java#L62-L64 makes no sense in production code.

Given age, no need to hold out for a bug fix, and given install count, I'm not adding a deprecation message.