### PR TITLE
Exclude audit-trail version 393.v6a_3d1e251274 from distribution

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -934,3 +934,6 @@ aws-java-sdk2-sts
 
 # Sources were wiped
 simplify-qa-connector = https://github.com/jenkins-infra/update-center2/pull/849
+
+# JENKINS-75425. breaks Jenkins startup
+audit-trail@393.v6a_3d1e251274


### PR DESCRIPTION
It prevents instances from starting up (JENKINS-75425). Fixed by https://github.com/jenkinsci/audit-trail-plugin/pull/170