### PR TITLE
Removing advisory for SECURITY-1966

### DIFF
--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -8799,7 +8799,7 @@
     "versions": [
       {
         "lastVersion": "1.0",
-        "pattern": ".*"
+        "pattern": "1[.].*"
       }
     ]
   },


### PR DESCRIPTION
I've fixed this SECURITY-1966 vulnerability in [PR:3](https://github.com/jenkinsci/copy-data-to-workspace-plugin/pull/3)
and release [new version 39.v89417c885936](https://github.com/jenkinsci/copy-data-to-workspace-plugin/releases/tag/39.v89417c885936)
so version 1.0 was the only version affected.