### PR TITLE
chore(publish) stop copying UC site to (aws.)updates.jenkins.io VM (also known as `pkg`)

### DIFF
--- a/site/publish.sh
+++ b/site/publish.sh
@@ -6,7 +6,7 @@
 # - [mandatory] UPDATE_CENTER_FILESHARES_ENV_FILES (directory path): directory containing environment files to be sources for each sync. destination.
 #     Each task named XX expects a file named 'env-XX' in this directory to be sourced by the script to retrieve settings for the task.
 RUN_STAGES="${RUN_STAGES:-generate-site|sync-plugins|sync-uc}"
-SYNC_UC_TASKS="${SYNC_UC_TASKS:-rsync-updates.jenkins.io|rsync-archives.jenkins.io|rsync-updates.jenkins.io-data-content|rsync-updates.jenkins.io-data-redirections-unsecured|rsync-updates.jenkins.io-data-redirections-secured|s3sync-westeurope|s3sync-eastamerica}"
+SYNC_UC_TASKS="${SYNC_UC_TASKS:-rsync-archives.jenkins.io|rsync-updates.jenkins.io-data-content|rsync-updates.jenkins.io-data-redirections-unsecured|rsync-updates.jenkins.io-data-redirections-secured|s3sync-westeurope|s3sync-eastamerica}"
 MIRRORBITS_HOST="${MIRRORBITS_HOST:-updates.jio-cli.trusted.ci.jenkins.io}"
 
 # Split strings to arrays for feature flags setup


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2755171440 and https://github.com/jenkins-infra/helpdesk/issues/4610

This PR stops copying UC metadata to the `pkg` VM since it does not host any update center site anymore.