### PR TITLE
Fix file writing

### DIFF
--- a/src/main/java/io/jenkins/update_center/json/WithoutSignature.java
+++ b/src/main/java/io/jenkins/update_center/json/WithoutSignature.java
@@ -3,6 +3,7 @@ package io.jenkins.update_center.json;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.serializer.SerializerFeature;
 
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -14,10 +15,12 @@ public class WithoutSignature {
         if (!parent.mkdirs() && !parent.isDirectory()) {
             throw new IOException("Failed to create " + parent);
         }
-        if (pretty) {
-            JSON.writeJSONString(Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8), this, SerializerFeature.DisableCircularReferenceDetect, SerializerFeature.PrettyFormat);
-        } else {
-            JSON.writeJSONString(Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8), this, SerializerFeature.DisableCircularReferenceDetect);
+        try (BufferedWriter writer = Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8)) {
+            if (pretty) {
+                JSON.writeJSONString(writer, this, SerializerFeature.DisableCircularReferenceDetect, SerializerFeature.PrettyFormat);
+            } else {
+                JSON.writeJSONString(writer, this, SerializerFeature.DisableCircularReferenceDetect);
+            }
         }
     }
 }


### PR DESCRIPTION
Amends https://github.com/jenkins-infra/update-center2/pull/858.

With the update of `fastjson`, secondary files ended up empty.