### PR TITLE
Follow HTTP redirects

### DIFF
--- a/src/main/java/io/jenkins/update_center/ArtifactoryRepositoryImpl.java
+++ b/src/main/java/io/jenkins/update_center/ArtifactoryRepositoryImpl.java
@@ -278,7 +278,7 @@ public class ArtifactoryRepositoryImpl extends BaseMavenRepository {
             if (!parentFile.mkdirs() && !parentFile.isDirectory()) {
                 throw new IllegalStateException("Failed to create non-existing directory " + parentFile);
             }
-            try (final HttpClient client = HttpClient.newHttpClient()) {
+            try (final HttpClient client = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build()) {
                 final HttpRequest request = HttpRequest.newBuilder()
                         .GET()
                         .uri(URI.create(url))


### PR DESCRIPTION
By default, redirects are not followed, and HTTP 302 is considered a failure to download a few lines down.

This looks like it would explain the recent problems with cached download failures.

Amends https://github.com/jenkins-infra/update-center2/pull/840

CC @alecharp 