### PR TITLE
SECURITY-1966 Remove warning from copy-data-to-workspace-plugin

### DIFF
--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -8798,8 +8798,8 @@
     "url": "https://www.jenkins.io/security/advisory/2020-09-16/#SECURITY-1966",
     "versions": [
       {
-        "lastVersion": "1.0",
-        "pattern": ".*"
+        "lastVersion": "39.v89417c885936",
+        "pattern": "(1|3[469])(|[.-].+)"
       }
     ]
   },


### PR DESCRIPTION
Superseed https://github.com/jenkins-infra/update-center2/pull/855

The vulnerability was corrected by https://github.com/jenkinsci/copy-data-to-workspace-plugin/pull/3 & https://github.com/jenkinsci/copy-data-to-workspace-plugin/pull/23 which was released in `63.ve6c51d760236`