### PR TITLE
Suspend vss plugin

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -947,3 +947,6 @@ audit-trail@393.v6a_3d1e251274
 
 # https://jenkins.io/security/advisory/2025-05-14/
 wso2id-oauth = https://www.jenkins.io/security/plugins/#suspensions
+
+# project discontinued
+vss-plugin = https://github.com/jenkins-infra/update-center2/issues/866


### PR DESCRIPTION
The SCM this plugin integrates with had last major release in 2005 and its support was discontinued in 2017.
The plugin itself was not updated for 13 years and is not compatible with recent versions of Jenkins (https://github.com/jenkinsci/vss-plugin/pull/8, https://github.com/jenkinsci/vss-plugin/pull/9).