### PR TITLE
Suspend distribution of jackson2-api 2.19.0-404.vb_b_0fd2fea_e10

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -425,6 +425,7 @@ uno-choice@1.5.3              # While we serve pre-2.7 update sites; depends on 
 # depends on scripttrigger
 xtrigger = https://www.jenkins.io/security/plugins/#suspensions
 
+
 # These plugins implement Groovy scripting in an unsafe way, but are currently unreleased -- so suspend preemptively
 groovy-choice-parameter
 groovy-script-scheduler


### PR DESCRIPTION
## Suspend distribution of jackson2-api 2.19.0-404.vb_b_0fd2fea_e10

Confirmed that none of the plugins reported by the Jenkins update center depend on this release.

Plugin release 2.19.0-404.vb_b_0fd2fea_e10 causes issues for Jenkins users with Kubernetes agents.  Issue reports include:

* https://issues.jenkins.io/browse/JENKINS-75712
* https://issues.jenkins.io/browse/JENKINS-75718

More details are available in BOM pull request:

* https://github.com/jenkinsci/bom/pull/5114

Additional details also in the request for a fix in Kubernetes client API 6.x:

* https://github.com/fabric8io/kubernetes-client/issues/7107

CC: @jtnord, @jgarciacloudbees
