### PR TITLE
Suspend crossbrowsertesting plugin - service discontinued

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -956,3 +956,7 @@ jackson2-api@2.19.0-404.vb_b_0fd2fea_e10        # https://github.com/jenkinsci/b
 
 # SECURITY-3588
 gatling@136.vb_9009b_3d33a_e
+
+# service discontinued
+# https://groups.google.com/g/jenkinsci-dev/c/8VMFBfcmOu4/m/zbnWkyPdAAAJ
+crossbrowsertesting = https://support.smartbear.com/crossbrowsertesting/docs/about.html

--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -959,4 +959,4 @@ gatling@136.vb_9009b_3d33a_e
 
 # service discontinued
 # https://groups.google.com/g/jenkinsci-dev/c/8VMFBfcmOu4/m/zbnWkyPdAAAJ
-crossbrowsertesting = https://support.smartbear.com/crossbrowsertesting/docs/about.html
+crossbrowsertesting = https://github.com/jenkins-infra/update-center2/pull/870


### PR DESCRIPTION
## Suspend crossbrowsertesting plugin - service discontinued

The SmartBear CrossBrowserTesting [About page](https://support.smartbear.com/crossbrowsertesting/docs/about.html) and [documentation index](https://support.smartbear.com/crossbrowsertesting/docs/index.html) say:

> CrossBrowserTesting will no longer be available on July 31, 2023.

Jonathan Parrilla of SmartBear requested that the repository be archived in a [message](https://groups.google.com/g/jenkinsci-dev/c/8VMFBfcmOu4/m/zbnWkyPdAAAJ) to the Jenkins developers mailing list

Let's suspend distribution since the service has been unavailable for almost 12 months.
