### PR TITLE
Restore distribution of jackson2-api

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -951,9 +951,6 @@ wso2id-oauth = https://www.jenkins.io/security/plugins/#suspensions
 # project discontinued
 vss = https://github.com/jenkins-infra/update-center2/issues/866
 
-# https://github.com/jenkinsci/jackson2-api-plugin/releases/tag/2.19.0-404.vb_b_0fd2fea_e10
-jackson2-api@2.19.0-404.vb_b_0fd2fea_e10        # https://github.com/jenkinsci/bom/pull/5114
-
 # SECURITY-3588
 gatling@136.vb_9009b_3d33a_e
 


### PR DESCRIPTION
To merge only when https://github.com/jenkinsci/kubernetes-client-api-plugin/pull/296 is released

User that will upgrade to kubernetes-client-api-plugin must upgrade to jackson 2.19.+