### PR TITLE
SECURITY-2717 Remove warning for JDK Parameter plugin

### DIFF
--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -12188,8 +12188,8 @@
     "url": "https://www.jenkins.io/security/advisory/2022-05-17/#SECURITY-2717",
     "versions": [
       {
-        "lastVersion": "1.0",
-        "pattern": ".*"
+        "lastVersion": "1.2",
+        "pattern": "(1[.][0-2])(|[.-].+)"
       }
     ]
   },


### PR DESCRIPTION
https://issues.jenkins.io/browse/SECURITY-2713 was resolved by https://github.com/jenkinsci/JDK_Parameter_Plugin-plugin/pull/16 which was released in v1.3