### PR TITLE
Remove deprecation of bmc-change-manager-imstm

### DIFF
--- a/resources/deprecations.properties
+++ b/resources/deprecations.properties
@@ -6,7 +6,6 @@ async-http-client = https://github.com/jenkins-infra/update-center2/pull/650
 BlameSubversion = https://github.com/jenkinsci/jenkins/pull/5320
 blueocean-executor-info = https://issues.jenkins.io/browse/JENKINS-56773
 bmc-rpd = https://github.com/jenkins-infra/update-center2/pull/833
-bmc-change-manager-imstm = https://github.com/jenkinsci/bmc-change-manager-imstm-plugin/pull/13
 chosen = https://github.com/jenkins-infra/update-center2/pull/833
 cloverphp = https://github.com/jenkinsci/jenkins/pull/5320
 cmvc = https://github.com/jenkinsci/jenkins/pull/5320


### PR DESCRIPTION
## Remove deprecation of bmc-change-manager-imstm

The [BMC AMI DevOps for Change Manager for IMS TM Plugin](https://plugins.jenkins.io/bmc-change-manager-imstm/) was deprecated because it included the Jenkins test harness in its most recent release.  The deprecation is in pull request:

* https://github.com/jenkins-infra/update-center2/pull/864

A maintainer has arrived, @mcohen11 , and has merged the pull request that removes the Jenkins test harness.  That is pull request:

* https://github.com/jenkinsci/bmc-change-manager-imstm-plugin/pull/13

The plugin has been updated to require Java 17 and a modern Jenkins version with pull request:

* https://github.com/jenkinsci/bmc-change-manager-imstm-plugin/pull/23

The new release is available from the update center as shown by the [mirrorlist](https://get.jenkins.io/plugins/bmc-change-manager-imstm/66.v12c841920f7d/bmc-change-manager-imstm.hpi?mirrorlist).

I've loaded the new release into Jenkins 2.519 successfully.

We can remove the deprecation.

This partially reverts 8280594e9e171d642abe6cf10db247436df62e7c
