### PR TITLE
suspend commons-lang

### DIFF
--- a/resources/artifact-ignores.properties
+++ b/resources/artifact-ignores.properties
@@ -957,3 +957,6 @@ gatling@136.vb_9009b_3d33a_e
 # service discontinued
 # https://groups.google.com/g/jenkinsci-dev/c/8VMFBfcmOu4/m/zbnWkyPdAAAJ
 crossbrowsertesting = https://github.com/jenkins-infra/update-center2/pull/870
+
+# unused, EOL and CVE-2025-48924 
+commons-lang-api = https://github.com/jenkins-infra/update-center2/pull/880


### PR DESCRIPTION
commons-lang is EOL since 2011 and vulnerable (CVE-2025-48924). The library plugin is not used by any other plugin. Due to ongoing activities to remove commons-lang from core and all plugins it will also not be needed via an implied dependency.