### PR TITLE
chore(publish) copy released plugins to get.jenkins.io directly

### DIFF
--- a/site/publish.sh
+++ b/site/publish.sh
@@ -36,9 +36,16 @@ then
     ## $download_dir folder processing
     # push plugins to mirrors.jenkins-ci.org
     chmod -R a+r "${download_dir}"
+    # TODO: remove in favor of the local NFS mount
     rsync -rlptDvz --chown=mirrorbrain:www-data --size-only "${download_dir}"/plugins/ "${RSYNC_USER}@${UPDATES_SITE}":/srv/releases/jenkins/plugins
+    # Also copy on the new local NFS (no compress, no need to chown) -
+    # TODO: use the credentials to retrieve the mount point
+    rsync --recursive --links --size-only \
+        --times --perms --verbose --devices --specials \
+        --size-only "${download_dir}"/plugins/ /data-storage-jenkins-io/get.jenkins.io/mirrorbits/plugins/
 
     # Invoke a minimal mirrorsync to mirrorbits which will use the 'recent-releases.json' file as input
+    # TODO: remove in favor of the local NFS mount
     ssh "${RSYNC_USER}@${UPDATES_SITE}" "cat > /tmp/update-center2-rerecent-releases.json" < "${www2_dir}"/experimental/recent-releases.json
     ssh "${RSYNC_USER}@${UPDATES_SITE}" "/srv/releases/sync-recent-releases.sh /tmp/update-center2-rerecent-releases.json"
 fi
@@ -74,7 +81,7 @@ then
             # Required variables that should now be set from the .env file
             : "${RSYNC_HOST?}" "${RSYNC_USER?}" "${RSYNC_GROUP?}" "${RSYNC_REMOTE_DIR?}" "${RSYNC_IDENTITY_NAME?}"
 
-            time rsync --chown="${RSYNC_USER}":"${RSYNC_GROUP}" --recursive --links --perms --times -D \
+            time rsync --chown="${RSYNC_USER}":"${RSYNC_GROUP}" --recursive --links --perms --times --devices --specials \
                 --rsh="ssh -i ${UPDATE_CENTER_FILESHARES_ENV_FILES}/${RSYNC_IDENTITY_NAME}" `# rsync identity file is stored with .env files` \
                 --checksum --verbose --compress \
                 --exclude=/updates `# populated by https://github.com/jenkins-infra/crawler` \
@@ -87,7 +94,7 @@ then
             # Required variables that should now be set from the .env file
             : "${RSYNC_REMOTE_DIR?}"
 
-            time rsync --recursive --links --times -D \
+            time rsync --recursive --links --times --devices --specials \
                 --checksum --verbose \
                 --exclude=/updates `# populated by https://github.com/jenkins-infra/crawler` \
                 --delete `# delete old sites` \

--- a/site/publish.sh
+++ b/site/publish.sh
@@ -7,7 +7,7 @@
 #     Each task named XX expects a file named 'env-XX' in this directory to be sourced by the script to retrieve settings for the task.
 RUN_STAGES="${RUN_STAGES:-generate-site|sync-plugins|sync-uc}"
 SYNC_UC_TASKS="${SYNC_UC_TASKS:-rsync-archives.jenkins.io|localrsync-updates.jenkins.io-content|localrsync-updates.jenkins.io-redirections|s3sync-westeurope|s3sync-eastamerica}"
-MIRRORBITS_HOST="${MIRRORBITS_HOST:-updates.jenkins.io.trusted.ci.jenkins.io}"
+MIRRORBITS_HOST="${MIRRORBITS_HOST:-updates.jenkins.io.privatelink.azurecr.io}"
 
 # Split strings to arrays for feature flags setup
 run_stages=()


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4767#issuecomment-3184312247

This PR has been tested on trusted.ci using the source branch for at least 2 weeks.

The goal of this PR are:

- Fix the hostname of the `mirrorbits` API server (changed from custom hostname to an Azure-defined by convention).
- Populate`get.jenkins.io` directly from the trusted.ci permanent agent using the new NFS share used by mirrorbits. 
    - The final goal is to stop sending files to the `pkg.origin.jenkins.io` VM (unless it is a package but that should be the jenkins-infra/release responsibility). But it will require a subsequent PR to remove the "rsync copy + remote SSH script" in favor of "rsync to archives.jio" step.

Task lists:

- [x] Copy data from local agent to NFS mount, along with existing copy to `pkg`
- [x] Verify it works with the `update_center` build using this PR source branch
- [x] Verify it works with the `staging.get.jenkins.io` (ref. https://github.com/jenkins-infra/helpdesk/issues/4767) using the NFS destination (with preserved timestamps)