### PR TITLE
Do not generate update-center.json.html anymore

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -239,5 +239,3 @@ Then add these arguments to your tool invocation (or arguments file):
 To have your Jenkins instance accept update site JSON signed with this certificate, create a directory `update-center-rootCAs/` in the Jenkins home directory, and copy the `demo.crt` file in there.
 Once update site JSON files are generated, configure Jenkins to download them in _Manage Jenkins » Manage Plugin » Advanced_:
 Either set up a local HTTP server so the URL would be something like `+http://localhost:8000/update-center.json+`, or specify a `file://` URL like `+file:///Users/yourname/git/update-center2/www2/update-center.json+`
-
-NOTE: For historical reason, the configured URL points to `update-center.json`, but the file actually downloaded by Jenkins (at least up to 2.235 as of this writing) is `update-center.json.html`.

--- a/site/LAYOUT.md
+++ b/site/LAYOUT.md
@@ -27,8 +27,6 @@ These variants exist for historical purposes.
 
 * `update-center.json` contains JSONP (with callback wrapper) on the first and last lines.
   This is the file actually downloaded by Jenkins 2.200+.
-* `update-center.json.html` contains HTML with JSON wrapped in JS.
-  This used to be downloaded using browser-based metadata download (deprecated in 2015, removed in 2.200)
 * `update-center.actual.json` (actual JSON for programmatic clients)
 
 
@@ -99,13 +97,11 @@ The Jenkins project publishes a limited, fixed number of tiered update sites to 
 ├── latestCore.txt                   (Unused, may be removed)
 ├── update-center.actual.json
 ├── update-center.json
-├── update-center.json.html
 └── updates  ->  ../updates
 stable-2.204/
 ├── latestCore.txt                   (Unused, may be removed)
 ├── update-center.actual.json
 ├── update-center.json
-├── update-center.json.html
 └── updates  ->  ../updates
 ```
 
@@ -138,7 +134,6 @@ current/
 ├── release-history.json             (supports top-level file, may be moved)
 ├── update-center.actual.json
 ├── update-center.json
-├── update-center.json.html
 └── updates  ->  ../updates
 ```
 
@@ -150,7 +145,6 @@ stable/
 ├── latestCore.txt
 ├── update-center.actual.json
 ├── update-center.json
-├── update-center.json.html
 └── updates  ->  ../updates
 ```
 
@@ -170,7 +164,6 @@ Otherwise, this is similar to `current/` in that no version caps exist.
 experimental/
 ├── update-center.actual.json
 ├── update-center.json
-├── update-center.json.html
 └── updates  ->  ../updates
 ```
 

--- a/site/generate.sh
+++ b/site/generate.sh
@@ -155,7 +155,7 @@ ln -sf ../updates "$WWW_ROOT_DIR/current/updates"
 # generate symlinks to retain compatibility with past layout and make Apache index useful
 pushd "$WWW_ROOT_DIR"
   ln -s "$lastLTS" stable
-  for f in latest latestCore.txt plugin-documentation-urls.json release-history.json plugin-versions.json update-center.json update-center.actual.json update-center.json.html ; do
+  for f in latest latestCore.txt plugin-documentation-urls.json release-history.json plugin-versions.json update-center.json update-center.actual.json ; do
     ln -s "current/$f" .
   done
 popd

--- a/site/test/test.sh
+++ b/site/test/test.sh
@@ -44,7 +44,6 @@ function assert {
 }
 
 test_redirect "$TEST_BASE_URL/update-center.json" "$TEST_BASE_URL/current/update-center.json"
-test_redirect "$TEST_BASE_URL/update-center.json.html" "$TEST_BASE_URL/current/update-center.json.html"
 
 # Accessed by https://github.com/jenkins-infra/jenkins.io/blob/3892ea2ad4b4a67e1f8aebbfab261ae88628c176/scripts/fetch-external-resources#L48
 test_redirect "$TEST_BASE_URL/update-center.actual.json" "$TEST_BASE_URL/current/update-center.actual.json"

--- a/src/main/java/io/jenkins/update_center/Main.java
+++ b/src/main/java/io/jenkins/update_center/Main.java
@@ -257,7 +257,6 @@ public class Main {
             final String signedUpdateCenterJson = new UpdateCenterRoot(id, connectionCheckUrl, repo, new File(Main.resourcesDir, WARNINGS_JSON_FILENAME)).encodeWithSignature(signer, prettyPrint);
             writeToFile(updateCenterPostCallJson(signedUpdateCenterJson), new File(www, UPDATE_CENTER_JSON_FILENAME));
             writeToFile(signedUpdateCenterJson, new File(www, UPDATE_CENTER_ACTUAL_JSON_FILENAME));
-            writeToFile(updateCenterPostMessageHtml(signedUpdateCenterJson), new File(www, UPDATE_CENTER_JSON_HTML_FILENAME));
         }
 
         if (generatePluginDocumentationUrls) {
@@ -285,11 +284,6 @@ public class Main {
 
     private String updateCenterPostCallJson(String updateCenterJson) {
         return "updateCenter.post(" + EOL + updateCenterJson + EOL + ");";
-    }
-
-    private String updateCenterPostMessageHtml(String updateCenterJson) {
-        // needs the DOCTYPE to make JSON.stringify work on IE8
-        return "\uFEFF<!DOCTYPE html><html><head><meta http-equiv='Content-Type' content='text/html;charset=UTF-8' /></head><body><script>window.onload = function () { window.parent.postMessage(JSON.stringify(" + EOL + updateCenterJson+ EOL + "),'*'); };</script></body></html>";
     }
 
     private static void writeToFile(String string, final File file) throws IOException {
@@ -360,7 +354,6 @@ public class Main {
     private static final String WARNINGS_JSON_FILENAME = "warnings.json";
     private static final String UPDATE_CENTER_JSON_FILENAME = "update-center.json";
     private static final String UPDATE_CENTER_ACTUAL_JSON_FILENAME = "update-center.actual.json";
-    private static final String UPDATE_CENTER_JSON_HTML_FILENAME = "update-center.json.html";
     private static final String PLUGIN_DOCUMENTATION_URLS_JSON_FILENAME = "plugin-documentation-urls.json";
     private static final String PLUGIN_VERSIONS_JSON_FILENAME = "plugin-versions.json";
     private static final String RELEASE_HISTORY_JSON_FILENAME = "release-history.json";


### PR DESCRIPTION
Consuming this file was removed in https://github.com/jenkinsci/jenkins/pull/3970, so it's probably time to clean up here.
