### PR TITLE
fix: proper URLs in all updates.jenkins.io pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 
 # Mac OS X
 .DS_Store
+
+# Backups from sed
+*.bak

--- a/site/generate.sh
+++ b/site/generate.sh
@@ -164,7 +164,7 @@ popd
 echo '{}' > "$WWW_ROOT_DIR/uctest.json"
 wget -q --convert-links -O "$WWW_ROOT_DIR/index.html" --convert-links https://www.jenkins.io/templates/updates/index.html
 # replace relative paths in URLs and footer by absolute ones, and set the proper attributes for jio-components
-sed -i '' \
+sed -i.bak '' \
   -e 's|href="/|href="https://www.jenkins.io/|g' \
   -e 's|property="https://www.jenkins.io"|property="https://updates.jenkins.io"|g' \
   -e 's|sourcepath=""|sourcepath="content/templates/updates.adoc"|' \

--- a/site/generate.sh
+++ b/site/generate.sh
@@ -166,6 +166,7 @@ wget -q --convert-links -O "$WWW_ROOT_DIR/index.html" --convert-links https://ww
 # replace relative paths in URLs and footer by absolute ones, and set the proper attributes for jio-components
 sed -i.bak '' \
   -e 's|href="/|href="https://www.jenkins.io/|g' \
+  -e 's|src="/|src="https://www.jenkins.io/|g' \
   -e 's|property="https://www.jenkins.io"|property="https://updates.jenkins.io"|g' \
   -e 's|sourcepath=""|sourcepath="content/templates/updates.adoc"|' \
   "$WWW_ROOT_DIR/index.html"

--- a/src/main/java/io/jenkins/update_center/JenkinsIndexTemplateProvider.java
+++ b/src/main/java/io/jenkins/update_center/JenkinsIndexTemplateProvider.java
@@ -25,6 +25,9 @@ public class JenkinsIndexTemplateProvider extends IndexTemplateProvider {
 
             doc.getElementsByAttribute("href").forEach(element -> setAbsoluteUrl(element, "href"));
             doc.getElementsByAttribute("src").forEach(element -> setAbsoluteUrl(element, "src"));
+            doc.select("[property=https://www.jenkins.io]").forEach(element -> element.attr("property", "https://updates.jenkins.io"));
+            doc.select("[sourcepath=\"\"]").forEach(element -> element.attr("sourcepath", "content/templates/updates.adoc"));
+
             globalTemplate = doc.toString();
         } catch (IOException ioe) {
             LOGGER.log(Level.SEVERE, "Problem loading template", ioe);


### PR DESCRIPTION
Amends:
- #907 

Supersedes: 
- #670

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4882
- https://github.com/jenkins-infra/update-center2/pull/907#issuecomment-3945442368 