### PR TITLE
set fixed version for security-2167 in list-git-branches-parameter-plugin

### DIFF
--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -11343,8 +11343,8 @@
     "url": "https://www.jenkins.io/security/advisory/2022-03-15/#SECURITY-2167",
     "versions": [
       {
-        "lastVersion": "0.0.21",
-        "pattern": "0[.]0[.]([0-9]|1[0-9]|2[0-1])"
+        "lastVersion": "0.0.11",
+        "pattern": "0[.]0[.]([0-9]|1[0-1])"
       }
     ]
   },

--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -11343,8 +11343,8 @@
     "url": "https://www.jenkins.io/security/advisory/2022-03-15/#SECURITY-2167",
     "versions": [
       {
-        "lastVersion": "0.0.9",
-        "pattern": ".*"
+        "lastVersion": "0.0.21",
+        "pattern": "0[.]0[.]([0-9]|1[0-9]|2[0-1])"
       }
     ]
   },


### PR DESCRIPTION
Set fixed version for [list-git-branches-parameter-plugin](https://github.com/jenkinsci/list-git-branches-parameter-plugin) for the security advisory: [security-2167](https://www.jenkins.io/security/advisory/2022-03-15/#SECURITY-2167)

According to the [changelog](https://github.com/jenkinsci/list-git-branches-parameter-plugin/compare/list-git-branches-parameter-0.0.11...list-git-branches-parameter-0.0.12) this should be fixed in [PR#15](https://github.com/jenkinsci/list-git-branches-parameter-plugin/pull/15)

I'm not sure if I got the pattern correct, but 0.0.11 should be the last vulnerable version and 0.0.12 should have the fix included