### PR TITLE
Update Center: mark docker-swarm-plugin as deprecated

### DIFF
--- a/resources/label-definitions.properties
+++ b/resources/label-definitions.properties
@@ -278,6 +278,7 @@ docker-build-publish=builder
 docker-build-step=builder
 docker-commons=library
 docker-plugin=cloud cluster
+docker-swarm-plugin=deprecated
 docker-workflow=deployment devops
 doclinks=ui post-build
 dos-trigger=trigger


### PR DESCRIPTION
Following https://github.com/jenkinsci/docker-swarm-plugin/pull/141.
I'm not sure if this should go in `label-definitions.properties` (as in the docs) or in the [deprecations.properties](https://github.com/rantoniuk/jenkinsci-update-center2/blob/master/resources/deprecations.properties)

/cc @roemer 
