### PR TITLE
SECURITY-3200 fixed in docker-build-step 2.14

### DIFF
--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -17733,8 +17733,8 @@
     "url": "https://www.jenkins.io/security/advisory/2024-03-06/#SECURITY-3200",
     "versions": [
       {
-        "lastVersion": "2.11",
-        "pattern": ".*"
+        "lastVersion": "2.13",
+        "pattern": "([0-1][.].*|2[.]([0-9]|1[0-3]))(|[.-].*)"
       }
     ]
   },


### PR DESCRIPTION
## Summary

Update warning for SECURITY-3200 (docker-build-step) to reflect that version 2.14 contains the fix.

- Update `lastVersion` from `2.11` to `2.13` (last affected version)
- Update `pattern` from `.*` to `([0-1][.].*|2[.]([0-9]|1[0-3]))(|[.-].*)` so that 2.14+ are no longer flagged

Fix PR: https://github.com/jenkinsci/docker-build-step-plugin/pull/95

## Test plan

- [ ] Verify pattern matches versions 2.0–2.13 and does not match 2.14

🤖 Generated with [Claude Code](https://claude.com/claude-code)