### PR TITLE
Gracefully handle JSON parse errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <bouncycastle.version>1.80</bouncycastle.version>
+    <bouncycastle.version>1.80.2</bouncycastle.version>
   </properties>
 
   <build>

--- a/src/main/java/io/jenkins/update_center/GitHubSource.java
+++ b/src/main/java/io/jenkins/update_center/GitHubSource.java
@@ -1,6 +1,7 @@
 package io.jenkins.update_center;
 
 import io.jenkins.update_center.util.Environment;
+import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
 import org.apache.commons.codec.binary.Base64;
 
@@ -152,7 +153,7 @@ public class GitHubSource {
                         );
                     }
                 }
-            } catch(InterruptedException e) {
+            } catch(InterruptedException|JSONException e) {
                 throw new IOException(e);
             }
         }


### PR DESCRIPTION
Also fix upper bounds error from https://search.maven.org/artifact/org.bouncycastle/bcpkix-jdk18on/1.80/jar to make this build again.

```
[ERROR] Failed while enforcing RequireUpperBoundDeps. The error(s) are [
[ERROR] Require upper bound dependencies error for org.bouncycastle:bcprov-jdk18on:1.80 paths to dependency are:
[ERROR] +-org.jenkins-ci:update-center2:3.18.3-SNAPSHOT
[ERROR]   +-org.bouncycastle:bcprov-jdk18on:1.80
[ERROR] and
[ERROR] +-org.jenkins-ci:update-center2:3.18.3-SNAPSHOT
[ERROR]   +-org.bouncycastle:bcpkix-jdk18on:1.80
[ERROR]     +-org.bouncycastle:bcutil-jdk18on:1.80.2
[ERROR]       +-org.bouncycastle:bcprov-jdk18on:1.80.2
[ERROR] ]
```