### PR TITLE
chore(site/publish.sh): use agent-provided jq instead of self-downloading

### DIFF
--- a/site/publish.sh
+++ b/site/publish.sh
@@ -16,20 +16,8 @@ IFS='|' read -r -a run_stages <<< "${RUN_STAGES}"
 www2_dir="${WWW2_DIR:-./www2}"
 download_dir="${DOWNLOAD_DIR:-./download}"
 
-# Allow using binaries such as `jq` from local directory
-export PATH=.:$PATH
-
 recent_releases_json_file="${1:-"${www2_dir}"/experimental/recent-releases.json}"
 
-# Ensure jq is present or install it;io
-# TODO: stop relying on this code block once jq is installed (and maintained) in the "permanent agent" in trusted.ci.jenkins.io.
-if ! command -v jq >/dev/null
-then
-    ## Install jq, required by generate.sh script
-    wget --no-verbose -O jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 || { echo "Failed to download jq" >&2 ; exit 1; }
-    chmod +x jq || { echo "Failed to make jq executable" >&2 ; exit 1; }
-
-fi
 
 if [[ "${run_stages[*]}" =~ 'generate-site' ]]
 then
@@ -40,7 +28,7 @@ fi
 # Publish freshly released plugins to get.jenkins.io (if any)
 if [[ "${run_stages[*]}" =~ 'sync-plugins' ]]
 then
-    RECENT_RELEASES=$( ./jq --raw-output '.releases[] | .name + "/" + .version' "${recent_releases_json_file}" )
+    RECENT_RELEASES=$( jq --raw-output '.releases[] | .name + "/" + .version' "${recent_releases_json_file}" )
     if [[ -n "${RECENT_RELEASES}" ]] ; then
         pushd "${download_dir}"
 


### PR DESCRIPTION
Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5117

`site/publish.sh` no longer downloads its own `jq` from the deprecated/archived `stedolan/jq` repo. It now uses the `jq` provided on the agent.

`update-center2` runs on the trusted.ci permanent agent, which now ships `jq` 1.8.2 via Puppet (jenkins-infra/jenkins-infra#4930). With jq available on the agent, the self-download is redundant and pins an old, unmaintained 1.5 from a dead repo.

There was already a TODO in `publish.sh` noting this block should be removed once jq is installed and maintained on the permanent agent.

- Remove the `if ! command -v jq … wget stedolan/jq …` download block from `site/publish.sh`.
- Change `./jq` to `jq` so the agent-provided binary on `PATH` is used.
- Remove the now-purposeless `export PATH=.:$PATH` line (its only documented purpose was to pick up the locally-downloaded jq).

## Testing

Verified the three jq filters used by the UC2 pipeline produce identical output on jq 1.8.2 (the version now installed on the agent), using:

```console
$ jq --version
jq-1.8.2

# publish.sh: .releases[] | .name + "/" + .version
$ jq --raw-output '.releases[] | .name + "/" + .version' recent-releases.json
git/5.2.1
matrix-auth/3.2.2

# generate.sh: .weeklyCores[]
$ jq '.weeklyCores[]' cores.json
"2.470"
"2.471"

# generate.sh: .stableCores[]
$ jq '.stableCores[]' cores.json
"2.462.1"
"2.462.2"
```

## Merge order:

Do not merge until jenkins-infra/jenkins-infra#4930 is merged and the trusted.ci permanent agent has re-provisioned with jq 1.8.2. Merging before then would leave the publish job with no jq. Kept as draft until the agent is confirmed shipping jq.


