### PR TITLE
Specify first version of checkmarx-ast-scanner issue

### DIFF
--- a/resources/warnings.json
+++ b/resources/warnings.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/jenkins-infra/update-center2/pull/914",
     "versions": [
       {
+        "firstVersion": "2026.5.09",
         "lastVersion": "2026.5.09",
         "pattern": "2026[.]5[.]09"
       }


### PR DESCRIPTION
Amends #916.

This makes it clearer that no earlier releases are affected on https://plugins.jenkins.io/checkmarx-ast-scanner/ per https://github.com/jenkins-infra/plugin-site/blob/f6561042ed3a53adc780f0fb54380cf896a965f4/plugins/plugin-site/src/components/PluginReadableVersion.jsx. https://github.com/jenkins-infra/plugin-site/pull/2571 improves the presentation.

CC @cx-umesh-waghode 